### PR TITLE
Updated vendored Pipes library to 0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/go-offsets-tracker v0.1.2
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
-	github.com/mariomac/pipes v0.8.0
+	github.com/mariomac/pipes v0.9.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524 h1:24nnoPrOI7cw2YZTWqDHqIchSJ07thcQDIUNnL6V+2o=
 github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524/go.mod h1:TMuTALUh4SPCDJdYOuOYIEwBgH2rzCDP1nNgj+lI8AE=
-github.com/mariomac/pipes v0.8.0 h1:xx/DLxqHAwyhjWkw+uqH/0EVJZkDxCHlNuwui/4lqcg=
-github.com/mariomac/pipes v0.8.0/go.mod h1:c4UsamVvniQ7+YX+X2mxDTTfyXOEU35pMFKZ8JD4ShE=
+github.com/mariomac/pipes v0.9.0 h1:spCbBgHQpCbFoI8yNZDiwsUFuKaeUSbWe1oqt0mnY8U=
+github.com/mariomac/pipes v0.9.0/go.mod h1:c4UsamVvniQ7+YX+X2mxDTTfyXOEU35pMFKZ8JD4ShE=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/vendor/github.com/mariomac/pipes/pkg/graph/builder.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/builder.go
@@ -21,39 +21,90 @@ type codecKey struct {
 	Out reflect.Type
 }
 
+// outTyper is any node with an output channel: node.Start, node.Middle
 type outTyper interface {
 	OutType() reflect.Type
 }
 
+// inTyper is any node with an input channel: node.Middle, node.Terminal, node.MiddleDemux, node.TerminalDemux
 type inTyper interface {
 	InType() reflect.Type
 }
 
+// inOutTyper is any node with an input and an output channel: node.Middle
 type inOutTyper interface {
 	inTyper
 	outTyper
+}
+
+// inDemuxedOutTyper type is any node with an input channel and an output Demux: node.MiddleDemux
+type inDemuxedOutTyper interface {
+	inTyper
+	node.Demuxed
+}
+
+// destinableInNode stores information about any node that can be connected as output of another node.
+// It keeps information about the input node and a reflected reference to DemuxAdd[T]
+type destinableInNode struct {
+	node          inTyper
+	inputDemuxAdd reflect.Value
+}
+
+// destinableInOutNode stores information about any node that can be connected as output of another node,
+// and also has an output to another node.
+// it keeps information about the in/out node and a reflected reference to DemuxAdd[T]
+type destinableInOutNode struct {
+	node          inOutTyper
+	inputDemuxAdd reflect.Value
+}
+
+type reflectedDemuxedNode struct {
+	node          inTyper
+	inputDemuxAdd reflect.Value
+	demuxed       node.Demuxed // nillable
+}
+
+type reflectedNode struct {
+	demuxed bool
+	// reflect value of AsStart, AsMiddle, etc...
+	instancer reflect.Value
+	// reflect value of StartFunc, MiddleFunc, etc...
+	provider reflect.Value
+	// reflection of the DemuxAdd[O](demux, node) function
+	// This is set in the destination node instead of the source node
+	// as we have the output type information only
+	inputDemuxAdd reflect.Value
 }
 
 // Builder helps to build a graph and to connect their nodes. It takes care of instantiating all
 // its stages given a name and a type, as well as connect them. If two connected stages have
 // incompatible types, it will insert a codec in between to translate between the stage types
 type Builder struct {
-	startProviders    map[reflect.Type][2]reflect.Value //0: reflect.ValueOf(node.AsStart[I, O]), 1: reflect.ValueOf(startfunc)
-	middleProviders   map[reflect.Type][2]reflect.Value
-	terminalProviders map[reflect.Type][2]reflect.Value
+	// providers here are function that return StartFunc, MiddleFunc, TermFunc...
+	// they are invoked first, then its returned values will be stored in startNodes, middleNodes, etc... attributes
+	startProviders    map[reflect.Type]reflectedNode
+	middleProviders   map[reflect.Type]reflectedNode
+	terminalProviders map[reflect.Type]reflectedNode
+	// a provider just for codecs
+	codecs map[codecKey]reflectedNode
+	// non-demuxed nodes
 	// keys: instance IDs
-	ingests    map[string]outTyper
-	transforms map[string]inOutTyper
-	exports    map[string]inTyper
-	codecs     map[codecKey][2]reflect.Value // 0: reflect.ValueOf(node.AsMiddle[I,O]), 1: reflect.ValueOf(middleFunc[I, O])
-	options    []reflect.Value
+	startNodes  map[string]outTyper
+	middleNodes map[string]destinableInOutNode
+	termNodes   map[string]destinableInNode
+	// demuxed nodes that do not directly implement outTyper but node.Demuxed
+	startDemuxedNodes  map[string]node.Demuxed
+	middleDemuxedNodes map[string]reflectedDemuxedNode
+
+	options []reflect.Value
 	// used to check unconnected nodes
 	inNodeNames  map[string]struct{}
 	outNodeNames map[string]struct{}
 	// used to avoid failing a "sendTo" annotation pointing to a disabled node
 	disabledNodes map[string]struct{}
 	// used to forward data from disabled Nodes
-	forwarderNodes map[string][]string
+	// key: forwarder node IDs, value: destinations of that forwarder
+	forwarderNodes map[string][]dstConnector
 }
 
 // NewBuilder instantiates a Graph Builder with the default configuration, which can be overridden via the
