### PR TITLE
Update http.status_code to new OTEL spec

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel/sc"
+
 	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 
 	"golang.org/x/exp/slog"
@@ -152,7 +154,7 @@ func (r *MetricsReporter) metricAttributes(span *transform.HTTPRequestSpan) []at
 	case transform.EventTypeHTTP:
 		attrs := []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
-			semconv.HTTPStatusCode(span.Status),
+			sc.HTTPResponseStatusCode.Int(span.Status),
 		}
 		if r.reportTarget {
 			attrs = append(attrs, semconv.HTTPTarget(span.Path))
@@ -177,7 +179,7 @@ func (r *MetricsReporter) metricAttributes(span *transform.HTTPRequestSpan) []at
 	case transform.EventTypeHTTPClient:
 		attrs := []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
-			semconv.HTTPStatusCode(span.Status),
+			sc.HTTPResponseStatusCode.Int(span.Status),
 		}
 		if r.reportPeer {
 			attrs = append(attrs, semconv.NetSockPeerName(span.Host))

--- a/pkg/export/otel/sc/sc.go
+++ b/pkg/export/otel/sc/sc.go
@@ -1,0 +1,10 @@
+package sc
+
+import "go.opentelemetry.io/otel/attribute"
+
+// HTTPResponseStatusCode is a temporary patch until the otel library is updated.
+// TODO: use  semconv package as soon as a newer version of the library fixes the value according to the last version
+// of the documentation:
+// https://github.com/open-telemetry/opentelemetry-go/blob/main/semconv/v1.19.0/attribute_group.go#L41
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md
+var HTTPResponseStatusCode = attribute.Key("http.response.status_code")

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel/sc"
+
 	"github.com/grafana/ebpf-autoinstrument/pkg/pipe/global"
 
 	"golang.org/x/exp/slog"
@@ -132,7 +134,7 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 	case transform.EventTypeHTTP:
 		attrs := []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
-			semconv.HTTPStatusCode(span.Status),
+			sc.HTTPResponseStatusCode.Int(span.Status),
 			semconv.HTTPTarget(span.Path),
 			semconv.NetSockPeerAddr(span.Peer),
 			semconv.NetHostName(span.Host),
@@ -155,7 +157,7 @@ func traceAttributes(span *transform.HTTPRequestSpan) []attribute.KeyValue {
 	case transform.EventTypeHTTPClient:
 		return []attribute.KeyValue{
 			semconv.HTTPMethod(span.Method),
-			semconv.HTTPStatusCode(span.Status),
+			sc.HTTPResponseStatusCode.Int(span.Status),
 			semconv.HTTPURL(span.Path),
 			semconv.NetPeerName(span.Host),
 			semconv.NetPeerPort(span.HostPort),

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -29,7 +29,7 @@ const (
 	serviceNameKey       = "service_name"
 	httpMethodKey        = "http_method"
 	httpRouteKey         = "http_route"
-	httpStatusCodeKey    = "http_status_code"
+	httpStatusCodeKey    = "http_response_status_code"
 	httpTargetKey        = "http_target"
 	netSockPeerAddrKey   = "net_sock_peer_addr"
 	netSockPeerNameKey   = "net_sock_peer_name"

--- a/pkg/pipe/instrumenter_test.go
+++ b/pkg/pipe/instrumenter_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/ebpf-autoinstrument/pkg/export/otel/sc"
+
 	"github.com/grafana/ebpf-autoinstrument/pkg/testutil"
 
 	"github.com/mariomac/pipes/pkg/graph"
@@ -49,7 +51,7 @@ func TestBasicPipeline(t *testing.T) {
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.HTTPMethodKey):      "GET",
-			string(semconv.HTTPStatusCodeKey):  "404",
+			string(sc.HTTPResponseStatusCode):  "404",
 			string(semconv.HTTPTargetKey):      "/foo/bar",
 			string(semconv.NetSockPeerAddrKey): "1.1.1.1",
 		},
@@ -120,7 +122,7 @@ func TestRouteConsolidation(t *testing.T) {
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.HTTPMethodKey):     "GET",
-			string(semconv.HTTPStatusCodeKey): "200",
+			string(sc.HTTPResponseStatusCode): "200",
 			string(semconv.HTTPRouteKey):      "/user/{id}",
 		},
 		Type: pmetric.MetricTypeHistogram,
@@ -131,7 +133,7 @@ func TestRouteConsolidation(t *testing.T) {
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.HTTPMethodKey):     "GET",
-			string(semconv.HTTPStatusCodeKey): "200",
+			string(sc.HTTPResponseStatusCode): "200",
 			string(semconv.HTTPRouteKey):      "/products/{id}/push",
 		},
 		Type: pmetric.MetricTypeHistogram,
@@ -142,7 +144,7 @@ func TestRouteConsolidation(t *testing.T) {
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.HTTPMethodKey):     "GET",
-			string(semconv.HTTPStatusCodeKey): "200",
+			string(sc.HTTPResponseStatusCode): "200",
 			string(semconv.HTTPRouteKey):      "*",
 		},
 		Type: pmetric.MetricTypeHistogram,
