### PR TITLE
Trace span status

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -166,8 +166,8 @@ add a noticeable delay in the time the metrics are submitted and become external
 YAML section `routes`.
 
 This section can be only configured via the YAML file. If no `routes` section is provided in
-the YAML file, the routes' pipeline stage will not be created and data will not be filtered
-for the exporters.
+the YAML file, a default routes' pipeline stage will be created and filtered with the `wildcard`
+routes decorator.
 
 | YAML       | Env var | Type            | Default |
 | ---------- | ------- | --------------- | ------- |
@@ -215,7 +215,7 @@ Possible values for the `unmatch` property are:
 - `unset` will leave the `http.route` property as unset.
 - `path` will copy the `http.route` field property to the path value.
   - 🚨 Caution: this option could lead to cardinality explosion at the ingester side.
-- `wildcard` will set the `http.route` field property to a generic asterisk `*` value.
+- `wildcard` will set the `http.route` field property to a generic asterisk based `/**` value.
 
 ## OTEL metrics exporter
 

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -261,7 +261,7 @@ func grpcSpanStatusCode(span *request.Span) codes.Code {
 		semconv.RPCGRPCStatusCodeDeadlineExceeded.Value.AsInt64(),
 		semconv.RPCGRPCStatusCodeUnimplemented.Value.AsInt64(),
 		semconv.RPCGRPCStatusCodeInternal.Value.AsInt64(),
-		semconv.RPCGRPCStatusCodeUnimplemented.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeUnavailable.Value.AsInt64(),
 		semconv.RPCGRPCStatusCodeDataLoss.Value.AsInt64():
 		return codes.Error
 	}

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -13,6 +13,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mariomac/pipes/pkg/node"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -230,6 +231,54 @@ func (r *TracesReporter) close() {
 	}
 }
 
+// https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#status
+func httpSpanStatusCode(span *request.Span) codes.Code {
+	if span.Status < 400 {
+		return codes.Unset
+	}
+
+	if span.Status < 500 {
+		if span.Type == request.EventTypeHTTPClient {
+			return codes.Error
+		}
+		return codes.Unset
+	}
+
+	return codes.Error
+}
+
+// https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/rpc/#grpc-status
+func grpcSpanStatusCode(span *request.Span) codes.Code {
+	if span.Type == request.EventTypeGRPCClient {
+		if span.Status == int(semconv.RPCGRPCStatusCodeOk.Value.AsInt64()) {
+			return codes.Unset
+		}
+		return codes.Error
+	}
+
+	switch int64(span.Status) {
+	case semconv.RPCGRPCStatusCodeUnknown.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeDeadlineExceeded.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeUnimplemented.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeInternal.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeUnimplemented.Value.AsInt64(),
+		semconv.RPCGRPCStatusCodeDataLoss.Value.AsInt64():
+		return codes.Error
+	}
+
+	return codes.Unset
+}
+
+func spanStatusCode(span *request.Span) codes.Code {
+	switch span.Type {
+	case request.EventTypeHTTP, request.EventTypeHTTPClient:
+		return httpSpanStatusCode(span)
+	case request.EventTypeGRPC, request.EventTypeGRPCClient:
+		return grpcSpanStatusCode(span)
+	}
+	return codes.Unset
+}
+
 func (r *TracesReporter) traceAttributes(span *request.Span) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
@@ -366,6 +415,8 @@ func (r *TracesReporter) makeSpan(parentCtx context.Context, tracer trace2.Trace
 		trace2.WithSpanKind(spanKind(span)),
 		trace2.WithAttributes(r.traceAttributes(span)...),
 	)
+
+	sp.SetStatus(spanStatusCode(span), "")
 
 	if span.RequestStart != span.Start {
 		var spP trace2.Span

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -55,6 +55,7 @@ var defaultConfig = Config{
 		Enable:               transform.EnabledDefault,
 		InformersSyncTimeout: 30 * time.Second,
 	},
+	Routes: &transform.RoutesConfig{},
 }
 
 type Config struct {

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -96,6 +96,7 @@ kubernetes:
 			Enable:               transform.EnabledTrue,
 			InformersSyncTimeout: 30 * time.Second,
 		},
+		Routes: &transform.RoutesConfig{},
 	}, cfg)
 }
 

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -182,10 +182,10 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.ServiceNameKey):    "svc-1",
 			string(semconv.HTTPMethodKey):     "GET",
 			string(semconv.HTTPStatusCodeKey): "200",
-			string(semconv.HTTPRouteKey):      "*",
+			string(semconv.HTTPRouteKey):      "/**",
 		},
 		Type: pmetric.MetricTypeHistogram,
-	}, events["*"])
+	}, events["/**"])
 }
 
 func TestGRPCPipeline(t *testing.T) {

--- a/pkg/internal/transform/routes.go
+++ b/pkg/internal/transform/routes.go
@@ -24,7 +24,7 @@ const (
 	UnmatchDefault = UnmatchWildcard
 )
 
-const wildCard = "*"
+const wildCard = "/**"
 
 // RoutesConfig allows grouping URLs sharing a given pattern.
 type RoutesConfig struct {

--- a/pkg/internal/transform/routes_test.go
+++ b/pkg/internal/transform/routes_test.go
@@ -29,7 +29,7 @@ func TestUnmatchedWildcard(t *testing.T) {
 			in <- []request.Span{{Path: "/some/path"}}
 			assert.Equal(t, []request.Span{{
 				Path:  "/some/path",
-				Route: "*",
+				Route: "/**",
 			}}, testutil.ReadChannel(t, out, testTimeout))
 		})
 	}

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -19,14 +19,14 @@ import (
 )
 
 func testHTTPTracesNoTraceID(t *testing.T) {
-	testHTTPTracesCommon(t, false, 200, 0)
+	testHTTPTracesCommon(t, false, 200)
 }
 
 func testHTTPTraces(t *testing.T) {
-	testHTTPTracesCommon(t, true, 500, 1)
+	testHTTPTracesCommon(t, true, 500)
 }
 
-func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode, statusCode int) {
+func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	var traceID string
 	var parentID string
 


### PR DESCRIPTION
This PR improves the usability of traces. We should be setting the span.status for traces so that metrics generation in Tempo can correctly work. 

Also, while testing what is generated with unmatched routes with the Java OTel instrumentation I noticed that they put `/**` for unmatched paths, which a lot more visible than our `*`, so I switched the asterisk labelling to `/**`. I also added a default routes config, so we put this `/**` by default, telling customers that we did something with the path. If this is unset, because the default routes config is `nil`, the customers may think we didn't produce the trace events correctly.

TODO:
- [x] Tests
- [x] Docs