### PR TITLE
Modifying how we handle OTEL traces/metrics endpoints

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -237,6 +237,11 @@ The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable sets a common endpoint fo
 or the `endpoint` YAML, property will set the endpoint only for the metrics exporter node,
 such that the traces' exporter won't be activated unless explicitly specified.
 
+According to the OpenTelemetry standard, if you set the endpoint via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable,
+the OpenTelemetry exporter will automatically add the `/v1/metrics` path to the URL. If you want to avoid this
+addition, you can use either the `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` environment variable or the `environment` YAML
+property to use exactly the provided URL without any addition.
+
 | YAML       | Env var                                                                    | Type   | Default        |
 | ---------- | -------------------------------------------------------------------------- | ------ | -------------- |
 | `protocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` or<br/>`OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | string | `http/protobuf |
@@ -352,6 +357,11 @@ The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable sets a common endpoint fo
 [metrics](#otel-metrics-exporter) and the traces exporters. The `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variable
 or the `endpoint` YAML property, will set the endpoint only for the traces' exporter node,
 so the metrics exporter won't be activated unless explicitly specified.
+
+According to the OpenTelemetry standard, if you set the endpoint via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable,
+the OpenTelemetry exporter will automatically add the `/v1/traces` path to the URL. If you want to avoid this
+addition, you can use either the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variable or the `environment` YAML
+property to use exactly the provided URL without any addition.
 
 | YAML       | Env var                                                                   | Type   | Default        |
 | ---------- | ------------------------------------------------------------------------- | ------ | -------------- |

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -8,6 +8,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"google.golang.org/grpc/credentials"
@@ -132,6 +134,35 @@ func (o *otlpOptions) AsMetricGRPC() []otlpmetricgrpc.Option {
 	}
 	if o.SkipTLSVerify {
 		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
+	}
+	return opts
+}
+
+func (o *otlpOptions) AsTraceHTTP() []otlptracehttp.Option {
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(o.Endpoint),
+	}
+	if o.Insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	if o.URLPath != "" {
+		opts = append(opts, otlptracehttp.WithURLPath(o.URLPath))
+	}
+	if o.SkipTLSVerify {
+		opts = append(opts, otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
+	}
+	return opts
+}
+
+func (o *otlpOptions) AsTraceGRPC() []otlptracegrpc.Option {
+	opts := []otlptracegrpc.Option{
+		otlptracegrpc.WithEndpoint(o.Endpoint),
+	}
+	if o.Insecure {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+	if o.SkipTLSVerify {
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
 	}
 	return opts
 }

--- a/pkg/internal/export/otel/common_test.go
+++ b/pkg/internal/export/otel/common_test.go
@@ -45,3 +45,42 @@ func TestOtlpOptions_AsMetricGRPC(t *testing.T) {
 		})
 	}
 }
+
+func TestOtlpOptions_AsTraceHTTP(t *testing.T) {
+	type testCase struct {
+		in  otlpOptions
+		len int
+	}
+	testCases := []testCase{
+		{in: otlpOptions{Endpoint: "foo"}, len: 1},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc), func(t *testing.T) {
+			assert.Equal(t, tc.len, len(tc.in.AsTraceHTTP()))
+		})
+	}
+}
+
+func TestOtlpOptions_AsTraceGRPC(t *testing.T) {
+	type testCase struct {
+		in  otlpOptions
+		len int
+	}
+	testCases := []testCase{
+		{in: otlpOptions{Endpoint: "foo"}, len: 1},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc), func(t *testing.T) {
+			assert.Equal(t, tc.len, len(tc.in.AsTraceGRPC()))
+		})
+	}
+}

--- a/pkg/internal/export/otel/common_test.go
+++ b/pkg/internal/export/otel/common_test.go
@@ -1,0 +1,47 @@
+package otel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOtlpOptions_AsMetricHTTP(t *testing.T) {
+	type testCase struct {
+		in  otlpOptions
+		len int
+	}
+	testCases := []testCase{
+		{in: otlpOptions{Endpoint: "foo"}, len: 1},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
+		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc), func(t *testing.T) {
+			assert.Equal(t, tc.len, len(tc.in.AsMetricHTTP()))
+		})
+	}
+}
+
+func TestOtlpOptions_AsMetricGRPC(t *testing.T) {
+	type testCase struct {
+		in  otlpOptions
+		len int
+	}
+	testCases := []testCase{
+		{in: otlpOptions{Endpoint: "foo"}, len: 1},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint(tc), func(t *testing.T) {
+			assert.Equal(t, tc.len, len(tc.in.AsMetricGRPC()))
+		})
+	}
+}

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/url"
 	"os"
