### PR TITLE
move YAML open_port, executable_name and system_wide options to top level

### DIFF
--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -168,11 +168,10 @@ which we will explain in the rest of this section.
 
 First, you will need to specify the executable to instrument. If, for example,
 the service executable is a process that opens the port `443`, you can use the `open_port`
-property in the `ebpf` section of the YAML document:
+property of the YAML document:
 
 ```yaml
-ebpf:
-  open_port: 443
+open_port: 443
 ```
 
 The auto-instrumentation tool will automatically search and instrument the process

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -55,39 +55,6 @@ the options for each component.
 The properties in this section are first-level YAML properties, as they apply to the
 whole Beyla configuration:
 
-| YAML           | Env var                               | Type   | Default         |
-| -------------- |---------------------------------------| ------ | --------------- |
-| `service_name` | `SERVICE_NAME` or `OTEL_SERVICE_NAME` | string | executable name |
-
-Specifies the name of the instrumented service to be reported by the metrics exporter.
-If unset, it will be the name of the executable of the service.
-
-| YAML                | Env var             | Type   | Default |
-| ------------------- | ------------------- | ------ | ------- |
-| `service_namespace` | `SERVICE_NAMESPACE` | string | (unset) |
-
-Optionally, allows assigning a namespace for the service.
-
-| YAML        | Env var     | Type   | Default |
-| ----------- | ----------- | ------ | ------- |
-| `log_level` | `LOG_LEVEL` | string | `INFO`  |
-
-Sets the verbosity level of the process standard output logger.
-Valid log level values are: `DEBUG`, `INFO`, `WARN` and `ERROR`.
-`DEBUG` being the most verbose and `ERROR` the least verbose.
-
-| YAML           | Env var        | Type    | Default |
-| -------------- | -------------- | ------- | ------- |
-| `print_traces` | `PRINT_TRACES` | boolean | `false` |
-
-<a id="printer"></a>
-
-If `true`, prints any instrumented trace on the standard output (stdout).
-
-## EBPF tracer
-
-YAML section `ebpf`.
-
 | YAML              | Env var           | Type   | Default |
 | ----------------- | ----------------- | ------ | ------- |
 | `executable_name` | `EXECUTABLE_NAME` | string | (unset) |
@@ -139,6 +106,39 @@ At present time only HTTP (non SSL) requests are tracked system-wide, and there'
 When you are instrumenting Go applications, you should explicitly use `executable_name` or
 `open_port` instead of `system_wide` instrumentation. The Go specific instrumentation is of higher
 fidelity and incurs lesser overall overhead.
+
+| YAML           | Env var                               | Type   | Default         |
+| -------------- |---------------------------------------| ------ | --------------- |
+| `service_name` | `SERVICE_NAME` or `OTEL_SERVICE_NAME` | string | executable name |
+
+Overrides the name of the instrumented service to be reported by the metrics exporter.
+If unset, it will be the name of the executable of the service.
+
+| YAML                | Env var             | Type   | Default |
+| ------------------- | ------------------- | ------ | ------- |
+| `service_namespace` | `SERVICE_NAMESPACE` | string | (unset) |
+
+Optionally, allows assigning a namespace for the service.
+
+| YAML        | Env var     | Type   | Default |
+| ----------- | ----------- | ------ | ------- |
+| `log_level` | `LOG_LEVEL` | string | `INFO`  |
+
+Sets the verbosity level of the process standard output logger.
+Valid log level values are: `DEBUG`, `INFO`, `WARN` and `ERROR`.
+`DEBUG` being the most verbose and `ERROR` the least verbose.
+
+| YAML           | Env var        | Type    | Default |
+| -------------- | -------------- | ------- | ------- |
+| `print_traces` | `PRINT_TRACES` | boolean | `false` |
+
+<a id="printer"></a>
+
+If `true`, prints any instrumented trace on the standard output (stdout).
+
+## EBPF tracer
+
+YAML section `ebpf`.
 
 | YAML         | Env var          | Type   | Default |
 | ------------ | ---------------- | ------ | ------- |