@@ -348,7 +350,7 @@ func matchTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
 		Name: name,
 		Attributes: map[string]string{
 			string(semconv.HTTPMethodKey):               "GET",
-			string(semconv.HTTPStatusCodeKey):           "404",
+			string(sc.HTTPResponseStatusCode):           "404",
 			string(semconv.HTTPTargetKey):               "/foo/bar",
 			string(semconv.NetSockPeerAddrKey):          "1.1.1.1",
 			string(semconv.NetHostNameKey):              getHostname(),
@@ -403,7 +405,7 @@ func matchInnerGRPCTraceEvent(t *testing.T, name string, event collector.TraceRe
 func matchNestedEvent(t *testing.T, name, method, target, status string, kind ptrace.SpanKind, event collector.TraceRecord) {
 	assert.Equal(t, name, event.Name)
 	assert.Equal(t, method, event.Attributes["http.method"])
-	assert.Equal(t, status, event.Attributes["http.status_code"])
+	assert.Equal(t, status, event.Attributes["http.response.status_code"])
 	if kind == ptrace.SpanKindClient {
 		assert.Equal(t, target, event.Attributes["http.url"])
 	} else {

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -103,7 +103,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		var err error
 		results, err = pq.Query(`http_server_duration_seconds_count{` +
 			`http_method="GET",` +
-			`http_status_code="404",` +
+			`http_response_status_code="404",` +
 			`service_name="testserver",` +
 			`http_route="/basic/:rnd",` +
 			`http_target="` + path + `"}`)
@@ -123,7 +123,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 		var err error
 		results, err = pq.Query(`http_server_request_size_bytes_count{` +
 			`http_method="GET",` +
-			`http_status_code="404",` +
+			`http_response_status_code="404",` +
 			`service_name="testserver",` +
 			`http_route="/basic/:rnd",` +
 			`http_target="` + path + `"}`)
@@ -144,7 +144,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			var err error
 			results, err = pq.Query(`http_client_duration_seconds_count{` +
 				`http_method="GET",` +
-				`http_status_code="203",` +
+				`http_response_status_code="203",` +
 				`service_name="testserver"}`)
 			require.NoError(t, err)
 			// check duration_count has 3 calls
@@ -160,7 +160,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 			var err error
 			results, err = pq.Query(`http_client_request_size_bytes_count{` +
 				`http_method="GET",` +
-				`http_status_code="203",` +
+				`http_response_status_code="203",` +
 				`service_name="testserver"}`)
 			require.NoError(t, err)
 			// check duration_count has 3 calls
@@ -193,7 +193,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 	var err error
 	results, err = pq.Query(`http_server_duration_seconds_sum{` +
 		`http_method="GET",` +
-		`http_status_code="404",` +
+		`http_response_status_code="404",` +
 		`service_name="testserver",` +
 		`http_route="/basic/:rnd",` +
 		`http_target="` + path + `"}`)
@@ -211,7 +211,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url string) {
 	// check request_size_sum is at least 114B (3 * 38B)
 	results, err = pq.Query(`http_server_request_size_bytes_sum{` +
 		`http_method="GET",` +
-		`http_status_code="404",` +
+		`http_response_status_code="404",` +
 		`service_name="testserver",` +
 		`http_route="/basic/:rnd",` +
 		`http_target="` + path + `"}`)


### PR DESCRIPTION
(Related with Bug https://github.com/grafana/ebpf-autoinstrument/issues/112, but not causing it)

In the latest [OTEL spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status), `http.status_code` has been renamed to `http.response_status_code`.

We should stick to that name to allow it working with future implementations of SpanMetrics.

The latest version of the library still does not include that change, so I created a temporary global variable to use it.