@@ -19,7 +18,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"golang.org/x/exp/slog"
-	"google.golang.org/grpc/credentials"
 
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
@@ -40,9 +38,10 @@ const (
 )
 
 type MetricsConfig struct {
-	Interval        time.Duration `yaml:"interval" env:"METRICS_INTERVAL"`
-	Endpoint        string        `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	MetricsEndpoint string        `yaml:"-" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
+	Interval time.Duration `yaml:"interval" env:"METRICS_INTERVAL"`
+
+	CommonEndpoint  string `yaml:"" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
 
 	Protocol        Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
 	MetricsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
@@ -75,7 +74,7 @@ func (m *MetricsConfig) GetProtocol() Protocol {
 // This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
 // nolint:gocritic
 func (m MetricsConfig) Enabled() bool {
-	return m.Endpoint != "" || m.MetricsEndpoint != ""
+	return m.CommonEndpoint != "" || m.MetricsEndpoint != ""
 }
 
 // MetricsReporter implements the graph node that receives request.Span
@@ -215,7 +214,7 @@ func httpMetricsExporter(ctx context.Context, cfg *MetricsConfig) (metric.Export
 	if err != nil {
 		return nil, err
 	}
-	mexp, err := otlpmetrichttp.New(ctx, opts...)
+	mexp, err := otlpmetrichttp.New(ctx, opts.AsMetricHTTP()...)
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP metric exporter: %w", err)
 	}
@@ -227,7 +226,7 @@ func grpcMetricsExporter(ctx context.Context, cfg *MetricsConfig) (metric.Export
 	if err != nil {
 		return nil, err
 	}
-	mexp, err := otlpmetricgrpc.New(ctx, opts...)
+	mexp, err := otlpmetricgrpc.New(ctx, opts.AsMetricGRPC()...)
 	if err != nil {
 		return nil, fmt.Errorf("creating GRPC metric exporter: %w", err)
 	}
@@ -365,73 +364,80 @@ func (mr *MetricsReporter) reportMetrics(input <-chan []request.Span) {
 	mr.close()
 }
 
-func getHTTPMetricEndpointOptions(cfg *MetricsConfig) ([]otlpmetrichttp.Option, error) {
+func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
+	opts := otlpOptions{}
 	log := mlog().With("transport", "http")
-	murl, err := parseMetricsEndpoint(cfg)
+	murl, isCommon, err := parseMetricsEndpoint(cfg)
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	log.Debug("Configuring exporter",
 		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
 
 	setMetricsProtocol(cfg)
-	opts := []otlpmetrichttp.Option{
-		otlpmetrichttp.WithEndpoint(murl.Host),
-	}
+	opts.Endpoint = murl.Host
 	if murl.Scheme == "http" || murl.Scheme == "unix" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts = append(opts, otlpmetrichttp.WithInsecure())
+		opts.Insecure = true
 	}
-	if len(murl.Path) > 0 && murl.Path != "/" && !strings.HasSuffix(murl.Path, "/v1/metrics") {
-		urlPath := murl.Path + "/v1/metrics"
-		log.Debug("Specifying path", "path", urlPath)
-		opts = append(opts, otlpmetrichttp.WithURLPath(urlPath))
+	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/metrics to the path
+	// otherwise, we leave the path that is explicitly set by the user
+	opts.URLPath = murl.Path
+	if isCommon {
+		if strings.HasSuffix(opts.URLPath, "/") {
+			opts.URLPath += "v1/metrics"
+		} else {
+			opts.URLPath += "/v1/metrics"
+		}
 	}
+	log.Debug("Specifying path", "path", opts.URLPath)
+
 	if cfg.InsecureSkipVerify {
 		log.Debug("Setting InsecureSkipVerify")
-		opts = append(opts, otlpmetrichttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
+		opts.SkipTLSVerify = cfg.InsecureSkipVerify
 	}
 	return opts, nil
 }
 
-func getGRPCMetricEndpointOptions(cfg *MetricsConfig) ([]otlpmetricgrpc.Option, error) {
+func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
+	opts := otlpOptions{}
 	log := mlog().With("transport", "grpc")
-	murl, err := parseMetricsEndpoint(cfg)
+	murl, _, err := parseMetricsEndpoint(cfg)
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	log.Debug("Configuring exporter",
 		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
 
 	setMetricsProtocol(cfg)
-	opts := []otlpmetricgrpc.Option{
-		otlpmetricgrpc.WithEndpoint(murl.Host),
-	}
+	opts.Endpoint = murl.Host
 	if murl.Scheme == "http" || murl.Scheme == "unix" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts = append(opts, otlpmetricgrpc.WithInsecure())
+		opts.Insecure = true
 	}
 	if cfg.InsecureSkipVerify {
 		log.Debug("Setting InsecureSkipVerify")
-		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
+		opts.SkipTLSVerify = true
 	}
 	return opts, nil
 }
 
-func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, error) {
+func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, bool, error) {
+	isCommon := false
 	endpoint := cfg.MetricsEndpoint
 	if endpoint == "" {
-		endpoint = cfg.Endpoint
+		isCommon = true
+		endpoint = cfg.CommonEndpoint
 	}
 
 	murl, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
+		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
 	}
 	if murl.Scheme == "" || murl.Host == "" {
-		return nil, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
 	}
-	return murl, nil
+	return murl, isCommon, nil
 }
 
 // HACK: at the time of writing this, the otelpmetrichttp API does not support explicitly

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -40,7 +40,7 @@ const (
 type MetricsConfig struct {
 	Interval time.Duration `yaml:"interval" env:"METRICS_INTERVAL"`
 
-	CommonEndpoint  string `yaml:"" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	CommonEndpoint  string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
 
 	Protocol        Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -21,64 +21,57 @@ import (
 
 const timeout = 5 * time.Second
 
-func TestMetricsEndpoint(t *testing.T) {
+func TestHTTPMetricsEndpointOPtions(t *testing.T) {
 	mcfg := MetricsConfig{
-		Endpoint:        "https://localhost:3131",
-		MetricsEndpoint: "https://localhost:3232",
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "https://localhost:3232/v1/metrics",
 	}
 
 	t.Run("testing with two endpoints", func(t *testing.T) {
-		testMetricsEndpLen(t, 1, &mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics"}, mcfg)
 	})
 
 	mcfg = MetricsConfig{
-		Endpoint:        "https://localhost:3131",
-		MetricsEndpoint: "https://localhost:3232",
+		CommonEndpoint: "https://localhost:3131/otlp",
 	}
 
-	t.Run("testing with only metrics endpoint", func(t *testing.T) {
-		testMetricsEndpLen(t, 1, &mcfg)
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3131", URLPath: "/otlp/v1/metrics"}, mcfg)
 	})
 
-	mcfg.Endpoint = "https://localhost:3131"
-	mcfg.MetricsEndpoint = ""
-
-	t.Run("testing with only non-signal endpoint", func(t *testing.T) {
-		testMetricsEndpLen(t, 1, &mcfg)
-	})
-
-	mcfg.Endpoint = "http://localhost:3131"
+	mcfg = MetricsConfig{
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "http://localhost:3232",
+	}
 	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testMetricsEndpLen(t, 2, &mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, mcfg)
 	})
 
-	mcfg.Endpoint = "http://localhost:3131/path_to_endpoint"
-	t.Run("testing with insecure endpoint and path", func(t *testing.T) {
-		testMetricsEndpLen(t, 3, &mcfg)
-	})
+	mcfg = MetricsConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+	}
 
-	mcfg.Endpoint = "http://localhost:3131/v1/metrics"
-	t.Run("testing with insecure endpoint and containing v1/metrics", func(t *testing.T) {
-		testMetricsEndpLen(t, 2, &mcfg)
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", SkipTLSVerify: true}, mcfg)
 	})
 }
 
-func testMetricsEndpLen(t *testing.T, expected int, mcfg *MetricsConfig) {
-	opts, err := getHTTPMetricEndpointOptions(mcfg)
+func testMetricsHTTPOptions(t *testing.T, expected otlpOptions, mcfg MetricsConfig) {
+	opts, err := getHTTPMetricEndpointOptions(&mcfg)
 	require.NoError(t, err)
-	// otlpmetrichttp.Options are notoriously hard to compare, so we just test the length
-	assert.Equal(t, expected, len(opts))
+	assert.Equal(t, expected, opts)
 }
 
 func TestMissingSchemeInMetricsEndpoint(t *testing.T) {
-	opts, err := getHTTPMetricEndpointOptions(&MetricsConfig{Endpoint: "http://foo:3030"})
+	opts, err := getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "http://foo:3030"})
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 
-	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{Endpoint: "foo:3030"})
+	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3030"})
 	require.Error(t, err)
 