@@ -473,11 +473,11 @@ or the same (both metric families will be listed in the same scrape endpoint).
 ## YAML file example
 
 ```yaml
-log_level: DEBUG
+open_port: 443
 service_name: my-instrumented-service
+log_level: DEBUG
 
 ebpf:
-  open_port: 443
   wakeup_len: 100
 
 otel_traces:

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -136,6 +136,13 @@ Valid log level values are: `DEBUG`, `INFO`, `WARN` and `ERROR`.
 
 If `true`, prints any instrumented trace on the standard output (stdout).
 
+| YAML                       | Env var                    | Type    | Default |
+| -------------------------- | -------------------------- | ------- | ------- |
+| `skip_go_specific_tracers` | `SKIP_GO_SPECIFIC_TRACERS` | boolean | false   |
+
+Disables the detection of Go specifics when ebpf tracer inspects executables to be instrumented.
+The tracer will fallback to using generic instrumentation, which will generally be less efficient.
+
 ## EBPF tracer
 
 YAML section `ebpf`.
@@ -153,12 +160,6 @@ can help with reducing the CPU overhead of Beyla.
 In low-load services (in terms of requests/second), high values of `wakeup_len` could
 add a noticeable delay in the time the metrics are submitted and become externally visible.
 
-| YAML                       | Env var                    | Type    | Default |
-| -------------------------- | -------------------------- | ------- | ------- |
-| `skip_go_specific_tracers` | `SKIP_GO_SPECIFIC_TRACERS` | boolean | false   |
-
-Disables the detection of Go specifics when ebpf tracer inspects executables to be instrumented.
-The tracer will fallback to using generic instrumentation, which will generally be less efficient.
 
 ## Routes decorator
 

--- a/docs/sources/configure/resources/instrumenter-config.yml
+++ b/docs/sources/configure/resources/instrumenter-config.yml
@@ -1,5 +1,4 @@
-ebpf:
-  open_port: 443
+open_port: 443
 otel_metrics_export:
   endpoint: http://localhost:4318
 otel_traces_export:

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -58,8 +58,7 @@ The equivalent execution, but configured via a YAML file would look like:
 
 ```yaml
 cat > config.yml <<EOF
-ebpf:
-  open_port: 443
+open_port: 443
 prometheus_export:
   port: 8999
 EOF

