### PR TITLE
Replaced hardcoded relative paths by a ProjectDir function

### DIFF
--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/beyla/test/tools"
 )
 
 var debugData *dwarf.Data
@@ -41,13 +43,14 @@ func compileELF(source string, extraArgs ...string) *elf.File {
 
 func TestMain(m *testing.M) {
 	var err error
+	baseDir := tools.ProjectDir()
 	// Compiling the same executable twice, with and without debug data so we can inspect it later in the tests
-	debugData, err = compileELF("../../../test/cmd/pingserver/server.go").DWARF()
+	debugData, err = compileELF(baseDir + "/test/cmd/pingserver/server.go").DWARF()
 	if err != nil {
 		panic(err)
 	}
-	grpcElf, _ = compileELF("../../../test/cmd/grpc/server/server.go").DWARF()
-	smallELF = compileELF("../../../test/cmd/pingserver/server.go", "-ldflags", "-s -w")
+	grpcElf, _ = compileELF(baseDir + "/test/cmd/grpc/server/server.go").DWARF()
+	smallELF = compileELF(baseDir+"/test/cmd/pingserver/server.go", "-ldflags", "-s -w")
 	m.Run()
 }
 

--- a/test/integration/config.go
+++ b/test/integration/config.go
@@ -1,9 +1,13 @@
 package integration
 
-import "path"
+import (
+	"path"
+
+	"github.com/grafana/beyla/test/tools"
+)
 
 var (
-	pathRoot   = path.Join("..", "..")
+	pathRoot   = tools.ProjectDir()
 	pathOutput = path.Join(pathRoot, "testoutput")
 	pathVarRun = path.Join(pathOutput, "run")
 )

--- a/test/integration/k8s/k8s_main_test.go
+++ b/test/integration/k8s/k8s_main_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
+	"github.com/grafana/beyla/test/tools"
 )
 
 const (
@@ -25,9 +26,10 @@ const (
 )
 
 var (
-	pathRoot     = path.Join("..", "..", "..")
-	pathOutput   = path.Join(pathRoot, "testoutput")
-	pathKindLogs = path.Join(pathOutput, "kind")
+	pathRoot       = tools.ProjectDir()
+	pathOutput     = path.Join(pathRoot, "testoutput")
+	pathKindLogs   = path.Join(pathOutput, "kind")
+	componentsPath = path.Join(pathRoot, "test", "integration", "components")
 )
 
 // Ping stores the configuration data of a local pod that will be used to
@@ -43,10 +45,10 @@ var cluster *kube.Kind
 // TestMain is run once before all the tests in the package. If you need to mount a different cluster for
 // a different test suite, you should add a new TestMain in a new package together with the new test suite
 func TestMain(m *testing.M) {
-	if err := docker.Build(os.Stdout, "../../..",
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: "../components/testserver/Dockerfile"},
-		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: "../components/beyla/Dockerfile"},
-		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: "../components/grpcpinger/Dockerfile"},
+	if err := docker.Build(os.Stdout, pathRoot,
+		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: componentsPath + "/testserver/Dockerfile"},
+		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: componentsPath + "/beyla/Dockerfile"},
+		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: componentsPath + "/grpcpinger/Dockerfile"},
 	); err != nil {
 		slog.Error("can't build docker images", err)
 		os.Exit(-1)

--- a/test/tools/dir.go
+++ b/test/tools/dir.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"path"
+	"path/filepath"
+	"runtime"
+)
+
+// ProjectDir returns the path of the project's root folder
+func ProjectDir() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("can't get runtime caller(0) file path")
+	}
+	thisDir := filepath.Dir(thisFile)
+
+	// If we move this file path, this probaly will need to change
+	// Unit tests are provided to avoid a file move to break other tests
+	projectDirFromHere := path.Join(thisDir, "..", "..")
+
+	abs, err := filepath.Abs(projectDirFromHere)
+	if err != nil {
+		panic("can't get project's absolute file: " + err.Error())
+	}
+	return filepath.Clean(abs)
+}

--- a/test/tools/dir_test.go
+++ b/test/tools/dir_test.go
@@ -1,0 +1,21 @@
+package tools
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectDir(t *testing.T) {
+	prjDir := ProjectDir()
+	// Test that the project relative dir is correct by checking for the
+	// existence of a file that should be only placed in the project
+	// root (e.g. third_party_licenses.csv)
+	fi, err := os.Stat(path.Join(prjDir, "third_party_licenses.csv"))
+	require.NoError(t, err)
+	require.NotNil(t, fi)
+	assert.NotEmpty(t, fi.Name())
+}

--- a/test/tools/dirtest/dir_test.go
+++ b/test/tools/dirtest/dir_test.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/beyla/test/tools"
+)
+
+// Unorthodox way to provide another test case to ../dir.go: we are testing
+// that the relative path still works when invoked from another directory depth
+func TestProjectDir(t *testing.T) {
+	prjDir := tools.ProjectDir()
+	// Test that the project relative dir is correct by checking for the
+	// existence of a file that should be only placed in the project
+	// root (e.g. third_party_licenses.csv)
+	fi, err := os.Stat(path.Join(prjDir, "third_party_licenses.csv"))
+	require.NoError(t, err)
+	require.NotNil(t, fi)
+	assert.NotEmpty(t, fi.Name())
+}


### PR DESCRIPTION
In another task I'd need to move the Kubernetes integration tests to another folder, as I would need different test setups.

Changing hardcoded relative paths might be tedious and error prone so I created this `ProjectDir` helper function and replaced some hardcoded relative paths by an invocation to that function, so we can safely change the directory structure in the future.