-	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{Endpoint: "foo"})
+	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo"})
 	require.Error(t, err)
 }
 
@@ -106,7 +99,7 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	})
 	internalMetrics := &fakeInternalMetrics{}
 	exporter, err := ReportMetrics(context.Background(),
-		&MetricsConfig{Endpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16},
+		&MetricsConfig{CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16},
 		&global.ContextInfo{
 			ServiceName: "foo",
 			Metrics:     internalMetrics,
@@ -178,17 +171,49 @@ type fakeInternalMetrics struct {
 
 func TestGRPCMetricsEndpointOptions(t *testing.T) {
 	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
-		_, err := getGRPCMetricEndpointOptions(&MetricsConfig{Endpoint: "foo:3939"})
+		_, err := getGRPCMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3939"})
 		assert.Error(t, err)
 	})
-	t.Run("handles insecure skip verification", func(t *testing.T) {
-		opts, err := getGRPCMetricEndpointOptions(&MetricsConfig{
-			Endpoint:           "http://foo:3939",
-			InsecureSkipVerify: true,
-		})
-		assert.NoError(t, err)
-		assert.Len(t, opts, 3) // host, insecure, insecure skip
+
+	mcfg := MetricsConfig{
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "https://localhost:3232",
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232"}, mcfg)
 	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint: "https://localhost:3131",
+	}
+
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3131"}, mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "http://localhost:3232",
+	}
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+	}
+
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", SkipTLSVerify: true}, mcfg)
+	})
+}
+
+func testMetricsGRPCOptions(t *testing.T, expected otlpOptions, mcfg MetricsConfig) {
+	opts, err := getGRPCMetricEndpointOptions(&mcfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, opts)
 }
 
 func TestMetricsSetupHTTP_Protocol(t *testing.T) {
@@ -207,8 +232,8 @@ func TestMetricsSetupHTTP_Protocol(t *testing.T) {
 		t.Run(string(tc.ProtoVal)+"/"+string(tc.MetricProtoVal), func(t *testing.T) {
 			defer restoreEnvAfterExecution()()
 			_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-				Endpoint: "http://host:3333",
-				Protocol: tc.ProtoVal, MetricsProtocol: tc.MetricProtoVal,
+				CommonEndpoint: "http://host:3333",
+				Protocol:       tc.ProtoVal, MetricsProtocol: tc.MetricProtoVal,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
@@ -223,7 +248,7 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 		require.NoError(t, os.Setenv(envProtocol, "foo-proto"))
 		require.NoError(t, os.Setenv(envMetricsProtocol, "bar-proto"))
 		_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-			Endpoint: "http://host:3333", Protocol: "foo", MetricsProtocol: "bar",
+			CommonEndpoint: "http://host:3333", Protocol: "foo", MetricsProtocol: "bar",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
@@ -233,7 +258,7 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 		defer restoreEnvAfterExecution()()
 		require.NoError(t, os.Setenv(envProtocol, "foo-proto"))
 		_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-			Endpoint: "http://host:3333", Protocol: "foo",
+			CommonEndpoint: "http://host:3333", Protocol: "foo",
 		})
 		require.NoError(t, err)
 		_, ok := os.LookupEnv(envMetricsProtocol)

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -28,7 +28,7 @@ func TestHTTPMetricsEndpointOPtions(t *testing.T) {
 	}
 
 	t.Run("testing with two endpoints", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics"}, mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics"}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -36,7 +36,7 @@ func TestHTTPMetricsEndpointOPtions(t *testing.T) {
 	}
 
 	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3131", URLPath: "/otlp/v1/metrics"}, mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3131", URLPath: "/otlp/v1/metrics"}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -44,7 +44,7 @@ func TestHTTPMetricsEndpointOPtions(t *testing.T) {
 		MetricsEndpoint: "http://localhost:3232",
 	}
 	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -53,12 +53,12 @@ func TestHTTPMetricsEndpointOPtions(t *testing.T) {
 	}
 
 	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", SkipTLSVerify: true}, mcfg)
+		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", SkipTLSVerify: true}, &mcfg)
 	})
 }
 
