### PR TITLE
Change project name to Beyla in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eBPF autoinstrumenter
+# Beyla
 
 [![Build Status](https://drone.grafana.net/api/badges/grafana/ebpf-autoinstrument/status.svg?ref=refs/heads/main)](https://drone.grafana.net/grafana/ebpf-autoinstrument)
 


### PR DESCRIPTION
The project was renamed to Beyla, but the title of the readme still had the old name. I changed the title to Beyla.