### PR TITLE
Splitting ProcessTracer in Processfinder and ProcessTracer

### DIFF
--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -53,8 +53,8 @@ func main() {
 	// 1st executable - Invoke FindTarget, which also mounts the BPF maps
 	// 2nd executable - Invoke ReadAndForward, receiving the BPF map mountpoint as argument
 	instr := beyla.New(config)
-	if err := instr.FindTarget(ctx); err != nil {
-		slog.Error("Beyla couldn't find target service", err)
+	if err := instr.FindAndInstrument(ctx); err != nil {
+		slog.Error("Beyla couldn't find target process", err)
 		os.Exit(-1)
 	}
 	if err := instr.ReadAndForward(ctx); err != nil {

--- a/pkg/internal/ebpf/finder.go
+++ b/pkg/internal/ebpf/finder.go
@@ -1,0 +1,164 @@
+//go:build linux
+
+package ebpf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"golang.org/x/exp/slog"
+	"golang.org/x/sys/unix"
+
+	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
+	"github.com/grafana/beyla/pkg/internal/ebpf/goruntime"
+	"github.com/grafana/beyla/pkg/internal/ebpf/grpc"
+	"github.com/grafana/beyla/pkg/internal/ebpf/httpfltr"
+	"github.com/grafana/beyla/pkg/internal/ebpf/nethttp"
+	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/pipe/global"
+)
+
+func pflog() *slog.Logger {
+	return slog.With("component", "ebpf.ProcessFinder")
+}
+
+// ProcessFinder continuously listens in background for a process matching the
+// search criteria as specified to the user.
+type ProcessFinder struct {
+	Cfg     *ebpfcommon.TracerConfig
+	Metrics imetrics.Reporter
+	CtxInfo *global.ContextInfo
+
+	discoveredTracers chan *ProcessTracer
+	pinPath           string
+}
+
+func (pf *ProcessFinder) Start(ctx context.Context) (<-chan *ProcessTracer, error) {
+	log := pflog()
+	log.Debug("Starting Process Finder")
+
+	pf.discoveredTracers = make(chan *ProcessTracer, pf.CtxInfo.ChannelBufferLen)
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("removing memory lock: %w", err)
+	}
+	var err error
+	pf.pinPath, err = mountBpfPinPath(pf.Cfg)
+	if err != nil {
+		return nil, fmt.Errorf("mounting BPF FS in %q: %w", pf.Cfg.BpfBaseDir, err)
+	}
+	go func() {
+		// TODO, for multi-process inspection
+		// 1. Keep searching processes matching a given search criteria
+		// 2. Instrument these that haven't been instrumented already
+		// 3. Do not report service name as part of a shared configuration but as part of the trace
+
+		log.Debug("Finding process in background...")
+		pt, err := pf.findAndInstrument(ctx, pf.Metrics)
+		if err != nil {
+			log.Error("finding instrumentable process", err)
+			return
+		}
+		// TODO: move this to each tracer so each process would have its own service name
+		// If system-wide tracing is set, we don't use the initially-found
+		// executable name as service name, as it might be anything.
+		// We'll use the service name as traced from eBPF
+		if pf.CtxInfo.ServiceName == "" && !pf.Cfg.SystemWide {
+			pf.CtxInfo.ServiceName = pt.ELFInfo.ExecutableName()
+		}
+		pf.discoveredTracers <- pt
+	}()
+	return pf.discoveredTracers, nil
+}
+
+func (pf *ProcessFinder) Close() error {
+	unmountBpfPinPath(pf.pinPath)
+	return nil
+}
+
+func mountBpfPinPath(cfg *ebpfcommon.TracerConfig) (string, error) {
+	pinPath := path.Join(cfg.BpfBaseDir, strconv.Itoa(os.Getpid()))
+	log := pflog().With("path", pinPath)
+	log.Debug("mounting BPF map pinning path")
+	if _, err := os.Stat(pinPath); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("accessing %s stat: %w", pinPath, err)
+		}
+		log.Debug("BPF map pinning path does not exist. Creating before mounting")
+		if err := os.MkdirAll(pinPath, 0700); err != nil {
+			return "", fmt.Errorf("creating directory %s: %w", pinPath, err)
+		}
+	}
+
+	return pinPath, bpfMount(pinPath)
+}
+
+func unmountBpfPinPath(pinPath string) {
+	log := slog.With("component", "ebpf.TracerProvider", "path", pinPath)
+	log.Debug("context has been canceled. Unmounting BPF map pinning path")
+	if err := unix.Unmount(pinPath, unix.MNT_FORCE); err != nil {
+		log.Warn("can't unmount pinned root. Try unmounting and removing it manually", err)
+		return
+	}
+	log.Debug("unmounted bpf file system")
+	if err := os.RemoveAll(pinPath); err != nil {
+		log.Warn("can't remove pinned root. Try removing it manually", err)
+	} else {
+		log.Debug("removed pin path")
+	}
+}
+
+func (pf *ProcessFinder) findAndInstrument(ctx context.Context, metrics imetrics.Reporter) (*ProcessTracer, error) {
+	var log = logger()
+
+	// Each program is an eBPF source: net/http, grpc...
+	programs := []Tracer{
+		&nethttp.Tracer{Cfg: pf.Cfg, Metrics: metrics},
+		&nethttp.GinTracer{Tracer: nethttp.Tracer{Cfg: pf.Cfg, Metrics: metrics}},
+		&grpc.Tracer{Cfg: pf.Cfg, Metrics: metrics},
+		&goruntime.Tracer{Cfg: pf.Cfg, Metrics: metrics},
+	}
+
+	// merging all the functions from all the programs, in order to do
+	// a complete inspection of the target executable
+	allFuncs := allGoFunctionNames(programs)
+	elfInfo, goffsets, err := inspect(ctx, pf.Cfg, allFuncs)
+	if err != nil {
+		return nil, fmt.Errorf("inspecting offsets: %w", err)
+	}
+
+	if goffsets != nil {
+		programs = filterNotFoundPrograms(programs, goffsets)
+		if len(programs) == 0 {
+			return nil, errors.New("no instrumentable function found")
+		}
+	} else {
+		// We are not instrumenting a Go application, we override the programs
+		// list with the generic kernel/socket space filters
+		programs = []Tracer{&httpfltr.Tracer{Cfg: pf.Cfg, Metrics: metrics}}
+	}
+
+	// Instead of the executable file in the disk, we pass the /proc/<pid>/exec
+	// to allow loading it from different container/pods in containerized environments
+	exe, err := link.OpenExecutable(elfInfo.ProExeLinkPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening %q executable file: %w", elfInfo.ProExeLinkPath, err)
+	}
+
+	if pf.Cfg.SystemWide {
+		log.Info("system wide instrumentation")
+	}
+	return &ProcessTracer{
+		programs: programs,
+		ELFInfo:  elfInfo,
+		goffsets: goffsets,
+		exe:      exe,
+		pinPath:  pf.pinPath,
+	}, nil
+}

