### PR TITLE
Integration test: Prune default github docker images before test.  Print free space, docker system df, and docker images

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
+      - name: Clean up disk space
+        run: |
+          docker system prune -af
+          docker volume prune -f
       - name: Run integration tests
         run: make integration-test
         timeout-minutes: 60

--- a/test/integration/close_test.go
+++ b/test/integration/close_test.go
@@ -49,3 +49,14 @@ func PrintDockerStorage(t *testing.T) {
 		t.Logf("Docker system df output:\n%s", string(out))
 	}
 }
+
+func DockerSystemPrune(t *testing.T) {
+	PrintStorage(t)
+	PrintDockerStorage(t)
+	out, err := exec.Command("docker", "system", "prune", "-f").CombinedOutput()
+	if err == nil {
+		t.Logf("Docker system prune -f\n%s", string(out))
+	}
+	PrintStorage(t)
+	PrintDockerStorage(t)
+}

--- a/test/integration/close_test.go
+++ b/test/integration/close_test.go
@@ -29,8 +29,8 @@ func testBPFPinningUnmounted(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, entries)
 
-	// Convenient hook for monitoring/managing image storage space:
-	DeleteDockerImage(t, "hatest-*autoinstrumenter")
+	// Convenient hook for monitoring image storage space:
+	PrintDockerStorage(t)
 }
 
 func PrintFreeStorage(t *testing.T) {
@@ -52,15 +52,5 @@ func PrintDockerStorage(t *testing.T) {
 	require.NoError(t, err)
 	if err == nil {
 		t.Logf("Docker images:\n%s", string(out))
-	}
-}
-
-func DeleteDockerImage(t *testing.T, imageName string) {
-	PrintDockerStorage(t)
-	cmd := exec.Command("/bin/bash", "-c", "docker rmi -f $(docker images -q \""+imageName+"\")")
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	if err == nil {
-		t.Logf("Docker remove images:\n %s", string(out))
 	}
 }

--- a/test/integration/close_test.go
+++ b/test/integration/close_test.go
@@ -2,9 +2,11 @@ package integration
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // prerequisite: the testoutput/run folder was empty before starting the tests
@@ -26,4 +28,24 @@ func testBPFPinningUnmounted(t *testing.T) {
 	entries, err := os.ReadDir(pathVarRun)
 	require.NoError(t, err)
 	require.Empty(t, entries)
+
+	// Convenient hook for monitoring storage space:
+	PrintStorage(t)
+	PrintDockerStorage(t)
+}
+
+func PrintStorage(t *testing.T) {
+	// Convenient hook for monitoring storage space:
+	var stat unix.Statfs_t
+	wd, err := os.Getwd()
+	if err == nil && unix.Statfs(wd, &stat) == nil {
+		t.Logf("Free storage space (in %s) is: %dMB\n", wd, stat.Bavail*uint64(stat.Bsize)/(1024*1024))
+	}
+}
+
+func PrintDockerStorage(t *testing.T) {
+	out, err := exec.Command("docker", "system", "df").CombinedOutput()
+	if err == nil {
+		t.Logf("Docker system df output:\n%s", string(out))
+	}
 }

--- a/test/integration/close_test.go
+++ b/test/integration/close_test.go
@@ -48,6 +48,10 @@ func PrintDockerStorage(t *testing.T) {
 	if err == nil {
 		t.Logf("Docker system df output:\n%s", string(out))
 	}
+	out, err = exec.Command("docker", "images").CombinedOutput()
+	if err == nil {
+		t.Logf("Docker images:\n%s", string(out))
+	}
 }
 
 func DockerSystemPrune(t *testing.T) {

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -232,9 +232,6 @@ func TestSuite_NodeJSTLS(t *testing.T) {
 }
 
 func TestSuite_Rails(t *testing.T) {
-	// The rails setup uses a lot of storage, try to recover some first.
-	DockerSystemPrune(t)
-
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby.log"))
 	compose.Env = append(compose.Env, `OPEN_PORT=3040`, `EXECUTABLE_NAME=`, `TEST_SERVICE_PORTS=3041:3040`)
 	require.NoError(t, err)
@@ -246,9 +243,6 @@ func TestSuite_Rails(t *testing.T) {
 }
 
 func TestSuite_RailsTLS(t *testing.T) {
-	// The rails setup uses a lot of storage, try to recover some first.
-	DockerSystemPrune(t)
-
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby-tls.log"))
 	compose.Env = append(compose.Env, `OPEN_PORT=3043`, `EXECUTABLE_NAME=`, `TESTSERVER_IMAGE_SUFFIX=-tls`, `TEST_SERVICE_PORTS=3044:3043`)
 	require.NoError(t, err)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -232,6 +232,9 @@ func TestSuite_NodeJSTLS(t *testing.T) {
 }
 
 func TestSuite_Rails(t *testing.T) {
+	// The rails setup uses a lot of storage, try to recover some first.
+	DockerSystemPrune(t)
+
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby.log"))
 	compose.Env = append(compose.Env, `OPEN_PORT=3040`, `EXECUTABLE_NAME=`, `TEST_SERVICE_PORTS=3041:3040`)
 	require.NoError(t, err)
@@ -243,6 +246,9 @@ func TestSuite_Rails(t *testing.T) {
 }
 
 func TestSuite_RailsTLS(t *testing.T) {
+	// The rails setup uses a lot of storage, try to recover some first.
+	DockerSystemPrune(t)
+
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby-tls.log"))
 	compose.Env = append(compose.Env, `OPEN_PORT=3043`, `EXECUTABLE_NAME=`, `TESTSERVER_IMAGE_SUFFIX=-tls`, `TEST_SERVICE_PORTS=3044:3043`)
 	require.NoError(t, err)


### PR DESCRIPTION
To avoid running out of github runner disk storage, the default docker images will be removed before the start of the test, gaining about 5.5GB of space.

The integration test does a set of tests that each bring docker compose up, run tests, then docker compose down.  Hooking in to the close of test, we will print the free storage space in the working folder.  Additionally, print output from "docker system df".
For the short term, we will also print output from "docker images" to get a better handle on how storage is being used.
