### PR TITLE
Group kubernetes section in deploy folder

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -43,7 +43,8 @@ get started.
 
 ## Get started
 
-Follow the [setup]({{< relref "./setup/_index.md" >}}) documentation to get started with Beyla either as a standalone service or with Docker.
+Follow the [setup]({{< relref "./setup/_index.md" >}}) documentation to get started with Beyla either as a standalone
+service, with Docker or with Kubernetes.
 
 Follow the [Quick start tutorial]({{< relref "./tutorial/index.md" >}}) to get a complete guide to instrument an application with Beyla and data to Grafana Cloud.
 

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -44,7 +44,7 @@ To run in Direct mode by using the Prometheus scrape endpoint, please refer to t
 > as local Linux OS executables. For further examples on downloading and running the
 > auto-instrumentation tool as an OCI container, you can check the documentation sections on
 > [running the Beyla as a Docker container]({{< relref "../setup/docker.md" >}})
-> or [running Beyla in Kubernetes]({{< relref "../kubernetes.md" >}}).
+> or [running Beyla in Kubernetes]({{< relref "../setup/kubernetes.md" >}}).
 
 First, you will need to locally install and configure the [Grafana Agent in **Flow** mode, according to the latest documentation](/docs/agent/latest/flow/).
 Running the Agent in Flow mode will facilitate the ingestion of OpenTelemetry

--- a/docs/sources/setup/_index.md
+++ b/docs/sources/setup/_index.md
@@ -14,6 +14,6 @@ There are different options to set up and run Beyla:
 
 1. [As a standalone Linux process]({{< relref "./standalone.md" >}}).
 2. [With Docker to instrument a process running in a container]({{< relref "./docker.md" >}}).
-3. [As a Kubernetes sidecar container]({{< relref "../kubernetes.md" >}})
+3. [As a Kubernetes sidecar container]({{< relref "./kubernetes.md" >}})
 
 For information on configuration options and data export modes, see the [Configure Beyla]({{< relref "../configure/_index.md" >}}) documentation.

--- a/docs/sources/setup/_index.md
+++ b/docs/sources/setup/_index.md
@@ -10,11 +10,10 @@ keywords:
 
 # Setup Beyla
 
-There are two options to set up and run Beyla:
+There are different options to set up and run Beyla:
 
 1. [As a standalone Linux process]({{< relref "./standalone.md" >}}).
 2. [With Docker to instrument a process running in a container]({{< relref "./docker.md" >}}).
+3. [As a Kubernetes sidecar container]({{< relref "../kubernetes.md" >}})
 
 For information on configuration options and data export modes, see the [Configure Beyla]({{< relref "../configure/_index.md" >}}) documentation.
-
-For information to deploy Beyla on Kubernetes, see the [Deploy Beyla in Kubernetes]({{< relref "../kubernetes.md" >}}) documentation.

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -2,7 +2,7 @@
 title: Deploy Beyla in Kubernetes
 menuTitle: Deploy in Kubernetes
 description: Learn how to deploy Beyla in Kubernetes.
-weight: 5
+weight: 3
 keywords:
   - Beyla
   - eBPF
@@ -15,6 +15,9 @@ You can deploy Beyla in Kubernetes in two separate ways:
 
 - As a Sidecar Container (recommended)
 - As a DaemonSet
+
+In the future, we will release a [Beyla operator](https://github.com/grafana/beyla-operator)
+but at the moment it is work in progress and its API is not stable enough. 
 
 ## Deploying as a sidecar container
 

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -90,7 +90,7 @@ spec:
 ```
 
 For more information about the different configuration options, please check the
-[Configuration]({{< relref "./configure/options.md" >}}) section of this documentation site.
+[Configuration]({{< relref "../configure/options.md" >}}) section of this documentation site.
 
 Deploying as a sidecar container, is the default deployment mode for the
 [eBPF auto-instrument Kubernetes Operator](https://github.com/grafana/beyla-operator).


### PR DESCRIPTION
I think the "deploy in kubernetes" should Go in the same folder as "deploy in a containr" and "deploy standalone".

It also mentions the "Kubernetes operator" as a future option.