### PR TITLE
Update pipes library to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grafana/go-offsets-tracker v0.1.2
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
-	github.com/mariomac/pipes v0.7.0
+	github.com/mariomac/pipes v0.8.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524 h1:24nnoPrOI7cw2YZTWqDHqIchSJ07thcQDIUNnL6V+2o=
 github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524/go.mod h1:TMuTALUh4SPCDJdYOuOYIEwBgH2rzCDP1nNgj+lI8AE=
-github.com/mariomac/pipes v0.7.0 h1:J7exY2HSiDD/ANy0PB7+PCHomSlC0tG1R1je+zhBYhQ=
-github.com/mariomac/pipes v0.7.0/go.mod h1:jQjrTTJxshdixw/Gh4NbnilbL0pVyq2Ssp/v2YE3A1c=
+github.com/mariomac/pipes v0.8.0 h1:xx/DLxqHAwyhjWkw+uqH/0EVJZkDxCHlNuwui/4lqcg=
+github.com/mariomac/pipes v0.8.0/go.mod h1:c4UsamVvniQ7+YX+X2mxDTTfyXOEU35pMFKZ8JD4ShE=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/pkg/internal/ebpf/common/ringbuf.go
+++ b/pkg/internal/ebpf/common/ringbuf.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/ringbuf"
-	"github.com/mariomac/pipes/pkg/node"
 	"golang.org/x/exp/slog"
 
 	"github.com/grafana/beyla/pkg/internal/imetrics"
