### PR TITLE
fix integration tests

### DIFF
--- a/test/integration/components/jaeger/jaeger_test.go
+++ b/test/integration/components/jaeger/jaeger_test.go
@@ -89,3 +89,42 @@ func Fixture() *TracesQuery {
 	}
 	return &t
 }
+
+func TestDiff(t *testing.T) {
+	expected := []Tag{
+		{Key: "foo", Type: "string", Value: 123},
+		{Key: "match", Type: "int", Value: 321},
+		{Key: "baz", Type: "float", Value: 111},
+		{Key: "nf", Type: "float", Value: 321},
+	}
+	actual := []Tag{
+		{Key: "baz", Type: "float", Value: 111},
+		{Key: "match", Type: "string", Value: 321},
+		{Key: "foo", Type: "string", Value: 321},
+	}
+	dr := Diff(expected, actual)
+	t.Log(dr.String())
+	assert.Equal(t, dr, DiffResult{
+		{ErrType: ErrTypeNotEqual, Expected: expected[0], Actual: actual[2]},
+		{ErrType: ErrTypeNotEqual, Expected: expected[1], Actual: actual[1]},
+		{ErrType: ErrTypeMissing, Expected: expected[3]},
+	})
+}
+
+func TestDiff_Matching(t *testing.T) {
+	expected := []Tag{
+		{Key: "foo", Type: "string", Value: 123},
+		{Key: "match", Type: "int", Value: 321},
+		{Key: "baz", Type: "float", Value: 111},
+		{Key: "nf", Type: "float", Value: 321},
+	}
+	actual := []Tag{
+		expected[1], expected[3], expected[0], expected[2],
+		// any tag in the actual set is ignored if not specified in the "expected" set
+		{Key: "triliri", Type: "float", Value: 111},
+		{Key: "tralara", Type: "string", Value: 321},
+	}
+	dr := Diff(expected, actual)
+	t.Log(dr.String())
+	assert.Emptyf(t, dr, "expected empty but got: %s", dr.String())
+}

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -67,14 +67,15 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 	require.Len(t, spans, 1)
 	span := spans[0]
 
-	assert.Truef(t, span.AllMatches(
+	sd := span.Diff(
 		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(statusCode)},
 		jaeger.Tag{Key: "http.url", Type: "string", Value: "/"},
 		jaeger.Tag{Key: "net.peer.port", Type: "int64", Value: float64(port)},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
-	), "not all tags matched in %+v", span.Tags)
+	)
+	assert.Empty(t, sd, sd.String())
 
 	/*
 	 The code in client.js generates spans like these:

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -68,7 +68,6 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 	span := spans[0]
 
 	sd := span.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(statusCode)},
 		jaeger.Tag{Key: "http.url", Type: "string", Value: "/"},

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -85,7 +85,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 	// check duration is at least 2us
 	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 	// check span attributes
-	assert.Truef(t, parent.AllMatches(
+	sd := parent.Diff(
 		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(200)},
@@ -93,14 +93,16 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 		jaeger.Tag{Key: "net.host.port", Type: "int64", Value: float64(port)},
 		jaeger.Tag{Key: "http.route", Type: "string", Value: "/trace"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
-	), "not all tags matched in %+v", parent.Tags)
+	)
+	assert.Empty(t, sd, sd.String())
 
 	process := trace.Processes[parent.ProcessID]
 	assert.Equal(t, comm, process.ServiceName)
-	assert.Truef(t, jaeger.AllMatches(process.Tags, []jaeger.Tag{
+	sd = jaeger.Diff([]jaeger.Tag{
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
-	}), "not all tags matched in %+v", process.Tags)
+	}, process.Tags)
+	assert.Empty(t, sd, sd.String())
 
 }
 

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -86,7 +86,6 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 	// check span attributes
 	sd := parent.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(200)},
 		jaeger.Tag{Key: "http.target", Type: "string", Value: "/trace"},
@@ -99,6 +98,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 	process := trace.Processes[parent.ProcessID]
 	assert.Equal(t, comm, process.ServiceName)
 	sd = jaeger.Diff([]jaeger.Tag{
+		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
-	require.NoError(t, err)
-	require.NoError(t, compose.Up())
+	//compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
+	//require.NoError(t, err)
+	//require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
 	t.Run("HTTP traces (no traceID)", testHTTPTracesNoTraceID)
@@ -24,7 +24,7 @@ func TestSuite(t *testing.T) {
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
 
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
-	require.NoError(t, compose.Close())
+	//require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
 

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	//compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
-	//require.NoError(t, err)
-	//require.NoError(t, compose.Up())
+	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
 	t.Run("HTTP traces (no traceID)", testHTTPTracesNoTraceID)
@@ -24,7 +24,7 @@ func TestSuite(t *testing.T) {
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
 
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
-	//require.NoError(t, compose.Close())
+	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
 

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -73,7 +73,6 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	assert.Less(t, (10 * time.Millisecond).Microseconds(), parent.Duration)
 	// check span attributes
 	sd := parent.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(httpCode)},
 		jaeger.Tag{Key: "http.target", Type: "string", Value: "/" + slug},
@@ -107,7 +106,6 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	// check span attributes
 	// check span attributes
 	sd = queue.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -127,7 +125,6 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		processing.StartTime+processing.Duration,
 		parent.StartTime+parent.Duration+1)
 	sd = queue.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -139,6 +136,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	process := trace.Processes[parent.ProcessID]
 	assert.Equal(t, "testserver", process.ServiceName)
 	jaeger.Diff([]jaeger.Tag{
+		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)
@@ -241,7 +239,6 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 	assert.Less(t, (10 * time.Millisecond).Microseconds(), parent.Duration)
 	// check span attributes
 	sd := parent.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "net.host.port", Type: "int64", Value: float64(50051)},
 		jaeger.Tag{Key: "rpc.grpc.status_code", Type: "int64", Value: float64(2)},
 		jaeger.Tag{Key: "rpc.method", Type: "string", Value: "/routeguide.RouteGuide/Debug"},
@@ -267,7 +264,6 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 		parent.StartTime+parent.Duration+1) // adding 1 to tolerate inaccuracies from rounding from ns to ms
 	// check span attributes
 	sd = queue.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -287,7 +283,6 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 	assert.LessOrEqual(t, processing.StartTime+processing.Duration, parent.StartTime+parent.Duration+1)
 	// check span attributes
 	sd = queue.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -299,6 +294,7 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 	process := trace.Processes[parent.ProcessID]
 	assert.Equal(t, svcName, process.ServiceName)
 	jaeger.Diff([]jaeger.Tag{
+		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)
@@ -385,7 +381,6 @@ func testHTTPTracesKProbes(t *testing.T) {
 	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 	// check span attributes
 	sd := parent.Diff(
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		jaeger.Tag{Key: "http.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.status_code", Type: "int64", Value: float64(200)},
 		jaeger.Tag{Key: "http.target", Type: "string", Value: "/bye"},
@@ -398,6 +393,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 	process := trace.Processes[parent.ProcessID]
 	assert.Equal(t, "node", process.ServiceName)
 	jaeger.Diff([]jaeger.Tag{
+		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)


### PR DESCRIPTION
* Added a jaeger tags diff'er that gives more insights about the missing/changed tags, rather than a simple boolean.
* It seems that latest jaeger OTEL converter now puts the `otel.library.name` attribute into the process tags, instead of the trace generic tags.