--- a/pkg/beyla/beyla.go
+++ b/pkg/beyla/beyla.go
@@ -71,7 +71,7 @@ func LoadConfig(reader io.Reader) (*Config, error) {
 // selection criteria.
 func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
 	finder := &ebpf.ProcessFinder{
-		Cfg:     &i.config.EBPF,
+		Cfg:     i.config,
 		CtxInfo: i.ctxInfo,
 		Metrics: i.ctxInfo.Metrics,
 	}

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -21,19 +21,7 @@ type HTTPRequestTrace bpfHttpRequestTrace
 
 // TracerConfig configuration for eBPF programs
 type TracerConfig struct {
-	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
-	Exec string `yaml:"executable_name" env:"EXECUTABLE_NAME"`
-	// Port allows selecting the instrumented executable that owns the Port value. If this value is set (and
-	// different to zero), the value of the Exec property won't take effect.
-	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter
-	// will instrument all the service calls in all the ports, not only the port specified here.
-	Port int `yaml:"open_port" env:"OPEN_PORT"`
-	// SystemWide allows instrumentation of all HTTP (no gRPC) calls, incoming and outgoing at a system wide scale.
-	// No filtering per application will be done. Using this option may result in reduced quality of information
-	// gathered for certain languages, such as Golang.
-	SystemWide bool   `yaml:"system_wide" env:"SYSTEM_WIDE"`
-	LogLevel   string `yaml:"log_level" env:"LOG_LEVEL"`
-	BpfDebug   bool   `yaml:"bfp_debug" env:"BPF_DEBUG"`
+	BpfDebug bool `yaml:"bfp_debug" env:"BPF_DEBUG"`
 
 	// WakeupLen specifies how many messages need to be accumulated in the eBPF ringbuffer
 	// before sending a wakeup request.

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -39,9 +39,6 @@ type TracerConfig struct {
 	// BpfBaseDir specifies the base directory where the BPF pinned maps will be mounted.
 	// By default, it will be /var/run/beyla
 	BpfBaseDir string `yaml:"bpf_fs_base_dir" env:"BPF_FS_BASE_DIR"`
-
-	// This can be enabled to use generic HTTP tracers only, no Go-specifics will be used:
-	SkipGoSpecificTracers bool `yaml:"skip_go_specific_tracers" env:"SKIP_GO_SPECIFIC_TRACERS"`
 }
 
 // Probe holds the information of the instrumentation points of a given function: its start and end offsets and

--- a/pkg/internal/ebpf/finder.go
+++ b/pkg/internal/ebpf/finder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/ebpf/httpfltr"
 	"github.com/grafana/beyla/pkg/internal/ebpf/nethttp"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 )
 
@@ -31,7 +32,7 @@ func pflog() *slog.Logger {
 // ProcessFinder continuously listens in background for a process matching the
 // search criteria as specified to the user.
 type ProcessFinder struct {
-	Cfg     *ebpfcommon.TracerConfig
+	Cfg     *pipe.Config
 	Metrics imetrics.Reporter
 	CtxInfo *global.ContextInfo
 
@@ -49,9 +50,9 @@ func (pf *ProcessFinder) Start(ctx context.Context) (<-chan *ProcessTracer, erro
 		return nil, fmt.Errorf("removing memory lock: %w", err)
 	}
 	var err error
-	pf.pinPath, err = mountBpfPinPath(pf.Cfg)
+	pf.pinPath, err = mountBpfPinPath(&pf.Cfg.EBPF)
 	if err != nil {
-		return nil, fmt.Errorf("mounting BPF FS in %q: %w", pf.Cfg.BpfBaseDir, err)
+		return nil, fmt.Errorf("mounting BPF FS in %q: %w", pf.Cfg.EBPF.BpfBaseDir, err)
 	}
 	go func() {
 		// TODO, for multi-process inspection
@@ -112,10 +113,10 @@ func (pf *ProcessFinder) findAndInstrument(ctx context.Context, metrics imetrics
 
 	// Each program is an eBPF source: net/http, grpc...
 	programs := []Tracer{
-		&nethttp.Tracer{Cfg: pf.Cfg, Metrics: metrics},
-		&nethttp.GinTracer{Tracer: nethttp.Tracer{Cfg: pf.Cfg, Metrics: metrics}},
-		&grpc.Tracer{Cfg: pf.Cfg, Metrics: metrics},
-		&goruntime.Tracer{Cfg: pf.Cfg, Metrics: metrics},
+		&nethttp.Tracer{Cfg: &pf.Cfg.EBPF, Metrics: metrics},
+		&nethttp.GinTracer{Tracer: nethttp.Tracer{Cfg: &pf.Cfg.EBPF, Metrics: metrics}},
+		&grpc.Tracer{Cfg: &pf.Cfg.EBPF, Metrics: metrics},
+		&goruntime.Tracer{Cfg: &pf.Cfg.EBPF, Metrics: metrics},
 	}
 
 	// merging all the functions from all the programs, in order to do

--- a/pkg/internal/ebpf/finder_darwin.go
+++ b/pkg/internal/ebpf/finder_darwin.go
@@ -3,14 +3,14 @@ package ebpf
 import (
 	"context"
 
-	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 )
 
 // dummy functions and types to avoid compilation errors in Darwin. The finder component is only usable in Linux.
 type ProcessFinder struct {
-	Cfg     *ebpfcommon.TracerConfig
+	Cfg     *pipe.Config
 	Metrics imetrics.Reporter
 	CtxInfo *global.ContextInfo
 }

--- a/pkg/internal/ebpf/httpfltr/httpfltr.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/exec"
 	"github.com/grafana/beyla/pkg/internal/goexec"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/request"
 )
 
@@ -45,7 +46,7 @@ type HTTPInfo struct {
 }
 
 type Tracer struct {
-	Cfg        *ebpfcommon.TracerConfig
+	Cfg        *pipe.Config
 	Metrics    imetrics.Reporter
 	bpfObjects bpfObjects
 	closers    []io.Closer
@@ -54,7 +55,7 @@ type Tracer struct {
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 	loader := loadBpf
-	if p.Cfg.BpfDebug {
+	if p.Cfg.EBPF.BpfDebug {
 		loader = loadBpf_debug
 	}
 
@@ -221,7 +222,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
 func (p *Tracer) Run(ctx context.Context, eventsChan chan<- []request.Span, svcName string) {
 	ebpfcommon.ForwardRingbuf[HTTPInfo](
 		svcName,
-		p.Cfg, p.log(), p.bpfObjects.Events,
+		&p.Cfg.EBPF, p.log(), p.bpfObjects.Events,
 		p.readHTTPInfoIntoSpan,
 		p.Metrics,
 		append(p.closers, &p.bpfObjects)...,

--- a/pkg/internal/ebpf/httpfltr/httpfltr_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/stretchr/testify/assert"
 
-	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
+	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/request"
 )
 
@@ -100,7 +100,7 @@ func TestToRequestTrace(t *testing.T) {
 	err := binary.Write(buf, binary.LittleEndian, &record)
 	assert.NoError(t, err)
 
-	tracer := Tracer{Cfg: &ebpfcommon.TracerConfig{}}
+	tracer := Tracer{Cfg: &pipe.Config{}}
 	result, _, err := tracer.readHTTPInfoIntoSpan(&ringbuf.Record{RawSample: buf.Bytes()})
 	assert.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestToRequestTraceNoConnection(t *testing.T) {
 	err := binary.Write(buf, binary.LittleEndian, &record)
 	assert.NoError(t, err)
 
-	tracer := Tracer{Cfg: &ebpfcommon.TracerConfig{}}
+	tracer := Tracer{Cfg: &pipe.Config{}}
 	result, _, err := tracer.readHTTPInfoIntoSpan(&ringbuf.Record{RawSample: buf.Bytes()})
 	assert.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestToRequestTraceNoConnection(t *testing.T) {
 }
 
 func TestExtractTraceParent(t *testing.T) {
-	tracer := Tracer{Cfg: &ebpfcommon.TracerConfig{}}
+	tracer := Tracer{Cfg: &pipe.Config{}}
 
 	// normal formulated request
 	assert.Equal(t, "ABBA", tracer.extractTraceParent([]byte(

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -19,6 +19,7 @@ import (
 	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/exec"
 	"github.com/grafana/beyla/pkg/internal/goexec"
+	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/request"
 )
 
@@ -190,7 +191,7 @@ func allGoFunctionNames(programs []Tracer) []string {
 	return functions
 }
 
-func inspect(ctx context.Context, cfg *ebpfcommon.TracerConfig, functions []string) (*exec.FileInfo, *goexec.Offsets, error) {
+func inspect(ctx context.Context, cfg *pipe.Config, functions []string) (*exec.FileInfo, *goexec.Offsets, error) {
 	// Finding the process by port is more complex, it needs to skip proxies
 	if cfg.Port != 0 {
 		return inspectByPort(ctx, cfg, functions)
@@ -224,7 +225,7 @@ func inspect(ctx context.Context, cfg *ebpfcommon.TracerConfig, functions []stri
 	return &execElf, offsets, nil
 }
 
-func inspectByPort(ctx context.Context, cfg *ebpfcommon.TracerConfig, functions []string) (*exec.FileInfo, *goexec.Offsets, error) {
+func inspectByPort(ctx context.Context, cfg *pipe.Config, functions []string) (*exec.FileInfo, *goexec.Offsets, error) {
 	finder := exec.OwnedPort(cfg.Port)
 
 	elfs, err := exec.FindExecELF(ctx, finder)

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -77,6 +77,8 @@ type Config struct {
 	// No filtering per application will be done. Using this option may result in reduced quality of information
 	// gathered for certain languages, such as Golang.
 	SystemWide bool `yaml:"system_wide" env:"SYSTEM_WIDE"`
+	// This can be enabled to use generic HTTP tracers only, no Go-specifics will be used:
+	SkipGoSpecificTracers bool `yaml:"skip_go_specific_tracers" env:"SKIP_GO_SPECIFIC_TRACERS"`
 
 	LogLevel string `yaml:"log_level" env:"LOG_LEVEL"`
 

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -66,6 +66,18 @@ type Config struct {
 	Prometheus prom.PrometheusConfig         `yaml:"prometheus_export"`
 	Printer    debug.PrintEnabled            `yaml:"print_traces" env:"PRINT_TRACES"`
 
+	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
+	Exec string `yaml:"executable_name" env:"EXECUTABLE_NAME"`
+	// Port allows selecting the instrumented executable that owns the Port value. If this value is set (and
+	// different to zero), the value of the Exec property won't take effect.
+	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter
+	// will instrument all the service calls in all the ports, not only the port specified here.
+	Port int `yaml:"open_port" env:"OPEN_PORT"`
+	// SystemWide allows instrumentation of all HTTP (no gRPC) calls, incoming and outgoing at a system wide scale.
+	// No filtering per application will be done. Using this option may result in reduced quality of information
+	// gathered for certain languages, such as Golang.
+	SystemWide bool `yaml:"system_wide" env:"SYSTEM_WIDE"`
+
 	LogLevel string `yaml:"log_level" env:"LOG_LEVEL"`
 
 	// ServiceName is taken from either SERVICE_NAME env var or OTEL_SERVICE_NAME (for OTEL spec compatibility)
@@ -89,10 +101,10 @@ func (e ConfigError) Error() string {
 }
 
 func (c *Config) validateInstrumentation() error {
-	if c.EBPF.Port == 0 && c.EBPF.Exec == "" && !c.EBPF.SystemWide {
+	if c.Port == 0 && c.Exec == "" && !c.SystemWide {
 		return ConfigError("missing EXECUTABLE_NAME, OPEN_PORT or SYSTEM_WIDE property")
 	}
-	if (c.EBPF.Port != 0 || c.EBPF.Exec != "") && c.EBPF.SystemWide {
+	if (c.Port != 0 || c.Exec != "") && c.SystemWide {
 		return ConfigError("use either SYSTEM_WIDE or any of EXECUTABLE_NAME and OPEN_PORT, not both")
 	}
 	if c.EBPF.BatchLength == 0 {

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -19,9 +19,9 @@ import (
 
 func TestConfig_Overrides(t *testing.T) {
 	userConfig := bytes.NewBufferString(`
+executable_name: tras
 channel_buffer_len: 33
 ebpf:
-  executable_name: tras
   functions:
     - FooBar
 otel_metrics_export:
@@ -49,13 +49,13 @@ kubernetes:
 	assert.NoError(t, cfg.Validate())
 
 	assert.Equal(t, &Config{
+		Exec:             "tras",
 		ServiceName:      "svc-name",
 		ChannelBufferLen: 33,
 		LogLevel:         "INFO",
 		Printer:          false,
 		Noop:             true,
 		EBPF: ebpfcommon.TracerConfig{
-			Exec:         "tras",
 			BatchLength:  100,
 			BatchTimeout: time.Second,
 			BpfBaseDir:   "/var/run/beyla",


### PR DESCRIPTION
The options to select the executable to instrument aren't concretely related to BPF but to Beyla as a product.

In addition, they will share the same level of the `services` section that we are going to add soon: https://github.com/grafana/beyla/issues/251

This change won't affect users that use the environment variables but will break the configuration of the users that define the mentioned variables as part of a YAML file.