### PR TITLE
Docs: Fix typos of Beyla

### DIFF
--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -17,6 +17,6 @@ Beyla can be configured in the following ways:
 1. By setting [configuration options]({{< relref "./options" >}}) in a number of ways.
 2. By changing [export modes]({{< relref "./export-modes.md" >}}) between direct or agent mode.
 
-For information on the metrics Belya exports, see the [exported metrics]({{< relref "../metrics.md" >}}) documentation.
+For information on the metrics Beyla exports, see the [exported metrics]({{< relref "../metrics.md" >}}) documentation.
 
 For information on profiling Beyla, see the [profiling]({{< relref "../profiling.md" >}}) documentation.

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -24,7 +24,7 @@ Beyla can export data in two modes:
 
 ![](https://grafana.com/media/docs/grafana-cloud/beyla/agent-vs-direct.png)
 
-<center><i>Beyal running in Agent mode (left) vs. Direct mode (right)</i></center>
+<center><i>Beyla running in Agent mode (left) vs. Direct mode (right)</i></center>
 
 ## Running in Direct mode
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -22,7 +22,7 @@ $ OPEN_PORT=8080 beyla -config /path/to/config.yaml
 
 At the end of this document, there is an [example of YAML configuration file](#yaml-file-example).
 
-Currently, Beyal consist of a pipeline of components which
+Currently, Beyla consist of a pipeline of components which
 generate, transform, and export traces from HTTP and GRPC services. In the
 YAML configuration, each component has its own first-level section.
 

--- a/docs/sources/tutorial/index.md
+++ b/docs/sources/tutorial/index.md
@@ -16,7 +16,7 @@ keywords:
 
 # Beyla quick start tutorial
 
-To reduce the time it takes to instrument an application and improve the adoption of Application Observability, Grafana built Belya, an eBPF auto-instrumentation tool, that is able to report basic transactions span information, as well as [RED metrics](/blog/2018/08/02/the-red-method-how-to-instrument-your-services/) for Linux HTTP/S and gRPC services, without any application code or configuration changes.
+To reduce the time it takes to instrument an application and improve the adoption of Application Observability, Grafana built Beyla, an eBPF auto-instrumentation tool, that is able to report basic transactions span information, as well as [RED metrics](/blog/2018/08/02/the-red-method-how-to-instrument-your-services/) for Linux HTTP/S and gRPC services, without any application code or configuration changes.
 
 ## eBPF overview
 


### PR DESCRIPTION
While searching the docs on the web (our main form of viewing the docs, which maybe we should link to in docs/README.md?) I found a few instances of Beyla being misspelled.
I'm not sure if there are any non-automated procedures for docs changes.