### PR TITLE
Guess OTEL_EXPORTER_OTLP_PROTOCOL from the Endpoint

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -243,9 +243,9 @@ the OpenTelemetry exporter will automatically add the `/v1/metrics` path to the 
 addition, you can use either the `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` environment variable or the `environment` YAML
 property to use exactly the provided URL without any addition.
 
-| YAML       | Env var                                                                    | Type   | Default        |
-| ---------- | -------------------------------------------------------------------------- | ------ | -------------- |
-| `protocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` or<br/>`OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | string | `http/protobuf |
+| YAML       | Env var                                                                    | Type   | Default   |
+| ---------- | -------------------------------------------------------------------------- | ------ |-----------|
+| `protocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` or<br/>`OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | string | (guessed) |
 
 Specifies the transport/encoding protocol of the OpenTelemetry endpoint.
 
@@ -254,6 +254,13 @@ The accepted values, as defined by the [OTLP Exporter Configuration document](ht
 The `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable sets a common protocol for both the metrics and
 [traces](#otel-traces-exporter) exporters. The `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` environment variable,
 or the `protocol` YAML property, will set the protocol only for the metrics exporter node.
+
+If this property is not provided, Beyla will guess it according to the following rules:
+
+* Beyla will guess `grpc` if the port ends in `4317` (`4317`, `14317`, `24317`, ...),
+  as `4317` is the usual Port number for the OTEL GRPC collector.
+* Beyla will guess `http/protobuf` if the port ends in `4318` (`4318`, `14318`, `24318`, ...),
+  as `4318` is the usual Port number for the OTEL HTTP collector.
 
 | YAML                   | Env var                     | Type | Default |
 | ---------------------- | --------------------------- | ---- | ------- |
@@ -364,9 +371,9 @@ the OpenTelemetry exporter will automatically add the `/v1/traces` path to the U
 addition, you can use either the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variable or the `environment` YAML
 property to use exactly the provided URL without any addition.
 
-| YAML       | Env var                                                                   | Type   | Default        |
-| ---------- | ------------------------------------------------------------------------- | ------ | -------------- |
-| `protocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` or<br/>`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | string | `http/protobuf |
+| YAML       | Env var                                                                   | Type   | Default   |
+| ---------- | ------------------------------------------------------------------------- | ------ |-----------|
+| `protocol` | `OTEL_EXPORTER_OTLP_PROTOCOL` or<br/>`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | string | (guessed) |
 
 Specifies the transport/encoding protocol of the OpenTelemetry traces endpoint.
 
@@ -375,6 +382,13 @@ The accepted values, as defined by the [OTLP Exporter Configuration document](ht
 The `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable sets a common protocol for both the metrics and
 the [traces](#otel-traces-exporter) exporters. The `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` environment variable,
 or the `protocol` YAML property, will set the protocol only for the traces' exporter node.
+
+If this property is not provided, Beyla will guess it according to the following rules:
+
+* Beyla will guess `grpc` if the port ends in `4317` (`4317`, `14317`, `24317`, ...),
+  as `4317` is the usual Port number for the OTEL GRPC collector.
+* Beyla will guess `http/protobuf` if the port ends in `4318` (`4318`, `14318`, `24318`, ...),
+  as `4318` is the usual Port number for the OTEL HTTP collector.
 
 | YAML                   | Env var                     | Type | Default |
 | ---------------------- | --------------------------- | ---- | ------- |

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -21,6 +21,7 @@ import (
 type Protocol string
 
 const (
+	ProtocolUnset        Protocol = ""
 	ProtocolGRPC         Protocol = "grpc"
 	ProtocolHTTPProtobuf Protocol = "http/protobuf"
 	ProtocolHTTPJSON     Protocol = "http/json"

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -25,13 +25,15 @@ var defaultConfig = Config{
 		BpfBaseDir:   "/var/run/beyla",
 	},
 	Metrics: otel.MetricsConfig{
-		Protocol:          otel.ProtocolHTTPProtobuf,
+		Protocol:          otel.ProtocolUnset,
+		MetricsProtocol:   otel.ProtocolUnset,
 		Interval:          5 * time.Second,
 		Buckets:           otel.DefaultBuckets,
 		ReportersCacheLen: 16,
 	},
 	Traces: otel.TracesConfig{
-		Protocol:           otel.ProtocolHTTPProtobuf,
+		Protocol:           otel.ProtocolUnset,
+		TracesProtocol:     otel.ProtocolUnset,
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
 		SamplingRatio:      1.0,

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -64,7 +64,7 @@ kubernetes:
 			Interval:          5 * time.Second,
 			CommonEndpoint:    "localhost:3131",
 			MetricsEndpoint:   "localhost:3030",
-			Protocol:          otel.ProtocolHTTPProtobuf,
+			Protocol:          otel.ProtocolUnset,
 			ReportersCacheLen: 16,
 			Buckets: otel.Buckets{
 				DurationHistogram:    []float64{0, 1, 2},
@@ -72,7 +72,7 @@ kubernetes:
 			},
 		},
 		Traces: otel.TracesConfig{
-			Protocol:           otel.ProtocolHTTPProtobuf,
+			Protocol:           otel.ProtocolUnset,
 			CommonEndpoint:     "localhost:3131",
 			TracesEndpoint:     "localhost:3232",
 			MaxQueueSize:       4096,


### PR DESCRIPTION
I have observed that users are struggling with the `OTEL_EXPORTER_OTLP_PROTOCOL` and rest of related variables. They usually forget it to set it and, if they use the wrong endpoint, then the OTEL SDK returns a protocol error which is not very clear nor indicative of what they did wrong.

In order to reduce trivial customer support requests, I have implemented a mechanism that will automatically select the protocol (if not set by the user) according to a simple rule:

* Beyla will guess `grpc` if the port ends in `4317` (`4317`, `14317`, `24317`, ...),
  as `4317` is the usual Port number for the OTEL GRPC collector.
* Beyla will guess `http/protobuf` if the port ends in `4318` (`4318`, `14318`, `24318`, ...),
  as `4318` is the usual Port number for the OTEL HTTP collector.