--- a/pkg/internal/ebpf/finder_darwin.go
+++ b/pkg/internal/ebpf/finder_darwin.go
@@ -1,0 +1,19 @@
+package ebpf
+
+import (
+	"context"
+
+	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
+	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/pipe/global"
+)
+
+// dummy functions and types to avoid compilation errors in Darwin. The finder component is only usable in Linux.
+type ProcessFinder struct {
+	Cfg     *ebpfcommon.TracerConfig
+	Metrics imetrics.Reporter
+	CtxInfo *global.ContextInfo
+}
+
+func (pf *ProcessFinder) Start(_ context.Context) (<-chan *ProcessTracer, error) { return nil, nil }
+func (pf *ProcessFinder) Close() error                                           { return nil }

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -8,26 +8,17 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	"github.com/cilium/ebpf/rlimit"
-	"github.com/mariomac/pipes/pkg/node"
 	"golang.org/x/exp/slog"
 	"golang.org/x/sys/unix"
 
 	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
-	"github.com/grafana/beyla/pkg/internal/ebpf/goruntime"
-	"github.com/grafana/beyla/pkg/internal/ebpf/grpc"
-	"github.com/grafana/beyla/pkg/internal/ebpf/httpfltr"
-	"github.com/grafana/beyla/pkg/internal/ebpf/nethttp"
 	"github.com/grafana/beyla/pkg/internal/exec"
 	"github.com/grafana/beyla/pkg/internal/goexec"
