### PR TITLE
Decreasing Python test image size

### DIFF
--- a/test/integration/components/pythonserver/Dockerfile
+++ b/test/integration/components/pythonserver/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile that will build a container that runs python flask with gunicorn on port 8080
-FROM python:3.11.4
+FROM python:3.11.6-slim
 EXPOSE 8080
 RUN pip install flask gunicorn
 # Alternative: RUN pip install flask uwsgi

--- a/test/integration/components/pythonserver/Dockerfile_tls
+++ b/test/integration/components/pythonserver/Dockerfile_tls
@@ -1,5 +1,5 @@
 # Dockerfile that will build a container that runs python flask with gunicorn on port 8080
-FROM python:3.11.4
+FROM python:3.11.6-slim
 EXPOSE 8080
 RUN pip install flask gunicorn
 


### PR DESCRIPTION
Decreased the Python integration test image from 1GB to 163MB.

This should temporarily alleviate the "out of disk space" error we are watching in some merge tests, but at some point we should handle it in a more solid/consistent way: https://github.com/grafana/beyla/issues/326