### PR TITLE
Docs: Change default standalone download method

### DIFF
--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -189,7 +189,7 @@ You can specify both `otel_metrics_export` and `otel_traces_export` properties t
 allow exporting both metrics and traces, or only one of them to export either
 metrics or traces.
 
-To run the auto-instrumentation tool (previously installed via `go install github.com/grafana/ebpf-autoinstrument/cmd/beyla@latest`),
+To run the auto-instrumentation tool (previously downloaded from the [Beyla releases page](https://github.com/grafana/beyla/releases)),
 you will need to specify the path to the configuration YAML file. For example `instrument-config.yml`:
 
 ```

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -15,8 +15,11 @@ data, you can follow our [step-by-step tutorial]({{< relref "../tutorial/index.m
 
 ## Download and install Beyla - the eBPF auto-instrumentation tool
 
-You can download the auto-instrumentation executable directly with the `go install`
-command line:
+You can directly download the latest version that matches your processor architecture
+from the [Beyla releases page](https://github.com/grafana/beyla/releases).
+
+As an alternative, if your system has the Go SDK installed, you can download the
+Beyla executable directly with the `go install` command line:
 
 ```sh
 go install github.com/grafana/beyla/cmd/beyla@latest

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -19,7 +19,7 @@ You can directly download the latest version that matches your processor archite
 from the [Beyla releases page](https://github.com/grafana/beyla/releases).
 
 As an alternative, if your system has the Go SDK installed, you can download the
-Beyla executable directly with the `go install` command line:
+Beyla executable directly with the `go install` command:
 
 ```sh
 go install github.com/grafana/beyla/cmd/beyla@latest

--- a/docs/sources/tutorial/index.md
+++ b/docs/sources/tutorial/index.md
@@ -130,7 +130,10 @@ ordinary operating system process. For more running modes, you can check the doc
 [running the eBPF auto-instrumentation tool as a Docker container](https://github.com/grafana/beyla/blob/main/docs/docker.md)
 or [deploying the eBPF auto-instrumentation tool in Kubernetes](https://github.com/grafana/beyla/blob/main/docs/k8s.md).
 
-You can download the auto-instrumentation executable directly with `go install`:
+You can download Beyla executable directly from the [Beyla releases page](https://github.com/grafana/beyla/releases).
+
+As an alternative, if your system has the Go SDK installed, you can download the
+Beyla executable directly with the `go install` command line:
 
 ```sh
 go install github.com/grafana/beyla/cmd/beyla@latest

--- a/docs/sources/tutorial/index.md
+++ b/docs/sources/tutorial/index.md
@@ -133,7 +133,7 @@ or [deploying the eBPF auto-instrumentation tool in Kubernetes](https://github.c
 You can download Beyla executable directly from the [Beyla releases page](https://github.com/grafana/beyla/releases).
 
 As an alternative, if your system has the Go SDK installed, you can download the
-Beyla executable directly with the `go install` command line:
+Beyla executable directly with the `go install` command:
 
 ```sh
 go install github.com/grafana/beyla/cmd/beyla@latest

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
   nginxbeyla:
     image: grafana/beyla:latest
     command:
-      - /otelauto
+      - /beyla
       - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
@@ -51,7 +51,7 @@ services:
   gobeyla:
     image: grafana/beyla:latest
     command:
-      - /otelauto
+      - /beyla
       - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
@@ -82,7 +82,7 @@ services:
   javabeyla:
     image: grafana/beyla:latest
     command:
-      - /otelauto
+      - /beyla
       - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
@@ -113,7 +113,7 @@ services:
   rustbeyla:
     image: grafana/beyla:latest
     command:
-      - /otelauto
+      - /beyla
       - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs


### PR DESCRIPTION
Replace `go install` (requires having Go installed in the target machine) by a link to the releases page.