-	"github.com/grafana/beyla/pkg/internal/imetrics"
 )
 
 // Tracer is an individual eBPF program (e.g. the net/http or the grpc tracers)
@@ -71,85 +62,33 @@ type ProcessTracer struct {
 	pinPath  string
 }
 
-// TracerProvider returns a StartFuncCtx for each discovered eBPF traceable source: GRPC, HTTP...
-func TracerProvider(_ context.Context, pt *ProcessTracer) ([]node.StartFuncCtx[[]any], error) {
-	return pt.TraceReaders()
-}
-
-func FindAndInstrument(ctx context.Context, cfg *ebpfcommon.TracerConfig, metrics imetrics.Reporter) (*ProcessTracer, error) {
+func (pt *ProcessTracer) Run(ctx context.Context, out chan<- []any) {
 	var log = logger()
 
-	// Each program is an eBPF source: net/http, grpc...
-	programs := []Tracer{
-		&nethttp.Tracer{Cfg: cfg, Metrics: metrics},
-		&nethttp.GinTracer{Tracer: nethttp.Tracer{Cfg: cfg, Metrics: metrics}},
-		&grpc.Tracer{Cfg: cfg, Metrics: metrics},
-		&goruntime.Tracer{Cfg: cfg, Metrics: metrics},
-	}
-
-	// merging all the functions from all the programs, in order to do
-	// a complete inspection of the target executable
-	allFuncs := allGoFunctionNames(programs)
-	elfInfo, goffsets, err := inspect(ctx, cfg, allFuncs)
+	// Searches for traceable functions
+	funcs, err := pt.tracerFunctions()
 	if err != nil {
-		return nil, fmt.Errorf("inspecting offsets: %w", err)
+		log.Error("couldn't trace process", err, "path", pt.ELFInfo.CmdExePath, "pid", pt.ELFInfo.Pid)
+		return
 	}
-
-	if goffsets != nil {
-		programs = filterNotFoundPrograms(programs, goffsets)
-		if len(programs) == 0 {
-			return nil, errors.New("no instrumentable function found")
-		}
-	} else {
-		// We are not instrumenting a Go application, we override the programs
-		// list with the generic kernel/socket space filters
-		programs = []Tracer{&httpfltr.Tracer{Cfg: cfg, Metrics: metrics}}
+	// run each tracer program
+	for _, fn := range funcs {
+		go fn(ctx, out)
 	}
-
-	// Instead of the executable file in the disk, we pass the /proc/<pid>/exec
-	// to allow loading it from different container/pods in containerized environments
-	exe, err := link.OpenExecutable(elfInfo.ProExeLinkPath)
-	if err != nil {
-		return nil, fmt.Errorf("opening %q executable file: %w", elfInfo.ProExeLinkPath, err)
-	}
-	if err := rlimit.RemoveMemlock(); err != nil {
-		return nil, fmt.Errorf("removing memory lock: %w", err)
-	}
-
-	pinPath, err := mountBpfPinPath(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("mounting BPF FS in %q: %w", cfg.BpfBaseDir, err)
-	}
-
-	if cfg.SystemWide {
-		log.Info("system wide instrumentation")
-	}
-	return &ProcessTracer{
-		programs: programs,
-		ELFInfo:  elfInfo,
-		goffsets: goffsets,
-		exe:      exe,
-		pinPath:  pinPath,
-	}, nil
 }
 
-// TraceReaders returns one StartFuncCtx for each discovered eBPF traceable source: GRPC, HTTP...
-func (pt *ProcessTracer) TraceReaders() ([]node.StartFuncCtx[[]any], error) {
+// tracerFunctions returns a tracing function for each discovered eBPF traceable source: GRPC, HTTP...
+func (pt *ProcessTracer) tracerFunctions() ([]func(context.Context, chan<- []any), error) {
 	var log = logger()
 
-	// startNodes contains the eBPF programs (HTTP, GRPC tracers...) plus a function
-	// that just waits for the passed context to finish before closing the BPF pin
-	// path
-	startNodes := []node.StartFuncCtx[[]any]{
-		waitToCloseBbfPinPath(pt.pinPath),
-	}
+	// tracerFuncs contains the eBPF programs (HTTP, GRPC tracers...)
+	var tracerFuncs []func(context.Context, chan<- []any)
 
 	for _, p := range pt.programs {
 		plog := log.With("program", reflect.TypeOf(p))
 		plog.Debug("loading eBPF program")
 		spec, err := p.Load()
 		if err != nil {
-			unmountBpfPinPath(pt.pinPath)
 			return nil, fmt.Errorf("loading eBPF program: %w", err)
 		}
 		if err := spec.RewriteConstants(p.Constants(pt.ELFInfo, pt.goffsets)); err != nil {
@@ -160,7 +99,6 @@ func (pt *ProcessTracer) TraceReaders() ([]node.StartFuncCtx[[]any], error) {
 				PinPath: pt.pinPath,
 			}}); err != nil {
 			printVerifierErrorInfo(err)
-			unmountBpfPinPath(pt.pinPath)
 			return nil, fmt.Errorf("loading and assigning BPF objects: %w", err)
 		}
 		i := instrumenter{
@@ -171,79 +109,34 @@ func (pt *ProcessTracer) TraceReaders() ([]node.StartFuncCtx[[]any], error) {
 		//Go style Uprobes
 		if err := i.goprobes(p); err != nil {
 			printVerifierErrorInfo(err)
-			unmountBpfPinPath(pt.pinPath)
 			return nil, err
 		}
 
 		//Kprobes to be used for native instrumentation points
 		if err := i.kprobes(p); err != nil {
 			printVerifierErrorInfo(err)
-			unmountBpfPinPath(pt.pinPath)
 			return nil, err
 		}
 
 		//Uprobes to be used for native module instrumentation points
 		if err := i.uprobes(pt.ELFInfo.Pid, p); err != nil {
 			printVerifierErrorInfo(err)
-			unmountBpfPinPath(pt.pinPath)
 			return nil, err
 		}
 
 		//Sock filters support
 		if err := i.sockfilters(p); err != nil {
 			printVerifierErrorInfo(err)
-			unmountBpfPinPath(pt.pinPath)
 			return nil, err
 		}
 
-		startNodes = append(startNodes, p.Run)
+		tracerFuncs = append(tracerFuncs, p.Run)
 	}
 
-	return startNodes, nil
-}
-
-func mountBpfPinPath(cfg *ebpfcommon.TracerConfig) (string, error) {
-	pinPath := path.Join(cfg.BpfBaseDir, strconv.Itoa(os.Getpid()))
-	log := slog.With("component", "ebpf.TracerProvider", "path", pinPath)
-	log.Debug("mounting BPF map pinning path")
-	if _, err := os.Stat(pinPath); err != nil {
-		if !os.IsNotExist(err) {
-			return "", fmt.Errorf("accessing %s stat: %w", pinPath, err)
-		}
-		log.Debug("BPF map pinning path does not exist. Creating before mounting")
-		if err := os.MkdirAll(pinPath, 0700); err != nil {
-			return "", fmt.Errorf("creating directory %s: %w", pinPath, err)
-		}
-	}
-
-	return pinPath, bpfMount(pinPath)
+	return tracerFuncs, nil
 }
 
 func logger() *slog.Logger { return slog.With("component", "ebpf.TracerProvider") }
-
-// this will be just a start node that listens for the context cancellation and then
-// unmounts the BPF pinning path
-func waitToCloseBbfPinPath(pinPath string) node.StartFuncCtx[[]any] {
-	return func(ctx context.Context, _ chan<- []any) {
-		<-ctx.Done()
-		unmountBpfPinPath(pinPath)
-	}
-}
-
-func unmountBpfPinPath(pinPath string) {
-	log := slog.With("component", "ebpf.TracerProvider", "path", pinPath)
-	log.Debug("context has been canceled. Unmounting BPF map pinning path")
-	if err := unix.Unmount(pinPath, unix.MNT_FORCE); err != nil {
-		log.Warn("can't unmount pinned root. Try unmounting and removing it manually", err)
-		return
-	}
-	log.Debug("unmounted bpf file system")
-	if err := os.RemoveAll(pinPath); err != nil {
-		log.Warn("can't remove pinned root. Try removing it manually", err)
-	} else {
-		log.Debug("removed pin path")
-	}
-}
 
 // filterNotFoundPrograms will filter these programs whose required functions (as
 // returned in the Offsets method) haven't been found in the offsets

--- a/pkg/internal/ebpf/tracer_darwin.go
+++ b/pkg/internal/ebpf/tracer_darwin.go
@@ -2,23 +2,9 @@ package ebpf
 
 import (
 	"context"
-
-	"github.com/mariomac/pipes/pkg/node"
-
-	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
-	"github.com/grafana/beyla/pkg/internal/exec"
-	"github.com/grafana/beyla/pkg/internal/imetrics"
 )
 
 // dummy functions and types to avoid compilation errors in Darwin. The tracer component is only usable in Linux.
-type ProcessTracer struct {
-	ELFInfo *exec.FileInfo
-}
+type ProcessTracer struct{}
 
-func TracerProvider(_ context.Context, _ *ProcessTracer) ([]node.StartFuncCtx[[]any], error) {
-	return nil, nil
-}
-
-func FindAndInstrument(_ context.Context, _ *ebpfcommon.TracerConfig, _ imetrics.Reporter) (*ProcessTracer, error) {
-	return nil, nil
-}
+func (pt *ProcessTracer) Run(_ context.Context, _ chan<- []any) {}

--- a/pkg/internal/pipe/global/context.go
+++ b/pkg/internal/pipe/global/context.go
@@ -8,6 +8,8 @@ import (
 // ContextInfo stores some context information that must be shared across some nodes of the
 // processing graph.
 type ContextInfo struct {
+	// ChannelBufferLen specifies, for each channel that is created in the pipeline, its buffer length
+	ChannelBufferLen int
 	// ReportRoutes sets whether the metrics should set the http.route attribute
 	ReportRoutes bool
 	// ServiceName is the value of the service_name config attribute, or the discovered value

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -7,20 +7,19 @@ import (
 	"github.com/mariomac/pipes/pkg/graph"
 	"github.com/mariomac/pipes/pkg/node"
 
-	"github.com/grafana/beyla/pkg/internal/ebpf"
 	"github.com/grafana/beyla/pkg/internal/export/debug"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/export/prom"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/pkg/internal/traces"
 	"github.com/grafana/beyla/pkg/internal/transform"
 )
 
 // nodesMap provides the architecture of the whole processing pipeline:
 // each node and which nodes are they connected to
 type nodesMap struct {
-	// TODO: use interface
-	TracerReader *ebpf.ProcessTracer `nodeId:"tracer" sendTo:"routes"`
+	TracesReader traces.Reader `nodeId:"tracer" sendTo:"routes"`
 
 	// Routes is an optional node. If not set, data will be bypassed to the next stage in the pipeline.
 	Routes *transform.RoutesConfig `nodeId:"routes" forwardTo:"kube"`
@@ -35,16 +34,15 @@ type nodesMap struct {
 	Noop       debug.NoopEnabled     `nodeId:"noop"`
 }
 
-func configToNodesMap(cfg *Config, tracer *ebpf.ProcessTracer) *nodesMap {
+func configToNodesMap(cfg *Config) *nodesMap {
 	return &nodesMap{
-		TracerReader: tracer,
-		Routes:       cfg.Routes,
-		Kubernetes:   cfg.Kubernetes,
-		Metrics:      cfg.Metrics,
-		Traces:       cfg.Traces,
-		Prometheus:   cfg.Prometheus,
-		Printer:      cfg.Printer,
-		Noop:         cfg.Noop,
+		Routes:     cfg.Routes,
+		Kubernetes: cfg.Kubernetes,
+		Metrics:    cfg.Metrics,
+		Traces:     cfg.Traces,
+		Prometheus: cfg.Prometheus,
+		Printer:    cfg.Printer,
+		Noop:       cfg.Noop,
 	}
 }
 
@@ -52,37 +50,41 @@ func configToNodesMap(cfg *Config, tracer *ebpf.ProcessTracer) *nodesMap {
 type graphFunctions struct {
 	config  *Config
 	builder *graph.Builder
-	tracer  *ebpf.ProcessTracer
 	ctxInfo *global.ContextInfo
+
+	// tracesCh is shared across all the eBPF tracing programs, which send there
+	// any discovered trace, and the input node of the graph, which reads and
+	// forwards them to the next stages.
+	tracesCh <-chan []any
 }
 
 // Build instantiates the whole instrumentation --> processing --> submit
 // pipeline graph and returns it as a startable item
-func Build(ctx context.Context, config *Config, ctxInfo *global.ContextInfo, tracer *ebpf.ProcessTracer) (*Instrumenter, error) {
+func Build(ctx context.Context, config *Config, ctxInfo *global.ContextInfo, tracesCh <-chan []any) (*Instrumenter, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("validating configuration: %w", err)
 	}
 
-	return newGraphBuilder(config, ctxInfo, tracer).buildGraph(ctx)
+	return newGraphBuilder(config, ctxInfo, tracesCh).buildGraph(ctx)
 }
 
 // private constructor that can be instantiated from tests to override the node providers
 // and offsets inspector
-func newGraphBuilder(config *Config, ctxInfo *global.ContextInfo, tracer *ebpf.ProcessTracer) *graphFunctions {
+func newGraphBuilder(config *Config, ctxInfo *global.ContextInfo, tracesCh <-chan []any) *graphFunctions {
 	// This is how the github.com/mariomac/pipes library, works:
 	// First, we create a graph builder
 	gnb := graph.NewBuilder(node.ChannelBufferLen(config.ChannelBufferLen))
 	gb := &graphFunctions{
-		builder: gnb,
-		config:  config,
-		tracer:  tracer,
-		ctxInfo: ctxInfo,
+		builder:  gnb,
+		config:   config,
+		ctxInfo:  ctxInfo,
+		tracesCh: tracesCh,
 	}
 	// Second, we register providers for each node. Each provider is a function that receives the
 	// type of each of the "nodesMap" struct fields, and returns the function that represents
 	// each node. Each function will have input and/or output channels.
 	graph.RegisterCodec(gnb, transform.ConvertToSpan)
-	graph.RegisterMultiStart(gnb, ebpf.TracerProvider)
+	graph.RegisterStart(gnb, traces.ReaderProvider)
 	graph.RegisterMiddle(gnb, transform.RoutesProvider)
 	graph.RegisterMiddle(gnb, transform.KubeDecoratorProvider)
 	graph.RegisterTerminal(gnb, gb.metricsReporterProvider)
@@ -102,7 +104,8 @@ func (gb *graphFunctions) buildGraph(ctx context.Context) (*Instrumenter, error)
 	// setting explicitly some configuration properties that are needed by their
 	// respective node providers
 
-	definedNodesMap := configToNodesMap(gb.config, gb.tracer)
+	definedNodesMap := configToNodesMap(gb.config)
+	definedNodesMap.TracesReader.TracesInput = gb.tracesCh
 	grp, err := gb.builder.Build(ctx, definedNodesMap)
 	if err != nil {
 		return nil, err

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -14,13 +14,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
-	"github.com/grafana/beyla/pkg/internal/ebpf"
 	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/ebpf/httpfltr"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/testutil"
+	"github.com/grafana/beyla/pkg/internal/traces"
 	"github.com/grafana/beyla/pkg/internal/transform"
 	"github.com/grafana/beyla/test/collector"
 )
@@ -40,9 +40,11 @@ func TestBasicPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newRequest(1, "GET", "/foo/bar", "1.1.1.1:3456", 404)
 		}, nil
@@ -74,9 +76,11 @@ func TestTracerPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newRequest(1, "GET", "/foo/bar", "1.1.1.1:3456", 404)
 		}, nil
@@ -104,9 +108,9 @@ func TestRouteConsolidation(t *testing.T) {
 	gb := newGraphBuilder(&Config{
 		Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint}, // ReportPeerInfo = false, no peer info
 		Routes:  &transform.RoutesConfig{Patterns: []string{"/user/{id}", "/products/{id}/push"}},
-	}, gctx(), &ebpf.ProcessTracer{})
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newRequest(1, "GET", "/user/1234", "1.1.1.1:3456", 200)
 			out <- newRequest(2, "GET", "/products/3210/push", "1.1.1.1:3456", 200)
@@ -166,9 +170,11 @@ func TestGRPCPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newGRPCRequest(1, "/foo/bar", 3)
 		}, nil
@@ -199,9 +205,11 @@ func TestTraceGRPCPipeline(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newGRPCRequest(1, "foo.bar", 3)
 		}, nil
@@ -226,9 +234,11 @@ func TestNestedSpanMatching(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data with nested client span
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newRequestWithTiming(1, transform.EventTypeHTTPClient, "GET", "/attach", "2.2.2.2:1234", 200, 60000, 60000, 70000)
 			out <- newRequestWithTiming(1, transform.EventTypeHTTP, "GET", "/user/1234", "1.1.1.1:3456", 200, 10000, 10000, 50000)
@@ -465,9 +475,11 @@ func TestBasicPipelineInfo(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Metrics: otel.MetricsConfig{MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newHTTPInfo("PATCH", "/aaa/bbb", "1.1.1.1", 204)
 		}, nil
@@ -499,9 +511,11 @@ func TestTracerPipelineInfo(t *testing.T) {
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	gb := newGraphBuilder(&Config{Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0}}, gctx(), &ebpf.ProcessTracer{})
+	gb := newGraphBuilder(&Config{
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0},
+	}, gctx(), make(<-chan []any))
 	// Override eBPF tracer to send some fake data
-	graph.RegisterStart(gb.builder, func(_ context.Context, _ *ebpf.ProcessTracer) (node.StartFuncCtx[[]any], error) {
+	graph.RegisterStart(gb.builder, func(_ context.Context, _ traces.Reader) (node.StartFuncCtx[[]any], error) {
 		return func(_ context.Context, out chan<- []any) {
 			out <- newHTTPInfo("PATCH", "/aaa/bbb", "1.1.1.1", 204)
 		}, nil

--- a/pkg/internal/traces/reader.go
+++ b/pkg/internal/traces/reader.go
@@ -1,0 +1,22 @@
+package traces
+
+import (
+	"context"
+
+	"github.com/mariomac/pipes/pkg/node"
+)
+
+// Reader is the input node of the processing graph. The eBPF tracers will send their
+// traces to the Reader's TracesInput, and the Reader will forward them to the next
+// pipeline stage
+type Reader struct {
+	TracesInput <-chan []any
+}
+
+func ReaderProvider(_ context.Context, r Reader) (node.StartFuncCtx[[]any], error) {
+	return func(ctx context.Context, out chan<- []any) {
+		for trace := range r.TracesInput {
+			out <- trace
+		}
+	}, nil
+}


### PR DESCRIPTION
Before this PR, the way beyla worked was, synchronously:
1. Find any instrumentable process.
2. Build a static graph to process its data. The start node of the graph was the eBPF reader.

This PR decouples process instrumention from graph creation, in preparation for a future support of multiple executables, which dynamically might be executed/stopped. It asynchronously:
1. Create the static graph to process the data. The start node of the graph it's just a forwarder for a provided channel (file `pkg/internal/traces/reader.go`).
2. Run the ProcessFinder in background.
   1.1. Keep searching for instrumentable process.
   1.2. Each time a process is discovered, a processTracer instance is started in its own goroutine, provided with the input channel of the start node of the processing graph.