@@ -64,22 +115,24 @@ func NewBuilder(options ...node.Option) *Builder {
 		optVals = append(optVals, reflect.ValueOf(opt))
 	}
 	return &Builder{
-		codecs:            map[codecKey][2]reflect.Value{},
-		startProviders:    map[reflect.Type][2]reflect.Value{}, // stage.StartProvider
-		middleProviders:   map[reflect.Type][2]reflect.Value{}, // stage.MiddleProvider{},
-		terminalProviders: map[reflect.Type][2]reflect.Value{}, // stage.TerminalProvider{},
-		ingests:           map[string]outTyper{},               // *node.StartCtx
-		transforms:        map[string]inOutTyper{},             // *node.Middle
-		exports:           map[string]inTyper{},                // *node.Terminal
-		options:           optVals,
-		inNodeNames:       map[string]struct{}{},
-		outNodeNames:      map[string]struct{}{},
-		disabledNodes:     map[string]struct{}{},
-		forwarderNodes:    map[string][]string{},
+		codecs:             map[codecKey]reflectedNode{},
+		startProviders:     map[reflect.Type]reflectedNode{}, // stage.StartProvider
+		middleProviders:    map[reflect.Type]reflectedNode{}, // stage.MiddleProvider{},
+		terminalProviders:  map[reflect.Type]reflectedNode{}, // stage.TerminalProvider{},
+		startNodes:         map[string]outTyper{},            // *node.Start
+		middleNodes:        map[string]destinableInOutNode{}, // *node.Middle
+		termNodes:          map[string]destinableInNode{},    // *node.Terminal
+		startDemuxedNodes:  map[string]node.Demuxed{},
+		middleDemuxedNodes: map[string]reflectedDemuxedNode{},
+		options:            optVals,
+		inNodeNames:        map[string]struct{}{},
+		outNodeNames:       map[string]struct{}{},
+		disabledNodes:      map[string]struct{}{},
+		forwarderNodes:     map[string][]dstConnector{},
 	}
 }
 
-// RegisterCodec registers a Codec into the graph builder. A Codec is a node.MiddleFunc function
+// RegisterCodec registers a Codec into the graph builder. A Codec is a node.MiddleFunc provider
 // that allows converting data types and it's automatically inserted when a node with a given
 // output type is connected to a node with a different input type. When nodes with different
 // types are connected, a codec converting between both MUST have been registered previously.