-func testMetricsHTTPOptions(t *testing.T, expected otlpOptions, mcfg MetricsConfig) {
-	opts, err := getHTTPMetricEndpointOptions(&mcfg)
+func testMetricsHTTPOptions(t *testing.T, expected otlpOptions, mcfg *MetricsConfig) {
+	opts, err := getHTTPMetricEndpointOptions(mcfg)
 	require.NoError(t, err)
 	assert.Equal(t, expected, opts)
 }
@@ -181,7 +181,7 @@ func TestGRPCMetricsEndpointOptions(t *testing.T) {
 	}
 
 	t.Run("testing with two endpoints", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232"}, mcfg)
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232"}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -189,7 +189,7 @@ func TestGRPCMetricsEndpointOptions(t *testing.T) {
 	}
 
 	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3131"}, mcfg)
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3131"}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -197,7 +197,7 @@ func TestGRPCMetricsEndpointOptions(t *testing.T) {
 		MetricsEndpoint: "http://localhost:3232",
 	}
 	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, mcfg)
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true}, &mcfg)
 	})
 
 	mcfg = MetricsConfig{
@@ -206,12 +206,12 @@ func TestGRPCMetricsEndpointOptions(t *testing.T) {
 	}
 
 	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", SkipTLSVerify: true}, mcfg)
+		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", SkipTLSVerify: true}, &mcfg)
 	})
 }
 
