### PR TITLE
Print version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ MAIN_GO_FILE ?= cmd/$(CMD)/main.go
 GOOS ?= linux
 GOARCH ?= amd64
 
+RELEASE_VERSION := $(shell git describe --tags --always)
+
 TEST_OUTPUT ?= ./testoutput
 
 IMG_REGISTRY ?= docker.io
@@ -148,7 +150,7 @@ all: generate build
 .PHONY: compile
 compile:
 	@echo "### Compiling project"
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags -a -o bin/$(CMD) $(MAIN_GO_FILE)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags="-X 'main.Version=$(RELEASE_VERSION)'" -a -o bin/$(CMD) $(MAIN_GO_FILE)
 
 # Generated binary can provide coverage stats according to https://go.dev/blog/integration-test-coverage
 .PHONY: compile-for-coverage

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	otelsdk "go.opentelemetry.io/otel/sdk"
+
 	"github.com/grafana/beyla/pkg/beyla"
 )
 
@@ -25,7 +27,7 @@ func main() {
 		Level: &lvl,
 	})))
 
-	slog.Info("Grafana Beyla", "Version", Version)
+	slog.Info("Grafana Beyla", "Version", Version, "OpenTelemetry SDK Version", otelsdk.Version())
 
 	configPath := flag.String("config", "", "path to the configuration file")
 	flag.Parse()

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -16,12 +16,16 @@ import (
 	"github.com/grafana/beyla/pkg/beyla"
 )
 
+var Version = "main"
+
 func main() {
 	lvl := slog.LevelVar{}
 	lvl.Set(slog.LevelInfo)
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: &lvl,
 	})))
+
+	slog.Info("Grafana Beyla", "Version", Version)
 
 	configPath := flag.String("config", "", "path to the configuration file")
 	flag.Parse()


### PR DESCRIPTION
This PR adds support for printing the build version and the OpenTelemetry SDK version on Beyla startup.

I'm not sure there's a better way to do this, I looked into debug/BuildInfo, but it's not as nice as git describe --tags and it has this restriction https://github.com/golang/go/issues/51264.

The one unfortunate sideffect is that it adds 10 seconds build time for me, the link time change of the value seems slow. Maybe we need better default make for development? 

Closes #343 