### PR TITLE
Add a Getting Started section at the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,46 @@ eBPF-based autoinstrumentation of HTTP/HTTPS/GRPC Go services, as well as HTTP/H
 written in other languages (intercepting Kernel-level socket operations as well as
 OpenSSL invocations).
 
-[Documentation](https://grafana.com/docs/TODO).
+## Getting Started
 
-Requirements:
+To try out Beyla, you need to run a network service for Beyla to instrument.
+Beyla supports a wide range of programming languages (Go, Java, .NET, NodeJS, Python, Ruby, Rust, etc.),
+so if you already have an example service you can use it.
+If you don't have an example, you can download and run the service from the `examples/` directory:
+
+```
+curl -OL https://github.com/grafana/beyla/blob/main/examples/example-http-service/example-http-service.go
+go run ./example-service.go
+```
+
+Next, generate some traffic. The following command will trigger a GET request to http://localhost:8080 every two seconds.
+
+```
+watch curl -s http://localhost:8080
+```
+
+Now that we have an example running, we are ready to download and run Beyla.
+
+First, download and unpack the latest release from the [Github releases page](https://github.com/grafana/beyla/releases).
+The release should contain the `./beyla` executable.
+
+Beyla supports multiple exposition format (Prometheus, OpenTelemetry metrics, Single Span traces),
+and multiple ways to find the service to be instrumented (by network port, executable name, process ID).
+
+For getting started, we'll tell Beyla to instrument the service running on port 8080 (our example service) and expose metrics in Prometheus on port 9400.
+
+```
+export BEYLA_PROMETHEUS_PORT=9400
+export OPEN_PORT=8080
+sudo -E ./beyla
+```
+
+Now, you should see metrics on [http://localhost:9400/metrics](http://localhost:9400/metrics).
+
+See [Documentation](https://grafana.com/docs/TODO) and the [quickstart tutorial](docs/sources/tutorial/index.md) for more info.
+
+## Requirements
+
 - Linux with Kernel 4.18 or higher
 - eBPF enabled in the host
 - For instrumenting Go programs, they must have been compiled with Go 1.17 or higher
@@ -26,11 +63,9 @@ Requirements:
 | [Gin](https://gin-gonic.com/)                 | ✅       |
 | [gRPC-Go](https://github.com/grpc/grpc-go)    | ✅       |
 
-## How to setup a quick demo
+## Kubernetes
 
-We recommend you to follow our [quickstart tutorial](docs/sources/tutorial/index.md).
-
-Optionally you can just trigger the Kubernetes descriptors in the `deployments/` folder.
+You can just trigger the Kubernetes descriptors in the `deployments/` folder.
 
 1. Provide your Grafana credentials. Use the following [K8s Secret template](deployments/01-grafana-credentials.template.yml)
    to introduce the endpoints, usernames and API keys for Mimir and Tempo:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you don't have an example, you can download and run the service from the `exa
 
 ```
 curl -OL https://github.com/grafana/beyla/blob/main/examples/example-http-service/example-http-service.go
-go run ./example-service.go
+go run ./example-http-service.go
 ```
 
 Next, generate some traffic. The following command will trigger a GET request to http://localhost:8080 every two seconds.
@@ -29,10 +29,10 @@ Now that we have an example running, we are ready to download and run Beyla.
 First, download and unpack the latest release from the [Github releases page](https://github.com/grafana/beyla/releases).
 The release should contain the `./beyla` executable.
 
-Beyla supports multiple exposition format (Prometheus, OpenTelemetry metrics, Single Span traces),
-and multiple ways to find the service to be instrumented (by network port, executable name, process ID).
+Beyla supports multiple ways to find the service to be instrumented (by network port, executable name, process ID),
+and multiple exposition formats (Prometheus, OpenTelemetry metrics, Single Span traces).
 
-For getting started, we'll tell Beyla to instrument the service running on port 8080 (our example service) and expose metrics in Prometheus on port 9400.
+For getting started, we'll tell Beyla to instrument the service running on port 8080 (our example service) and expose metrics in Prometheus format on port 9400.
 
 ```
 export BEYLA_PROMETHEUS_PORT=9400

--- a/examples/example-http-service/example-http-service.go
+++ b/examples/example-http-service/example-http-service.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// Simple example HTTP service for trying out Beyla.
+// 20% of calls will fail with HTTP status 500.
+
+func handleRequest(rw http.ResponseWriter, _ *http.Request) {
+	time.Sleep(time.Duration(rand.Float64()*400.0) * time.Millisecond)
+	if rand.Int31n(100) < 80 {
+		rw.WriteHeader(200)
+		if _, err := io.WriteString(rw, "Hello from the example HTTP service.\n"); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		rw.WriteHeader(500)
+		if _, err := io.WriteString(rw, "Simulating an error response with HTTP status 500.\n"); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func main() {
+	fmt.Println("Listening on http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", http.HandlerFunc(handleRequest)))
+}


### PR DESCRIPTION
I added a "Getting Started" example as discussed with @mariomac.

The goal is to make it as easy as possible for people to quickly try out `beyla`.