### PR TITLE
Process discovery: optimize Watcher

### DIFF
--- a/pkg/internal/discover/matcher_test.go
+++ b/pkg/internal/discover/matcher_test.go
@@ -28,19 +28,25 @@ func TestCriteriaMatcher(t *testing.T) {
 
 	matcherFunc, err := CriteriaMatcherProvider(CriteriaMatcher{Cfg: &pipeConfig})
 	require.NoError(t, err)
-	discoveredProcesses := make(chan []Event[*services.ProcessInfo], 10)
+	discoveredProcesses := make(chan []Event[processPorts], 10)
 	filteredProcesses := make(chan []Event[ProcessMatch], 10)
 	go matcherFunc(discoveredProcesses, filteredProcesses)
 	defer close(discoveredProcesses)
 
 	// it will filter unmatching processes and return a ProcessMatch for these that match
-	discoveredProcesses <- []Event[*services.ProcessInfo]{
-		{Type: EventCreated, Obj: &services.ProcessInfo{Pid: 1, ExePath: "/bin/weird33", OpenPorts: []uint32{1, 2, 3}}}, // pass
-		{Type: EventDeleted, Obj: &services.ProcessInfo{Pid: 2, ExePath: "/bin/weird33", OpenPorts: []uint32{4}}},       // filter
-		{Type: EventCreated, Obj: &services.ProcessInfo{Pid: 3, ExePath: "server", OpenPorts: []uint32{8433}}},          // filter
-		{Type: EventCreated, Obj: &services.ProcessInfo{Pid: 4, ExePath: "/bin/something", OpenPorts: []uint32{8083}}},  //pass
-		{Type: EventCreated, Obj: &services.ProcessInfo{Pid: 5, ExePath: "server", OpenPorts: []uint32{443}}},           // pass
-		{Type: EventCreated, Obj: &services.ProcessInfo{Pid: 6, ExePath: "/bin/clientweird99"}},                         // pass
+	processInfo = func(pp processPorts) (*services.ProcessInfo, error) {
+		exePath := map[PID]string{
+			1: "/bin/weird33", 2: "/bin/weird33", 3: "server",
+			4: "/bin/something", 5: "server", 6: "/bin/clientweird99"}[pp.pid]
+		return &services.ProcessInfo{Pid: int32(pp.pid), ExePath: exePath, OpenPorts: pp.openPorts}, nil
+	}
+	discoveredProcesses <- []Event[processPorts]{
+		{Type: EventCreated, Obj: processPorts{pid: 1, openPorts: []uint32{1, 2, 3}}}, // pass
+		{Type: EventDeleted, Obj: processPorts{pid: 2, openPorts: []uint32{4}}},       // filter
+		{Type: EventCreated, Obj: processPorts{pid: 3, openPorts: []uint32{8433}}},    // filter
+		{Type: EventCreated, Obj: processPorts{pid: 4, openPorts: []uint32{8083}}},    //pass
+		{Type: EventCreated, Obj: processPorts{pid: 5, openPorts: []uint32{443}}},     // pass
+		{Type: EventCreated, Obj: processPorts{pid: 6}},                               // pass
 	}
 
 	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)

--- a/pkg/internal/discover/watcher.go
+++ b/pkg/internal/discover/watcher.go
@@ -4,22 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/mariomac/pipes/pkg/node"
 	"github.com/shirou/gopsutil/net"
 	"github.com/shirou/gopsutil/process"
-
-	"github.com/grafana/beyla/pkg/internal/discover/services"
 )
 
 const (
 	defaultPollInterval = 5 * time.Second
 )
 