@@ -88,54 +141,60 @@ func RegisterCodec[I, O any](nb *Builder, middleFunc node.MiddleFunc[I, O]) {
 	var in I
 	var out O
 	// temporary middle node used only to check input/output types
-	nb.codecs[codecKey{In: reflect.TypeOf(in), Out: reflect.TypeOf(out)}] = [2]reflect.Value{
-		reflect.ValueOf(node.AsMiddle[I, O]),
-		reflect.ValueOf(middleFunc),
+	nb.codecs[codecKey{In: reflect.TypeOf(in), Out: reflect.TypeOf(out)}] = reflectedNode{
+		instancer: reflect.ValueOf(node.AsMiddle[I, O]),
+		provider:  reflect.ValueOf(middleFunc),
 	}
 }
 
 // RegisterStart registers a stage.StartProvider into the graph builder. When the Build
 // method is invoked later, any configuration field associated with the StartProvider will
-// result in the instantiation of a node.StartCtx with the provider's returned function.
+// result in the instantiation of a node.Start with the provider's returned provider.
 // The passed configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
 func RegisterStart[CFG, O any](nb *Builder, b stage.StartProvider[CFG, O]) {
-	nb.startProviders[typeOf[CFG]()] = [2]reflect.Value{
-		reflect.ValueOf(node.AsStart[O]),
-		reflect.ValueOf(b),
+	nb.startProviders[typeOf[CFG]()] = reflectedNode{
+		instancer: reflect.ValueOf(node.AsStart[O]),
+		provider:  reflect.ValueOf(b),
 	}
 }
 
 // RegisterMultiStart is similar to RegisterStart, but registers a stage.StartMultiProvider,
 // which allows associating multiple functions with a single node
 func RegisterMultiStart[CFG, O any](nb *Builder, b stage.StartMultiProvider[CFG, O]) {
-	nb.startProviders[typeOf[CFG]()] = [2]reflect.Value{
-		reflect.ValueOf(node.AsStart[O]),
-		reflect.ValueOf(b),
+	nb.startProviders[typeOf[CFG]()] = reflectedNode{
+		instancer: reflect.ValueOf(node.AsStart[O]),
+		provider:  reflect.ValueOf(b),
 	}
 }
 
 // RegisterMiddle registers a stage.MiddleProvider into the graph builder. When the Build
 // method is invoked later, any configuration field associated with the MiddleProvider will
-// result in the instantiation of a node.Middle with the provider's returned function.
+// result in the instantiation of a node.Middle with the provider's returned provider.
 // The passed configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
 func RegisterMiddle[CFG, I, O any](nb *Builder, b stage.MiddleProvider[CFG, I, O]) {
-	nb.middleProviders[typeOf[CFG]()] = [2]reflect.Value{
-		reflect.ValueOf(node.AsMiddle[I, O]),
-		reflect.ValueOf(b),
+	nb.middleProviders[typeOf[CFG]()] = reflectedNode{
+		instancer: reflect.ValueOf(node.AsMiddle[I, O]),
+		provider:  reflect.ValueOf(b),
+		// even if we don't know if the node will receive information from a Demux
+		// we need to store the function reference just in case
+		inputDemuxAdd: reflect.ValueOf(node.DemuxAdd[I]),
 	}
 }
 
 // RegisterTerminal registers a stage.TerminalProvider into the graph builder. When the Build
 // method is invoked later, any configuration field associated with the TerminalProvider will
-// result in the instantiation of a node.Terminal with the provider's returned function.
+// result in the instantiation of a node.Terminal with the provider's returned provider.
 // The passed configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
 func RegisterTerminal[CFG, I any](nb *Builder, b stage.TerminalProvider[CFG, I]) {
-	nb.terminalProviders[typeOf[CFG]()] = [2]reflect.Value{
-		reflect.ValueOf(node.AsTerminal[I]),
-		reflect.ValueOf(b),
+	nb.terminalProviders[typeOf[CFG]()] = reflectedNode{
+		instancer: reflect.ValueOf(node.AsTerminal[I]),
+		provider:  reflect.ValueOf(b),
+		// even if we don't know if the node will receive information from a Demux
+		// we need to store the function reference just in case
+		inputDemuxAdd: reflect.ValueOf(node.DemuxAdd[I]),
 	}
 }
 
@@ -149,11 +208,14 @@ func (b *Builder) Build(cfg any) (Graph, error) {
 		return g, err
 	}
 
-	for _, i := range b.ingests {
+	for _, i := range b.startNodes {
 		g.start = append(g.start, i.(startNode))
 	}
-	for _, e := range b.exports {
-		g.terms = append(g.terms, e.(terminalNode))
+	for _, i := range b.startDemuxedNodes {
+		g.start = append(g.start, i.(startNode))
+	}
+	for _, e := range b.termNodes {
+		g.terms = append(g.terms, e.node.(terminalNode))
 	}
 
 	// validate that there aren't nodes without connection
@@ -186,84 +248,118 @@ func (nb *Builder) instantiate(instanceID string, arg reflect.Value) error {
 		arg, // arg 0: configuration value
 	}
 	if ib, ok := nb.startProviders[arg.Type()]; ok {
-		// providedFunc, err = StartProvider(arg)
-		callResult := ib[1].Call(rargs)
-		providedFunc := callResult[0]
-		errVal := callResult[1]
-
-		if !errVal.IsNil() || !errVal.IsZero() {
-			return fmt.Errorf("instantiating start instance %q: %w", instanceID, errVal.Interface().(error))
-		}
-
-		// If the providedFunc is a slice of funcs, it means we need to call AsStartCtx as a variadic Function
-		var startNode []reflect.Value
-		if providedFunc.Kind() == reflect.Slice {
-			// startNode = AsStartCtx(providedFuncs...)
-			startNode = ib[0].CallSlice([]reflect.Value{providedFunc})
-		} else {
-			// startNode = AsStartCtx(providedFunc)
-			startNode = ib[0].Call([]reflect.Value{providedFunc})
-		}
-		nb.ingests[instanceID] = startNode[0].Interface().(outTyper)
-		nb.outNodeNames[instanceID] = struct{}{}
-		return nil
+		return nb.instantiateStart(instanceID, ib, rargs)
 	}
 	if tb, ok := nb.middleProviders[arg.Type()]; ok {
-		// providedFunc, err = MiddleProvider(arg)
-		callResult := tb[1].Call(rargs)
-		providedFunc := callResult[0]
-		errVal := callResult[1]
-
-		if !errVal.IsNil() || !errVal.IsZero() {
-			return fmt.Errorf("instantiating middle instance %q: %w", instanceID, errVal.Interface().(error))
-		}
-
-		// middleNode = AsMiddle(providedFunc, nb.options...)
-		middleNode := tb[0].Call(append([]reflect.Value{providedFunc}, nb.options...))
-		nb.transforms[instanceID] = middleNode[0].Interface().(inOutTyper)
-		nb.inNodeNames[instanceID] = struct{}{}
-		nb.outNodeNames[instanceID] = struct{}{}
-		return nil
+		return nb.instantiateMiddle(instanceID, tb, rargs)
 	}
 
 	if eb, ok := nb.terminalProviders[arg.Type()]; ok {
-		// providedFunc, err = TerminalProvider(arg)
-		callResult := eb[1].Call(rargs)
-		providedFunc := callResult[0]
-		errVal := callResult[1]
-
-		if !errVal.IsNil() || !errVal.IsZero() {
-			return fmt.Errorf("instantiating terminal instance %q: %w", instanceID, errVal.Interface().(error))
-		}
-
-		// termNode = AsTerminal(providedFunc, nb.options...)
-		termNode := eb[0].Call(append([]reflect.Value{providedFunc}, nb.options...))
-		nb.exports[instanceID] = termNode[0].Interface().(inTyper)
-		nb.inNodeNames[instanceID] = struct{}{}
-		return nil
+		return nb.instantiateTerminal(instanceID, eb, rargs)
 	}
 	return fmt.Errorf("for node ID: %q. Provider not registered for type %q", instanceID, arg.Type())
 }
 
-func (b *Builder) connect(src, dst string) error {
-	if src == dst {
-		return fmt.Errorf("node %q must not send data to itself", dst)
+func (nb *Builder) instantiateStart(instanceID string, ib reflectedNode, rargs []reflect.Value) error {
+	// providedFunc, err = StartProvider(arg)
+	callResult := ib.provider.Call(rargs)
+	providedFunc := callResult[0]
+	errVal := callResult[1]
+
+	if !errVal.IsNil() || !errVal.IsZero() {
+		return fmt.Errorf("instantiating start instance %q: %w", instanceID, errVal.Interface().(error))
+	}
+
+	// If the providedFunc is a slice of funcs, it means we need to call AsStart as a variadic Function
+	var startNode []reflect.Value
+	if providedFunc.Kind() == reflect.Slice {
+		// startNode = AsStart(providedFuncs...)
+		startNode = ib.instancer.CallSlice([]reflect.Value{providedFunc})
+	} else {
+		// startNode = AsStart(providedFunc)
+		startNode = ib.instancer.Call([]reflect.Value{providedFunc})
+	}
+	if ib.demuxed {
+		nb.startDemuxedNodes[instanceID] = startNode[0].Interface().(node.Demuxed)
+	} else {
+		nb.startNodes[instanceID] = startNode[0].Interface().(outTyper)
+	}
+	nb.outNodeNames[instanceID] = struct{}{}
+	return nil
+}
+
+func (nb *Builder) instantiateMiddle(instanceID string, tb reflectedNode, rargs []reflect.Value) error {
+	// providedFunc, err = MiddleProvider(arg)
+	callResult := tb.provider.Call(rargs)
+	providedFunc := callResult[0]
+	errVal := callResult[1]
+
+	if !errVal.IsNil() || !errVal.IsZero() {
+		return fmt.Errorf("instantiating middle instance %q: %w", instanceID, errVal.Interface().(error))
+	}
+
+	// middleNode = AsMiddle(providedFunc, nb.options...)
+	middleNode := tb.instancer.Call(append([]reflect.Value{providedFunc}, nb.options...))
+	if tb.demuxed {
+		mn := middleNode[0].Interface().(inDemuxedOutTyper)
+		nb.middleDemuxedNodes[instanceID] = reflectedDemuxedNode{
+			node:          mn,
+			inputDemuxAdd: tb.inputDemuxAdd,
+			demuxed:       mn,
+		}
+	} else {
+		nb.middleNodes[instanceID] = destinableInOutNode{
+			node:          middleNode[0].Interface().(inOutTyper),
+			inputDemuxAdd: tb.inputDemuxAdd,
+		}
+	}
+	nb.inNodeNames[instanceID] = struct{}{}
+	nb.outNodeNames[instanceID] = struct{}{}
+	return nil
+}
+
+func (nb *Builder) instantiateTerminal(instanceID string, eb reflectedNode, rargs []reflect.Value) error {
+	// providedFunc, err = TerminalProvider(arg)
+	callResult := eb.provider.Call(rargs)
+	providedFunc := callResult[0]
+	errVal := callResult[1]
+
+	if !errVal.IsNil() || !errVal.IsZero() {
+		return fmt.Errorf("instantiating terminal instance %q: %w", instanceID, errVal.Interface().(error))
+	}
+
+	// termNode = AsTerminal(providedFunc, nb.options...)
+	termNode := eb.instancer.Call(append([]reflect.Value{providedFunc}, nb.options...))
+	nb.termNodes[instanceID] = destinableInNode{
+		node:          termNode[0].Interface().(inTyper),
+		inputDemuxAdd: eb.inputDemuxAdd,
+	}
+	nb.inNodeNames[instanceID] = struct{}{}
+	return nil
+}
+
+func (b *Builder) connect(src string, dst dstConnector) error {
+	if src == dst.dstNode {
+		return fmt.Errorf("node %q must not send data to itself", dst.dstNode)
 	}
 	// remove the src and dst from the inNodeNames and outNodeNames to mark that
 	// they have been already connected
-	delete(b.inNodeNames, dst)
+	delete(b.inNodeNames, dst.dstNode)
 	delete(b.outNodeNames, src)
 	// Ignore disabled nodes, as they are disabled by the user
 	// despite the connection is hardcoded in the nodeId, sendTo tags
 	if _, ok := b.disabledNodes[src]; ok {
 		return nil
 	}
-	if _, ok := b.disabledNodes[dst]; ok {
+	if _, ok := b.disabledNodes[dst.dstNode]; ok {
 		// if the disabled destination is configured to forward data, it will recursively
 		// connect the source with its own destinations
-		if fwds, ok := b.forwarderNodes[dst]; ok {
+		if fwds, ok := b.forwarderNodes[dst.dstNode]; ok {
 			for _, fwdDst := range fwds {
-				if err := b.connect(src, fwdDst); err != nil {
+				// if the source is demuxed, we need to forward the source demux info
+				// instead of the destination demux
+				dstWithSrcDemux := dstConnector{demuxChan: dst.demuxChan, dstNode: fwdDst.dstNode}
+				if err := b.connect(src, dstWithSrcDemux); err != nil {
 					return err
 				}
 			}
@@ -272,44 +368,76 @@ func (b *Builder) connect(src, dst string) error {
 	}
 
 	// find source and destination stages
-	var srcNode outTyper
-	var ok bool
-	srcNode, ok = b.ingests[src]
+	var srcDemuxedNode node.Demuxed
+	srcNode, ok := b.getSrcNode(src)
 	if !ok {
-		srcNode, ok = b.transforms[src]
+		srcDemuxedNode, ok = b.getSrcDemuxedNode(src)
 		if !ok {
 			return fmt.Errorf("invalid source node: %q", src)
 		}
 	}
-	var dstNode inTyper
-	dstNode, ok = b.transforms[dst]
+	dstNode, ok := b.getDstNode(dst.dstNode)
 	if !ok {
-		dstNode, ok = b.exports[dst]
-		if !ok {
-			return fmt.Errorf("invalid destination node: %q", dst)
-		}
+		return fmt.Errorf("invalid destination node: %q", dst.dstNode)
+	}
+	if srcNode != nil {
+		return b.directConnection(src, dst, srcNode, dstNode)
+	} else {
+		return b.demuxedConnection(src, dst, srcDemuxedNode, dstNode)
+	}
+}
+
+func (b *Builder) directConnection(srcName string, dstName dstConnector, srcNode outTyper, dstNode reflectedDemuxedNode) error {
+	if dstName.demuxChan != "" {
+		return fmt.Errorf("node %q has no demuxed output. Its destination node name can't have the '%s:' prefix (%s:%s)",
+			srcName, dstName.demuxChan, dstName.demuxChan, dstName.dstNode)
 	}
 	srcSendsToMethod := reflect.ValueOf(srcNode).MethodByName("SendTo")
 	if srcSendsToMethod.IsZero() {
-		panic(fmt.Sprintf("BUG: for stage %q, source of type %T does not have SendTo method", src, srcNode))
+		panic(fmt.Sprintf("BUG: for stage %q, source of type %T does not have SendTo method", srcName, srcNode))
 	}
 	// check if they have compatible types
-	if srcNode.OutType() == dstNode.InType() {
-		srcSendsToMethod.Call([]reflect.Value{reflect.ValueOf(dstNode)})
+	if srcNode.OutType() == dstNode.node.InType() {
+		srcSendsToMethod.Call([]reflect.Value{reflect.ValueOf(dstNode.node)})
 		return nil
 	}
 	// otherwise, we will add in intermediate codec layer
-	codec, ok := b.newCodec(srcNode.OutType(), dstNode.InType())
+	codec, ok := b.newCodec(srcNode.OutType(), dstNode.node.InType())
 	if !ok {
+		// TODO: this is not tested
 		return fmt.Errorf("can't connect %q and %q stages because there isn't registered"+
-			" any %s -> %s codec", src, dst, srcNode.OutType(), dstNode.InType())
+			" any %s -> %s codec", srcName, dstName, srcNode.OutType(), dstNode.node.InType())
 	}
 	srcSendsToMethod.Call([]reflect.Value{codec})
 	codecSendsToMethod := codec.MethodByName("SendTo")
 	if codecSendsToMethod.IsZero() {
-		panic(fmt.Sprintf("BUG: for stage %q, codec of type %T does not have SendTo method", src, srcNode))
+		panic(fmt.Sprintf("BUG: for stage %q, codec of type %T does not have SendTo method", srcName, srcNode))
 	}
-	codecSendsToMethod.Call([]reflect.Value{reflect.ValueOf(dstNode)})
+	codecSendsToMethod.Call([]reflect.Value{reflect.ValueOf(dstNode.node)})
+	return nil
+}
+
+func (b *Builder) demuxedConnection(src string, dstName dstConnector, srcNode node.Demuxed, dstNode reflectedDemuxedNode) error {
+	if dstName.demuxChan == "" {
+		return fmt.Errorf("node %q has demuxed output. Its destination node name must have a named output prefix (for example out1:%s)",
+			src, dstName.dstNode)
+	}
+
+	// demux := DemuxAdd[outType](srcNode, "chanName")
+	reflectedDemux := dstNode.inputDemuxAdd.Call([]reflect.Value{reflect.ValueOf(srcNode), reflect.ValueOf(dstName.demuxChan)})
+
+	// check if the output of the demux is compatible with the input of the connected node
+	demuxOutType := reflectedDemux[0].Interface().(outTyper).OutType()
+	if demuxOutType != dstNode.node.InType() {
+		// in principle, this should never happen as the demuxOutType is created from the dstNode type
+		return fmt.Errorf("can't connect %s and %s:%s stages because the output %s (type %s) does not match"+
+			" the input of the node %s (type %s)", src, dstName.demuxChan, dstName.dstNode, dstName.demuxChan,
+			demuxOutType.String(), dstName.dstNode, dstNode.node.InType().String())
+	}
+
+	// demux.SendTo(dstNode)
+	reflectedDemux[0].MethodByName("SendTo").Call([]reflect.Value{reflect.ValueOf(dstNode.node)})
+
 	return nil
 }
 
@@ -320,11 +448,53 @@ func (b *Builder) newCodec(inType, outType reflect.Type) (reflect.Value, bool) {
 		return reflect.ValueOf(nil), false
 	}
 
-	result := codec[0].Call(codec[1:])
+	result := codec.instancer.Call([]reflect.Value{codec.provider})
 	return result[0], true
 }
 
 func typeOf[T any]() reflect.Type {
 	var t T
 	return reflect.TypeOf(t)
+}
+
+func (b *Builder) getSrcNode(id string) (outTyper, bool) {
+	if srcNode, ok := b.startNodes[id]; ok {
+		return srcNode, true
+	}
+	if srcNode, ok := b.middleNodes[id]; ok {
+		return srcNode.node, true
+	}
+	return nil, false
+}
+
+func (b *Builder) getSrcDemuxedNode(id string) (node.Demuxed, bool) {
+	if srcNode, ok := b.startDemuxedNodes[id]; ok {
+		return srcNode, true
+	}
+	if srcNode, ok := b.middleDemuxedNodes[id]; ok {
+		return srcNode.demuxed, true
+	}
+	return nil, false
+}
+
+func (b *Builder) getDstNode(id string) (reflectedDemuxedNode, bool) {
+	if dstNode, ok := b.middleNodes[id]; ok {
+		return reflectedDemuxedNode{
+			node:          dstNode.node,
+			inputDemuxAdd: dstNode.inputDemuxAdd,
+		}, true
+	}
+	if dstNode, ok := b.middleDemuxedNodes[id]; ok {
+		return reflectedDemuxedNode{
+			node:          dstNode.node,
+			inputDemuxAdd: dstNode.inputDemuxAdd,
+		}, true
+	}
+	if dstNode, ok := b.termNodes[id]; ok {
+		return reflectedDemuxedNode{
+			node:          dstNode.node,
+			inputDemuxAdd: dstNode.inputDemuxAdd,
+		}, true
+	}
+	return reflectedDemuxedNode{}, false
 }

--- a/vendor/github.com/mariomac/pipes/pkg/graph/connector.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/connector.go
@@ -1,0 +1,31 @@
+package graph
+
+import (
+	"strings"
+)
+
+type dstConnector struct {
+	demuxChan string // if empty, no demuxed channel but direct submission to the node
+	dstNode   string
+}
+
+func allConnectorsFrom(in string) []dstConnector {
+	var conns []dstConnector
+	for _, connection := range strings.Split(in, ",") {
+		conns = append(conns, connectorFrom(connection))
+	}
+	return conns
+}
+
+func connectorFrom(in string) dstConnector {
+	parts := strings.Split(strings.TrimSpace(in), ":")
+	if len(parts) == 1 {
+		return dstConnector{
+			dstNode: parts[0],
+		}
+	}
+	return dstConnector{
+		demuxChan: parts[0],
+		dstNode:   parts[1],
+	}
+}

--- a/vendor/github.com/mariomac/pipes/pkg/graph/grdemux.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/grdemux.go
@@ -1,0 +1,37 @@
+package graph
+
+import (
+	"reflect"
+
+	"github.com/mariomac/pipes/pkg/graph/stage"
+	"github.com/mariomac/pipes/pkg/node"
+)
+
+// RegisterStartDemux registers a stage.StartDemuxProvider into the graph builder. When the Build
+// method is invoked later, any configuration field associated with the StartProvider will
+// result in the instantiation of a node.StartDemux with the provider's returned provider.
+// The passed configuration type must either implement the stage.Instancer interface or the
+// configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
+func RegisterStartDemux[CFG any](nb *Builder, b stage.StartDemuxProvider[CFG]) {
+	nb.startProviders[typeOf[CFG]()] = reflectedNode{
+		demuxed:   true,
+		instancer: reflect.ValueOf(node.AsStartDemux),
+		provider:  reflect.ValueOf(b),
+	}
+}
+
+// RegisterMiddleDemux registers a stage.MiddleDemuxProvider into the graph builder. When the Build
+// method is invoked later, any configuration field associated with the MiddleProvider will
+// result in the instantiation of a node.MiddleDemux with the provider's returned provider.
+// The passed configuration type must either implement the stage.Instancer interface or the
+// configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
+func RegisterMiddleDemux[CFG, I any](nb *Builder, b stage.MiddleDemuxProvider[CFG, I]) {
+	nb.middleProviders[typeOf[CFG]()] = reflectedNode{
+		demuxed:   true,
+		instancer: reflect.ValueOf(node.AsMiddleDemux[I]),
+		provider:  reflect.ValueOf(b),
+		// even if we don't know if the node will receive information from a Demux
+		// we need to store the function reference just in case
+		inputDemuxAdd: reflect.ValueOf(node.DemuxAdd[I]),
+	}
+}

--- a/vendor/github.com/mariomac/pipes/pkg/graph/stage/stage.go
+++ b/vendor/github.com/mariomac/pipes/pkg/graph/stage/stage.go
@@ -57,3 +57,19 @@ type MiddleProvider[CFG, I, O any] func(CFG) (node.MiddleFunc[I, O], error)
 // The configuration type must either implement the stage.Instancer interface or the
 // configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
 type TerminalProvider[CFG, I any] func(CFG) (node.TerminalFunc[I], error)
+
+// StartDemuxProvider is a function that, given a configuration argument of a unique type,
+// returns a function fulfilling the node.StartFuncDemux type signature. Returned function
+// will run inside a Graph Start Node
+// If it returns an error, the graph building process will be interrupted.
+// The configuration type must either implement the stage.Instancer interface or the
+// configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
+type StartDemuxProvider[CFG any] func(CFG) (node.StartDemuxFunc, error)
+
+// MiddleDemuxProvider is a function that, given a configuration argument of a unique type,
+// returns a function fulfilling the node.MiddleDemuxFunc type signature. Returned functions
+// will run inside a Graph Middle Node.
+// If it returns an error, the graph building process will be interrupted.
+// The configuration type must either implement the stage.Instancer interface or the
+// configuration struct containing it must define a `nodeId` tag with an identifier for that stage.
+type MiddleDemuxProvider[CFG, I any] func(CFG) (node.MiddleDemuxFunc[I], error)

--- a/vendor/github.com/mariomac/pipes/pkg/node/demux.go
+++ b/vendor/github.com/mariomac/pipes/pkg/node/demux.go
@@ -1,0 +1,246 @@
+package node
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mariomac/pipes/pkg/node/internal/connect"
+)
+
+// Demuxed node whose output is not a channel but a Demux.
+// Can be both StartDemux or MiddleDemux nodes
+// Experimental API. Some names could change in the following versions.
+type Demuxed interface {
+	demuxBuilder() *demuxBuilder
+}
+
+// Demux is a collection of multiple output channels for a
+// Demuxed node, which receives them as a second argument in its
+// StartDemuxFunc or MiddleDemuxFunc functions.
+// During the graph definition time, multiple outputs can be
+// associated to a node by means of the DemuxAdd function.
+// At runtime, you can access the multiple named output
+// channels by means of the DemuxGet function.
+// Experimental API. Some names could change in the following versions.
+type Demux struct {
+	// Key: the key/name of the output
+	outChans map[any]any
+}
+
+// StartDemuxFunc is a function that receives a Demux as unique argument,
+// and sends, during an indefinite amount of time, values to the channels
+// contained in the Demux (previously accessed by the DemuxGet function).
+// Experimental API. Some names could change in the following versions.
+type StartDemuxFunc func(out Demux)
+
+// MiddleDemuxFunc is a function that receives a readable channel as first argument,
+// and a Demux as second argument.
+// It must process the inputs from the input channel until it's closed
+// and usually forward the processed values to any of the Demux output channels
+// (previously accessed by the DemuxGet function).
+// Experimental API. Some names could change in the following versions.
+type MiddleDemuxFunc[IN any] func(in <-chan IN, out Demux)
+
+// demuxBuilder is an accessory object to define, during the construction time,
+// the multiple outputs of a demuxed node
+type demuxBuilder struct {
+	// key: any value of any type, to identify the connection output
+	// value: reflect.ValueOf(&receiverGroup[OUT])
+	outNodes map[any]reflect.Value
+}
+
+// demuxOut provides reflection access to the value of a receiverGroup pointer
+// Their methods are equivalent to receiverGroup but using reflection access
+// to avoid compile-time check of generics
+type demuxOut[OUT any] struct {
+	reflectOut reflect.Value // reflect.ValueOf(&receiverGroup[OUT])
+}
+
+func (do *demuxOut[OUT]) OutType() reflect.Type {
+	var out OUT
+	return reflect.TypeOf(out)
+}
+
+func (do *demuxOut[OUT]) SendTo(outs ...Receiver[OUT]) {
+	for _, out := range outs {
+		// above block is equivalent to
+		// receiverGroup.Outs = append(receiverGroup.Outs, out)
+		outSlice := do.reflectOut.Elem().FieldByName("Outs")
+		outSlice.Grow(1)
+		outSlice.SetLen(outSlice.Cap())
+		outSlice.Index(outSlice.Cap() - 1).Set(reflect.ValueOf(out))
+	}
+}
+
+// DemuxAdd is used during the graph definition/construction time.
+// It allows associating multiple output paths to a Demuxed node
+// (which can be StartDemux or MiddleDemux). It returns a Sender
+// output that can be connected to a group of output nodes for that
+// path.
+// The Sender created output is
+// identified by a key that can be any value of any type, and
+// can be later accessed from inside the node's StartDemuxFunc or
+// MiddleDemuxFunc with the DemuxGet function.
+// Experimental API. Some names could change in the following versions.
+func DemuxAdd[OUT any](d Demuxed, key any) Sender[OUT] {
+	demux := d.demuxBuilder()
+	var out OUT
+	to := reflect.TypeOf(out)
+	outNod, ok := demux.outNodes[key]
+	if !ok {
+		outNod = reflect.ValueOf(&receiverGroup[OUT]{outType: to})
+		demux.outNodes[key] = outNod
+	}
+
+	return &demuxOut[OUT]{reflectOut: outNod}
+}
+
+// DemuxGet returns the output channel associated to the given key
+// in the provided Demux.
+// This function needs to be invoked inside a StartDemuxFunc or
+// MiddleDemuxFunc.
+// The function will panic if no output channel has been previously
+// defined at build time for that given key (using the DemuxAdd) function.
+// Experimental API. Some names could change in the following versions.
+func DemuxGet[OUT any](d Demux, key any) chan<- OUT {
+	if on, ok := d.outChans[key]; !ok {
+		panic(fmt.Sprintf("Demux has not registered any sender for key %#v", key))
+	} else {
+		return on.(chan OUT)
+	}
+}
+
+// StartDemux is equivalent to a Start node, but receiving a Demux instead
+// of a writable channel.
+// Start nodes are the starting points of a graph. This is, all the nodes that bring information
+// from outside the graph: e.g. because they generate them or because they acquire them from an
+// external source like a Web Service.
+// A graph must have at least one Start or StartDemux node.
+// A StartDemux node must have at least one output node.
+// Experimental API. Some names could change in the following versions.
+type StartDemux struct {
+	demux demuxBuilder
+	funs  []StartDemuxFunc
+}
+
+// AsStartDemux wraps a group of StartDemuxFunc into a StartDemux node.
+func AsStartDemux(funs ...StartDemuxFunc) *StartDemux {
+	return &StartDemux{
+		funs: funs,
+	}
+}
+
+func (i *StartDemux) demuxBuilder() *demuxBuilder {
+	if i.demux.outNodes == nil {
+		i.demux.outNodes = map[any]reflect.Value{}
+	}
+	return &i.demux
+}
+
+// Start starts the function wrapped in the StartDemux node. This method should be invoked
+// for all the start nodes of the same graph, so the graph can properly start and finish.
+func (i *StartDemux) Start() {
+	releasers, demux := startAndCollectReleaseFuncs(i)
+
+	// Invocation to all the start node functions, with
+	// deferred invocation to the ReleaseSender methods that were previously collected
+	for fn := range i.funs {
+		fun := i.funs[fn]
+		go func() {
+			defer func() {
+				for _, release := range releasers {
+					release.Call(nil)
+				}
+			}()
+			fun(demux)
+		}()
+	}
+}
+
+// for any demuxed node, starts the receivers and collects the released
+// nodes. It also returns a demux with the connections to the receiver
+// nodes.
+func startAndCollectReleaseFuncs(d Demuxed) ([]reflect.Value, Demux) {
+	db := d.demuxBuilder()
+	if len(db.outNodes) == 0 {
+		panic(fmt.Sprintf("Demux in the node of type %T should define at least one output", d))
+	}
+	// TODO: panic if no outputs?
+	releasers := make([]reflect.Value, 0, len(db.outNodes))
+	demux := Demux{outChans: map[any]any{}}
+	for k, on := range db.outNodes {
+		// forker, err := on.StartReceivers()
+		method := on.MethodByName("StartReceivers")
+		startResult := method.Call(nil)
+		// if err != nil {
+		if !startResult[1].IsNil() {
+			panic(fmt.Sprintf("%T node %s: %s", d, k, startResult[1].Interface()))
+		}
+		// outChans[k] = forker.AcquireSender()
+		forker := startResult[0]
+		demux.outChans[k] = forker.MethodByName("AcquireSender").Call(nil)[0].Interface()
+		// releasers = append(releasers, forker.ReleaseSender())
+		releasers = append(releasers, forker.MethodByName("ReleaseSender"))
+	}
+	return releasers, demux
+}
+
+// MiddleDemux is any intermediate node that receives data from another node, processes/filters it,
+// and forwards the data any of the output channels in the provided Demux.
+// An MiddleDemux node must have at least one output node.
+// Experimental API. Some names could change in the following versions.
+type MiddleDemux[IN any] struct {
+	fun    MiddleDemuxFunc[IN]
+	demux  demuxBuilder
+	inputs connect.Joiner[IN]
+	// nolint:unused
+	started bool
+	inType  reflect.Type
+}
+
+// AsMiddleDemux wraps an MiddleDemuxFunc into an MiddleDemux node.
+// Experimental API. Some names could change in the following versions.
+func AsMiddleDemux[IN any](fun MiddleDemuxFunc[IN], opts ...Option) *MiddleDemux[IN] {
+	var in IN
+	options := getOptions(opts...)
+	return &MiddleDemux[IN]{
+		inputs: connect.NewJoiner[IN](options.channelBufferLen),
+		fun:    fun,
+		inType: reflect.TypeOf(in),
+	}
+}
+
+// nolint:unused
+func (m *MiddleDemux[IN]) joiner() *connect.Joiner[IN] {
+	return &m.inputs
+}
+
+// nolint:unused
+func (m *MiddleDemux[IN]) isStarted() bool {
+	return m.started
+}
+
+func (m *MiddleDemux[IN]) InType() reflect.Type {
+	return m.inType
+}
+
+// nolint:unused
+func (m *MiddleDemux[IN]) start() {
+	releasers, demux := startAndCollectReleaseFuncs(m)
+
+	go func() {
+		defer func() {
+			for _, release := range releasers {
+				release.Call(nil)
+			}
+		}()
+		m.fun(m.inputs.Receiver(), demux)
+	}()
+}
+
+func (i *MiddleDemux[IN]) demuxBuilder() *demuxBuilder {
+	if i.demux.outNodes == nil {
+		i.demux.outNodes = map[any]reflect.Value{}
+	}
+	return &i.demux
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,7 +207,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
 ## explicit; go 1.18
 github.com/mariomac/guara/pkg/test
-# github.com/mariomac/pipes v0.8.0
+# github.com/mariomac/pipes v0.9.0
 ## explicit; go 1.18
 github.com/mariomac/pipes/pkg/graph
 github.com/mariomac/pipes/pkg/graph/stage


### PR DESCRIPTION
Until now, each node in the Beyla pipeline has only one input channel and one output channel.

Version 0.9.0 of the [Pipes](https://github.com/mariomac/pipes) library allows defining multi-channel (demuxed) outputs. This will be used in Beyla for:

* In the Process Finder component, the process creation and process deletion events will follow different paths, so we don't need to populate with "if eventType == EventCreated" some nodes like the CriteriaMatcher of the ExecTyper. The updated pipeline would look as:

```mermaid
flowchart TD
    subgraph discovery.Finder pipeline
        W(Watcher) --> |new processes| CM(CriteriaMatcher)
        W --> |deleted processes| TA
        CM --> |processes matching the selection criteria| ET(ExecTyper)
        ET --> |ELFs and its metadata| TA(TracerManager)
        TA -.-> EBPF1(ebpf.Tracer)
        TA -.-> |creates/destroys| EBPF2(ebpf.Tracer)
        TA -.-> EBPF3(ebpf.Tracer)
    end
```

Also, in the trace decoration and forwarding pipeline: as long as we keep adding more traces types, some of them might follow different paths for different types of operation/decoration. This way we don't have to make all the traces to pass for the same linear pipeline and populate it with type checks for each individual case.