@@ -46,7 +45,7 @@ type ringBufForwarder[T any] struct {
 // ForwardRingbuf returns a function reads HTTPRequestTraces from an input ring buffer, accumulates them into an
 // internal buffer, and forwards them to an output events channel, previously converted to request.Span
 // instances.
-// Despite it returns a StartFuncCtx, this is not used inside the Pipes' library but it's invoked
+// Despite it returns a StartFunc, this is not used inside the Pipes' library but it's invoked
 // directly in the code as a simple function.
 func ForwardRingbuf[T any](
 	svcName string,
@@ -56,7 +55,7 @@ func ForwardRingbuf[T any](
 	reader func(*ringbuf.Record) (request.Span, error),
 	metrics imetrics.Reporter,
 	closers ...io.Closer,
-) node.StartFuncCtx[[]request.Span] {
+) func(context.Context, chan<- []request.Span) {
 	rbf := ringBufForwarder[T]{
 		svcName: svcName, cfg: cfg, logger: logger, ringbuffer: ringbuffer,
 		closers: closers, reader: reader, metrics: metrics,

--- a/pkg/internal/ebpf/common/ringbuf.go
+++ b/pkg/internal/ebpf/common/ringbuf.go
@@ -45,8 +45,6 @@ type ringBufForwarder[T any] struct {
 // ForwardRingbuf returns a function reads HTTPRequestTraces from an input ring buffer, accumulates them into an
 // internal buffer, and forwards them to an output events channel, previously converted to request.Span
 // instances.
-// Despite it returns a StartFunc, this is not used inside the Pipes' library but it's invoked
-// directly in the code as a simple function.
 func ForwardRingbuf[T any](
 	svcName string,
 	cfg *TracerConfig,

--- a/pkg/internal/export/debug/debug.go
+++ b/pkg/internal/export/debug/debug.go
@@ -2,7 +2,6 @@
 package debug
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/mariomac/pipes/pkg/node"
@@ -16,7 +15,7 @@ func (p PrintEnabled) Enabled() bool {
 	return bool(p)
 }
 
-func PrinterNode(_ context.Context, _ PrintEnabled) (node.TerminalFunc[[]request.Span], error) {
+func PrinterNode(_ PrintEnabled) (node.TerminalFunc[[]request.Span], error) {
 	return func(input <-chan []request.Span) {
 		for spans := range input {
 			for i := range spans {
@@ -45,7 +44,7 @@ type NoopEnabled bool
 func (n NoopEnabled) Enabled() bool {
 	return bool(n)
 }
-func NoopNode(_ context.Context, _ NoopEnabled) (node.TerminalFunc[[]request.Span], error) {
+func NoopNode(_ NoopEnabled) (node.TerminalFunc[[]request.Span], error) {
 	counter := 0
 	return func(spans <-chan []request.Span) {
 		for range spans {

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -112,7 +112,7 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 			Metrics:     internalMetrics,
 		})
 	require.NoError(t, err)
-	inputNode.SendsTo(node.AsTerminal(exporter))
+	inputNode.SendTo(node.AsTerminal(exporter))
 
 	go inputNode.Start()
 

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -196,7 +196,7 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 			Metrics:     internalTraces,
 		})
 	require.NoError(t, err)
-	inputNode.SendsTo(node.AsTerminal(exporter))
+	inputNode.SendTo(node.AsTerminal(exporter))
 
 	go inputNode.Start()
 
@@ -288,7 +288,7 @@ func TestTraces_InternalInstrumentationSampling(t *testing.T) {
 			Metrics:     internalTraces,
 		})
 	require.NoError(t, err)
-	inputNode.SendsTo(node.AsTerminal(exporter))
+	inputNode.SendTo(node.AsTerminal(exporter))
 
 	go inputNode.Start()
 

--- a/pkg/internal/traces/reader.go
+++ b/pkg/internal/traces/reader.go
@@ -20,8 +20,8 @@ type Reader struct {
 	TracesInput <-chan []request.Span
 }
 
-func ReaderProvider(_ context.Context, r Reader) (node.StartFuncCtx[[]request.Span], error) {
-	return func(ctx context.Context, out chan<- []request.Span) {
+func ReadFromChannel(ctx context.Context, r Reader) (node.StartFunc[[]request.Span], error) {
+	return func(out chan<- []request.Span) {
 		cancelChan := ctx.Done()
 		for {
 			select {

--- a/pkg/internal/transform/k8s.go
+++ b/pkg/internal/transform/k8s.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -62,7 +61,7 @@ func (d KubernetesDecorator) Enabled() bool {
 	}
 }
 
-func KubeDecoratorProvider(_ context.Context, cfg KubernetesDecorator) (node.MiddleFunc[[]request.Span, []request.Span], error) {
+func KubeDecoratorProvider(cfg KubernetesDecorator) (node.MiddleFunc[[]request.Span, []request.Span], error) {
 	decorator, err := newMetadataDecorator(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes metadata decorator: %w", err)

--- a/pkg/internal/transform/routes.go
+++ b/pkg/internal/transform/routes.go
@@ -2,8 +2,6 @@
 package transform
 
 import (
-	"context"
-
 	"github.com/mariomac/pipes/pkg/node"
 	"golang.org/x/exp/slog"
 
@@ -35,7 +33,7 @@ type RoutesConfig struct {
 	Patterns []string `yaml:"patterns"`
 }
 
-func RoutesProvider(_ context.Context, rc *RoutesConfig) (node.MiddleFunc[[]request.Span, []request.Span], error) {
+func RoutesProvider(rc *RoutesConfig) (node.MiddleFunc[[]request.Span, []request.Span], error) {
 	// set default value for Unmatch action
 	var unmatchAction func(span *request.Span)
 	switch rc.Unmatch {

--- a/pkg/internal/transform/routes_test.go
+++ b/pkg/internal/transform/routes_test.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -17,7 +16,7 @@ const testTimeout = 5 * time.Second
 func TestUnmatchedWildcard(t *testing.T) {
 	for _, tc := range []UnmatchType{"", UnmatchWildcard, "invalid_value"} {
 		t.Run(string(tc), func(t *testing.T) {
-			router, err := RoutesProvider(context.TODO(), &RoutesConfig{Unmatch: tc, Patterns: []string{"/user/:id"}})
+			router, err := RoutesProvider(&RoutesConfig{Unmatch: tc, Patterns: []string{"/user/:id"}})
 			require.NoError(t, err)
 			in, out := make(chan []request.Span, 10), make(chan []request.Span, 10)
 			defer close(in)
@@ -37,7 +36,7 @@ func TestUnmatchedWildcard(t *testing.T) {
 }
 
 func TestUnmatchedPath(t *testing.T) {
-	router, err := RoutesProvider(context.TODO(), &RoutesConfig{Unmatch: UnmatchPath, Patterns: []string{"/user/:id"}})
+	router, err := RoutesProvider(&RoutesConfig{Unmatch: UnmatchPath, Patterns: []string{"/user/:id"}})
 	require.NoError(t, err)
 	in, out := make(chan []request.Span, 10), make(chan []request.Span, 10)
 	defer close(in)
@@ -55,7 +54,7 @@ func TestUnmatchedPath(t *testing.T) {
 }
 
 func TestUnmatchedEmpty(t *testing.T) {
-	router, err := RoutesProvider(context.TODO(), &RoutesConfig{Unmatch: UnmatchUnset, Patterns: []string{"/user/:id"}})
+	router, err := RoutesProvider(&RoutesConfig{Unmatch: UnmatchUnset, Patterns: []string{"/user/:id"}})
 	require.NoError(t, err)
 	in, out := make(chan []request.Span, 10), make(chan []request.Span, 10)
 	defer close(in)

--- a/vendor/github.com/mariomac/pipes/pkg/graph/graph.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/graph.go
@@ -1,9 +1,7 @@
 package graph
 
-import "context"
-
 type startNode interface {
-	StartCtx(ctx context.Context)
+	Start()
 }
 
 type terminalNode interface {
@@ -19,10 +17,10 @@ type Graph struct {
 }
 
 // Run all the stages of the graph and wait until all the nodes stopped processing.
-func (g *Graph) Run(ctx context.Context) {
+func (g *Graph) Run() {
 	// start all stages
 	for _, s := range g.start {
-		s.StartCtx(ctx)
+		s.Start()
 	}
 	// wait for all stages to finish
 	for _, t := range g.terms {

--- a/vendor/github.com/mariomac/pipes/pkg/graph/stage/stage.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/stage/stage.go
@@ -1,8 +1,6 @@
 package stage
 
 import (
-	"context"
-
 	"github.com/mariomac/pipes/pkg/node"
 )
 
@@ -33,28 +31,29 @@ var _ Instancer = (*Instance)(nil)
 var _ Instancer = Instance("")
 
 // StartProvider is a function that, given a configuration argument of a unique type,
-// returns a function fulfilling the node.StartFuncCtx type signature. Returned functions
+// returns a function fulfilling the node.StartFunc type signature. Returned function
 // will run inside a Graph Start Node
+// If it returns an error, the graph building process will be interrupted.
 // The configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
-// The context that is passed to the Provider doesn't have to be the same context that is
-// later passed to the node.StartFuncCtx instance.
-type StartProvider[CFG, O any] func(context.Context, CFG) (node.StartFuncCtx[O], error)
+type StartProvider[CFG, O any] func(CFG) (node.StartFunc[O], error)
 
 // StartMultiProvider is similar to StarProvider, but it is able to associate a variadic
 // number of functions that will behave as a single node.
-type StartMultiProvider[CFG, O any] func(context.Context, CFG) ([]node.StartFuncCtx[O], error)
+type StartMultiProvider[CFG, O any] func(CFG) ([]node.StartFunc[O], error)
 
 // MiddleProvider is a function that, given a configuration argument of a unique type,
 // returns a function fulfilling the node.MiddleFunc type signature. Returned functions
-// will run inside a Graph Middle Node
+// will run inside a Graph Middle Node.
+// If it returns an error, the graph building process will be interrupted.
 // The configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
-type MiddleProvider[CFG, I, O any] func(context.Context, CFG) (node.MiddleFunc[I, O], error)
+type MiddleProvider[CFG, I, O any] func(CFG) (node.MiddleFunc[I, O], error)
 
 // TerminalProvider is a function that, given a configuration argument of a unique type,
 // returns a function fulfilling the node.TerminalFunc type signature. Returned functions
-// will run inside a Graph Terminal Node
+// will run inside a Graph Terminal Node.
+// If it returns an error, the graph building process will be interrupted.
 // The configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
-type TerminalProvider[CFG, I any] func(context.Context, CFG) (node.TerminalFunc[I], error)
+type TerminalProvider[CFG, I any] func(CFG) (node.TerminalFunc[I], error)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
 ## explicit; go 1.18
 github.com/mariomac/guara/pkg/test
-# github.com/mariomac/pipes v0.7.0
+# github.com/mariomac/pipes v0.8.0
 ## explicit; go 1.18
 github.com/mariomac/pipes/pkg/graph
 github.com/mariomac/pipes/pkg/graph/stage


### PR DESCRIPTION
The [Pipes library has been updated to simplify its API](https://github.com/mariomac/pipes/blob/main/CHANGELOG.md).

For more information about the API, you can have a look at the [high-level API tutorials](https://github.com/mariomac/pipes/tree/main/docs/tutorial).