-// Watcher polls every PollInterval for new processes and forwards either new or deleted processes
-// as well as process that setup a new connection
+// Watcher polls every PollInterval for new processes and forwards either new or deleted process PIDs
+// as well as PIDs from processes that setup a new connection
 type Watcher struct {
 	Ctx          context.Context
 	PollInterval time.Duration
@@ -37,17 +34,24 @@ type Event[T any] struct {
 	Obj  T
 }
 
+type PID int32
+
+type processPorts struct {
+	pid       PID
+	openPorts []uint32
+}
+
 func wplog() *slog.Logger {
 	return slog.With("component", "discover.Watcher")
 }
 
-func WatcherProvider(w Watcher) (node.StartFunc[[]Event[*services.ProcessInfo]], error) {
+func WatcherProvider(w Watcher) (node.StartFunc[[]Event[processPorts]], error) {
 	acc := pollAccounter{
 		ctx:           w.Ctx,
 		interval:      w.PollInterval,
-		pids:          map[int32]*services.ProcessInfo{},
-		pidPorts:      map[pidPort]*services.ProcessInfo{},
-		listProcesses: connectedProcesses,
+		pids:          map[PID]processPorts{},
+		pidPorts:      map[pidPort]processPorts{},
+		listProcesses: fetchProcessPorts,
 	}
 	if acc.interval == 0 {
 		acc.interval = defaultPollInterval
@@ -57,7 +61,7 @@ func WatcherProvider(w Watcher) (node.StartFunc[[]Event[*services.ProcessInfo]],
 
 // pidPort associates a PID with its open port
 type pidPort struct {
-	Pid  int32
+	Pid  PID
 	Port uint32
 }
 
@@ -65,16 +69,16 @@ type pidPort struct {
 type pollAccounter struct {
 	ctx      context.Context
 	interval time.Duration
-	// last polled processes accessible by its pid
-	pids map[int32]*services.ProcessInfo
-	// last polled processes accesible by a combination of pid/connection port
+	// last polled process:ports accessible by its pid
+	pids map[PID]processPorts
+	// last polled process:ports accessible by a combination of pid/connection port
 	// same process might appear several times
-	pidPorts map[pidPort]*services.ProcessInfo
+	pidPorts map[pidPort]processPorts
 	// injectable function
-	listProcesses func() (map[int32]*services.ProcessInfo, error)
+	listProcesses func() (map[PID]processPorts, error)
 }
 
-func (pa *pollAccounter) Run(out chan<- []Event[*services.ProcessInfo]) {
+func (pa *pollAccounter) Run(out chan<- []Event[processPorts]) {
 	log := slog.With("component", "discover.Watcher", "interval", pa.interval)
 	for {
 		procs, err := pa.listProcesses()
@@ -98,31 +102,32 @@ func (pa *pollAccounter) Run(out chan<- []Event[*services.ProcessInfo]) {
 
 // snapshot compares the current processes with the status of the previous poll
 // and forwards a list of process creation/deletion events
-func (pa *pollAccounter) snapshot(fetchedProcs map[int32]*services.ProcessInfo) []Event[*services.ProcessInfo] {
-	var events []Event[*services.ProcessInfo]
-	currentPidPorts := make(map[pidPort]*services.ProcessInfo, len(fetchedProcs))
-	reportedProcs := map[int32]struct{}{}
+func (pa *pollAccounter) snapshot(fetchedProcs map[PID]processPorts) []Event[processPorts] {
+	var events []Event[processPorts]
+	currentPidPorts := make(map[pidPort]processPorts, len(fetchedProcs))
+	reportedProcs := map[PID]struct{}{}
 	// notify processes that are new, or already existed but have a new connection
-	for _, proc := range fetchedProcs {
+	for pid, proc := range fetchedProcs {
 		// if the process does not have open ports, we might still notify it
 		// for example, if it's a client with ephemeral connections, which might be later matched by executable name
-		if len(proc.OpenPorts) == 0 {
-			if ev, ok := pa.checkProcessNotification(proc, reportedProcs); ok {
-				events = append(events, ev)
+		if len(proc.openPorts) == 0 {
+			if pa.checkNewProcessNotification(pid, reportedProcs) {
+				events = append(events, Event[processPorts]{Type: EventCreated, Obj: proc})
 			}
 		} else {
-			for _, port := range proc.OpenPorts {
-				if ev, ok := pa.checkProcessConnectionNotification(proc, port, currentPidPorts, reportedProcs); ok {
-					events = append(events, ev)
+			for _, port := range proc.openPorts {
+				if pa.checkNewProcessConnectionNotification(proc, port, currentPidPorts, reportedProcs) {
+					events = append(events, Event[processPorts]{Type: EventCreated, Obj: proc})
+					// skip checking new connections for that process
 					continue
 				}
 			}
 		}
 	}
 	// notify processes that are removed
-	for pp, proc := range pa.pids {
-		if _, ok := fetchedProcs[pp]; !ok {
-			events = append(events, Event[*services.ProcessInfo]{Type: EventDeleted, Obj: proc})
+	for pid, proc := range pa.pids {
+		if _, ok := fetchedProcs[pid]; !ok {
+			events = append(events, Event[processPorts]{Type: EventDeleted, Obj: proc})
 		}
 	}
 	pa.pids = fetchedProcs
@@ -130,130 +135,65 @@ func (pa *pollAccounter) snapshot(fetchedProcs map[int32]*services.ProcessInfo) 
 	return events
 }
 
-func (pa *pollAccounter) checkProcessConnectionNotification(
-	proc *services.ProcessInfo,
+func (pa *pollAccounter) checkNewProcessConnectionNotification(
+	proc processPorts,
 	port uint32,
-	currentPidPorts map[pidPort]*services.ProcessInfo,
-	reportedProcs map[int32]struct{},
-) (Event[*services.ProcessInfo], bool) {
-	pp := pidPort{Pid: proc.Pid, Port: port}
+	currentPidPorts map[pidPort]processPorts,
+	reportedProcs map[PID]struct{},
+) bool {
+	pp := pidPort{Pid: proc.pid, Port: port}
 	currentPidPorts[pp] = proc
 	// the connection existed before iff we already had registered this pid/port pair
 	_, existingConnection := pa.pidPorts[pp]
 	// the proc existed before iff we already had registered this pid
-	_, existingProcess := pa.pids[proc.Pid]
+	_, existingProcess := pa.pids[proc.pid]
 	// we notify the creation either if the connection and the process is new...
 	if !existingConnection || !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
 		if _, ok := reportedProcs[pp.Pid]; !ok {
 			// avoid notifying multiple times the same process if it has multiple connections
-			reportedProcs[pp.Pid] = struct{}{}
-			return Event[*services.ProcessInfo]{Type: EventCreated, Obj: proc}, true
+			reportedProcs[proc.pid] = struct{}{}
+			return true
 		}
 	}
-	return Event[*services.ProcessInfo]{}, false
+	return false
 }
 
-func (pa *pollAccounter) checkProcessNotification(
-	proc *services.ProcessInfo,
-	reportedProcs map[int32]struct{},
-) (Event[*services.ProcessInfo], bool) {
+// checkNewProcessNotification returns true if the process has to be notified as new.
+// It accordingly updates the reportedProcs map
+func (pa *pollAccounter) checkNewProcessNotification(pid PID, reportedProcs map[PID]struct{}) bool {
 	// the proc existed before iff we already had registered this pid from a previous snapshot
-	if _, existingProcess := pa.pids[proc.Pid]; !existingProcess {
+	if _, existingProcess := pa.pids[pid]; !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
-		if _, ok := reportedProcs[proc.Pid]; !ok {
+		if _, ok := reportedProcs[pid]; !ok {
 			// avoid notifying multiple times the same process if it has multiple connections
-			reportedProcs[proc.Pid] = struct{}{}
-			return Event[*services.ProcessInfo]{Type: EventCreated, Obj: proc}, true
+			reportedProcs[pid] = struct{}{}
+			return true
 		}
 	}
-	return Event[*services.ProcessInfo]{}, false
+	return false
 }
 
-func connectedProcesses() (map[int32]*services.ProcessInfo, error) {
-	processes := map[int32]*services.ProcessInfo{}
-	// In containerized environments, processess might be visible through either
-	// the shared network or the shared PID namespace, so we fetch them from both sources
-	if err := fetchProcesses(processes); err != nil {
-		return nil, err
-	}
-	if err := fetchConnections(processes); err != nil {
-		return nil, err
-	}
-	return processes, nil
-}
-
-func fetchProcesses(processes map[int32]*services.ProcessInfo) error {
-	procs, err := process.Processes()
+// fetchProcessConnections returns a map with the PIDs of all the running processes as a key,
+// and the open ports for the given process as a value
+func fetchProcessPorts() (map[PID]processPorts, error) {
+	log := wplog()
+	processes := map[PID]processPorts{}
+	pids, err := process.Pids()
 	if err != nil {
-		return fmt.Errorf("can't get processes: %w", err)
+		return nil, fmt.Errorf("can't get processes: %w", err)
 	}
-	for _, proc := range procs {
-		if pi, err := processInfo(proc); err != nil {
-			wplog().Warn("can't get process information", "pid", proc.Pid, "error", err)
-		} else {
-			conns, _ := proc.Connections()
-			for _, conn := range conns {
-				pi.OpenPorts = append(pi.OpenPorts, conn.Laddr.Port)
-			}
-			processes[proc.Pid] = pi
-		}
-	}
-	return nil
-}
-
-func fetchConnections(processes map[int32]*services.ProcessInfo) error {
-	conns, err := net.Connections("inet")
-	if err != nil {
-		return fmt.Errorf("can't get network connections: %w", err)
-	}
-	for i := range conns {
-		conn := &conns[i]
-		if conn.Pid == 0 {
+	for _, pid := range pids {
+		conns, err := net.ConnectionsPid("inet", pid)
+		if err != nil {
+			log.Debug("can't get connections for process. Skipping", "pid", pid, "error", err)
 			continue
 		}
-		proc, ok := processes[conn.Pid]
-		if !ok {
-			if proc, err = processFromConnection(conn); err != nil {
-				wplog().Warn("can't read process information", "pid", conn.Pid, "err", err)
-				continue
-			}
-			processes[conn.Pid] = proc
+		var openPorts []uint32
+		for _, conn := range conns {
+			openPorts = append(openPorts, conn.Laddr.Port)
 		}
-		proc.OpenPorts = append(proc.OpenPorts, conn.Laddr.Port)
+		processes[PID(pid)] = processPorts{pid: PID(pid), openPorts: openPorts}
 	}
-	return nil
-}
-
-func processFromConnection(conn *net.ConnectionStat) (*services.ProcessInfo, error) {
-	proc, err := process.NewProcess(conn.Pid)
-	if err != nil {
-		return nil, err
-	}
-	return processInfo(proc)
-}
-
-func processInfo(proc *process.Process) (*services.ProcessInfo, error) {
-	ppid, _ := proc.Ppid()
-	exePath, err := proc.Exe()
-	if err != nil {
-		if err := tryAccessPid(proc.Pid); err != nil {
-			return nil, fmt.Errorf("can't read /proc/<pid>/fd information: %w", err)
-		}
-		// this might happen if you query from the port a service that does not have executable path.
-		// Since this value is just for attributing, we set a default placeholder
-		exePath = "unknown"
-	}
-	return &services.ProcessInfo{
-		Pid:     proc.Pid,
-		PPid:    ppid,
-		ExePath: exePath,
-	}, nil
-}
-
-func tryAccessPid(pid int32) error {
-	// TODO: allow overriding proc root
-	dir := fmt.Sprintf("/proc/%d/fd", pid)
-	_, err := os.Open(dir)
-	return err
+	return processes, nil
 }

--- a/pkg/internal/discover/watcher_test.go
+++ b/pkg/internal/discover/watcher_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/grafana/beyla/pkg/internal/discover/services"
 	"github.com/grafana/beyla/pkg/internal/testutil"
 )
 
@@ -16,36 +15,36 @@ const testTimeout = 5 * time.Second
 
 func TestWatcher_Poll(t *testing.T) {
 	// mocking a fake listProcesses method
-	p1_1 := &services.ProcessInfo{Pid: 1, OpenPorts: []uint32{3030}}
-	p1_2 := &services.ProcessInfo{Pid: 1, OpenPorts: []uint32{3030, 3031}}
-	p2 := &services.ProcessInfo{Pid: 2, OpenPorts: []uint32{123}}
-	p3 := &services.ProcessInfo{Pid: 3, OpenPorts: []uint32{456}}
-	p4 := &services.ProcessInfo{Pid: 4, OpenPorts: []uint32{789}}
-	p5 := &services.ProcessInfo{Pid: 10}
+	p1_1 := processPorts{pid: 1, openPorts: []uint32{3030}}
+	p1_2 := processPorts{pid: 1, openPorts: []uint32{3030, 3031}}
+	p2 := processPorts{pid: 2, openPorts: []uint32{123}}
+	p3 := processPorts{pid: 3, openPorts: []uint32{456}}
+	p4 := processPorts{pid: 4, openPorts: []uint32{789}}
+	p5 := processPorts{pid: 10}
 	invocation := 0
 	ctx, cancel := context.WithCancel(context.Background())
 	// GIVEN a pollAccounter
 	acc := pollAccounter{
 		interval: time.Microsecond,
 		ctx:      ctx,
-		pidPorts: map[pidPort]*services.ProcessInfo{},
-		listProcesses: func() (map[int32]*services.ProcessInfo, error) {
+		pidPorts: map[pidPort]processPorts{},
+		listProcesses: func() (map[PID]processPorts, error) {
 			invocation++
 			switch invocation {
 			case 1:
-				return map[int32]*services.ProcessInfo{p1_1.Pid: p1_1, p2.Pid: p2, p3.Pid: p3}, nil
+				return map[PID]processPorts{p1_1.pid: p1_1, p2.pid: p2, p3.pid: p3}, nil
 			case 2:
 				// p1_2 simulates that a new connection has been created for an existing process
-				return map[int32]*services.ProcessInfo{p1_2.Pid: p1_2, p3.Pid: p3, p4.Pid: p4}, nil
+				return map[PID]processPorts{p1_2.pid: p1_2, p3.pid: p3, p4.pid: p4}, nil
 			case 3:
-				return map[int32]*services.ProcessInfo{p2.Pid: p2, p3.Pid: p3, p4.Pid: p4}, nil
+				return map[PID]processPorts{p2.pid: p2, p3.pid: p3, p4.pid: p4}, nil
 			default:
 				// new processes with no connections (p5) should be also reported
-				return map[int32]*services.ProcessInfo{p5.Pid: p5, p2.Pid: p2, p3.Pid: p3, p4.Pid: p4}, nil
+				return map[PID]processPorts{p5.pid: p5, p2.pid: p2, p3.pid: p3, p4.pid: p4}, nil
 			}
 		},
 	}
-	accounterOutput := make(chan []Event[*services.ProcessInfo], 1)
+	accounterOutput := make(chan []Event[processPorts], 1)
 	accounterExited := make(chan struct{})
 	go func() {
 		acc.Run(accounterOutput)
@@ -55,7 +54,7 @@ func TestWatcher_Poll(t *testing.T) {
 	// WHEN it polls the process for the first time
 	// THEN it returns the creation of all the events
 	out := testutil.ReadChannel(t, accounterOutput, testTimeout)
-	assert.Equal(t, []Event[*services.ProcessInfo]{
+	assert.Equal(t, []Event[processPorts]{
 		{Type: EventCreated, Obj: p1_1},
 		{Type: EventCreated, Obj: p2},
 		{Type: EventCreated, Obj: p3},
@@ -65,13 +64,13 @@ func TestWatcher_Poll(t *testing.T) {
 	// THEN it returns the creation of the new processes/connections
 	// AND the deletion of the old processes
 	out = testutil.ReadChannel(t, accounterOutput, testTimeout)
-	assert.Equal(t, []Event[*services.ProcessInfo]{
+	assert.Equal(t, []Event[processPorts]{
 		{Type: EventCreated, Obj: p1_2},
 		{Type: EventDeleted, Obj: p2},
 		{Type: EventCreated, Obj: p4},
 	}, sort(out))
 	out = testutil.ReadChannel(t, accounterOutput, testTimeout)
-	assert.Equal(t, []Event[*services.ProcessInfo]{
+	assert.Equal(t, []Event[processPorts]{
 		{Type: EventDeleted, Obj: p1_2},
 		{Type: EventCreated, Obj: p2},
 	}, sort(out))
@@ -80,7 +79,7 @@ func TestWatcher_Poll(t *testing.T) {
 	// THEN it should be also reported
 	// (use case: we want to later match by executable path a client process with short-lived connections)
 	out = testutil.ReadChannel(t, accounterOutput, testTimeout)
-	assert.Equal(t, []Event[*services.ProcessInfo]{
+	assert.Equal(t, []Event[processPorts]{
 		{Type: EventCreated, Obj: p5},
 	}, sort(out))
 
@@ -104,9 +103,9 @@ func TestWatcher_Poll(t *testing.T) {
 }
 
 // auxiliary function just to allow comparing slices whose order is not deterministic
-func sort(events []Event[*services.ProcessInfo]) []Event[*services.ProcessInfo] {
-	slices.SortFunc(events, func(a, b Event[*services.ProcessInfo]) int {
-		return int(a.Obj.Pid) - int(b.Obj.Pid)
+func sort(events []Event[processPorts]) []Event[processPorts] {
+	slices.SortFunc(events, func(a, b Event[processPorts]) int {
+		return int(a.Obj.pid) - int(b.Obj.pid)
 	})
 	return events
 }


### PR DESCRIPTION
in the previous PR, the process watcher eagerly loaded all the process fields (exec, ppid...), even if these processes were going to be discarded later.

Loading process data requires multiple reads from the /proc filesystem. I learned from my past experience with infrastructure agents that, in big hosts with tons of processes and containers, the extraction of process information might represent a noticeable amount of CPU time (even if it is just waiting for IO, the reported CPU consumption is high and users don't like it).

This PR just loads eagerly the minimum required information to pass the first filter: the process ID as well as the process connections, and loads the rest of data when it is going to be accessed (only for these processes that passed the Matcher filter and are not cached by the Watcher).