-func testMetricsGRPCOptions(t *testing.T, expected otlpOptions, mcfg MetricsConfig) {
-	opts, err := getGRPCMetricEndpointOptions(&mcfg)
+func testMetricsGRPCOptions(t *testing.T, expected otlpOptions, mcfg *MetricsConfig) {
+	opts, err := getGRPCMetricEndpointOptions(mcfg)
 	require.NoError(t, err)
 	assert.Equal(t, expected, opts)
 }

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -62,7 +62,8 @@ kubernetes:
 		},
 		Metrics: otel.MetricsConfig{
 			Interval:          5 * time.Second,
-			Endpoint:          "localhost:3131",
+			CommonEndpoint:    "localhost:3131",
+			MetricsEndpoint:   "localhost:3030",
 			Protocol:          otel.ProtocolHTTPProtobuf,
 			ReportersCacheLen: 16,
 			Buckets: otel.Buckets{

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -73,7 +73,7 @@ kubernetes:
 		},
 		Traces: otel.TracesConfig{
 			Protocol:           otel.ProtocolHTTPProtobuf,
-			Endpoint:           "localhost:3131",
+			CommonEndpoint:     "localhost:3131",
 			TracesEndpoint:     "localhost:3232",
 			MaxQueueSize:       4096,
 			MaxExportBatchSize: 4096,


### PR DESCRIPTION
Investigating about https://github.com/grafana/beyla/issues/297, I realized an edge case in which a user setting the endpoint value via the `endpoint` YAML property would get automatically attached the `/v1/metrics` or `/v1/traces` path.

Since there each `endpoint` sets the value separately for their respective metrics or traces exporter, I think they should behave like the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` env vars (use the endpoint without modification) instead of the current `OTEL_EXPORTER_OTLP_ENDPOINT` (add `/v1/metrics` or `/v1/traces` accordingly).

There was also the issue that we indiscriminately added the `/v1/metrics` or `/v1/traces` path suffix even if a user explicitly set the values through the  `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. That means that an OTEL ingestor not exposing these standard paths but custom ones would not properly work with Beyla.

The **breaking change** relies in the way the YAML file is handled, and that we now stick to the standard.

This PR also refines the way the different exporter options are tested.