### PR TITLE
Detect programming language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,9 @@ compile:
 	@echo "### Compiling project"
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags="-X 'main.Version=$(RELEASE_VERSION)'" -a -o bin/$(CMD) $(MAIN_GO_FILE)
 
+.PHONY: dev
+dev: prereqs generate compile-for-coverage
+
 # Generated binary can provide coverage stats according to https://go.dev/blog/integration-test-coverage
 .PHONY: compile-for-coverage
 compile-for-coverage:

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -72,8 +72,8 @@ func (ta *TraceAttacher) getTracer(ie Instrumentable) (*ebpf.ProcessTracer, bool
 		return nil, false
 	}
 
-	technology := exec.FindProcLanguage(ie.FileInfo.Pid, ie.FileInfo.ELF)
-	ie.FileInfo.Service = svc.ID{Name: ie.FileInfo.Service.Name, Namespace: ie.FileInfo.Service.Namespace, Technology: technology}
+	sdkLang := exec.FindProcLanguage(ie.FileInfo.Pid, ie.FileInfo.ELF)
+	ie.FileInfo.Service = svc.ID{Name: ie.FileInfo.Service.Name, Namespace: ie.FileInfo.Service.Namespace, SDKLanguage: sdkLang}
 
 	// Instead of the executable file in the disk, we pass the /proc/<pid>/exec
 	// to allow loading it from different container/pods in containerized environments

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -11,9 +11,11 @@ import (
 	"github.com/mariomac/pipes/pkg/node"
 
 	"github.com/grafana/beyla/pkg/internal/ebpf"
+	"github.com/grafana/beyla/pkg/internal/exec"
 	"github.com/grafana/beyla/pkg/internal/goexec"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/pipe"
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 // TraceAttacher creates the available trace.Tracer implementations (Go HTTP tracer, GRPC tracer, Generic tracer...)
@@ -69,6 +71,9 @@ func (ta *TraceAttacher) getTracer(ie Instrumentable) (*ebpf.ProcessTracer, bool
 		ta.log.Warn("no instrumentable functions found. Ignoring", "pid", ie.FileInfo.Pid, "cmd", ie.FileInfo.CmdExePath)
 		return nil, false
 	}
+
+	technology := exec.FindProcLanguage(ie.FileInfo.Pid, ie.FileInfo.ELF)
+	ie.FileInfo.Service = svc.ID{Name: ie.FileInfo.Service.Name, Namespace: ie.FileInfo.Service.Namespace, Technology: technology}
 
 	// Instead of the executable file in the disk, we pass the /proc/<pid>/exec
 	// to allow loading it from different container/pods in containerized environments

--- a/pkg/internal/discover/watcher.go
+++ b/pkg/internal/discover/watcher.go
@@ -190,7 +190,7 @@ func fetchProcesses(processes map[int32]*services.ProcessInfo) error {
 	}
 	for _, proc := range procs {
 		if pi, err := processInfo(proc); err != nil {
-			wplog().Warn("can't get process information", "pid", proc.Pid, "error", err)
+			wplog().Debug("can't get process information", "pid", proc.Pid, "error", err)
 		} else {
 			conns, _ := proc.Connections()
 			for _, conn := range conns {

--- a/pkg/internal/ebpf/httpfltr/httpfltr.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr.go
@@ -435,8 +435,8 @@ func (p *Tracer) serviceInfo(pid uint32) svc.ID {
 	}
 
 	name := p.commName(pid)
-	tech := exec.FindProcLanguage(int32(pid), nil)
-	result := svc.ID{Name: name, Technology: tech}
+	lang := exec.FindProcLanguage(int32(pid), nil)
+	result := svc.ID{Name: name, SDKLanguage: lang}
 
 	activePids.Add(pid, result)
 

--- a/pkg/internal/ebpf/httpfltr/httpfltr_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 const bufSize = 160
@@ -115,6 +116,7 @@ func TestToRequestTrace(t *testing.T) {
 		Start:        123456,
 		End:          789012,
 		HostPort:     1,
+		ServiceID:    svc.ID{SDKLanguage: svc.InstrumentableGeneric},
 	}
 	assert.Equal(t, expected, result)
 }
@@ -149,6 +151,7 @@ func TestToRequestTraceNoConnection(t *testing.T) {
 		End:          789012,
 		Status:       200,
 		HostPort:     7033,
+		ServiceID:    svc.ID{SDKLanguage: svc.InstrumentableGeneric},
 	}
 	assert.Equal(t, expected, result)
 }

--- a/pkg/internal/ebpf/httpfltr/httpfltr_transform.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_transform.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/grafana/beyla/pkg/internal/request"
-	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func httpInfoToSpan(info *HTTPInfo) request.Span {
@@ -21,7 +20,7 @@ func httpInfoToSpan(info *HTTPInfo) request.Span {
 		Start:         int64(info.StartMonotimeNs),
 		End:           int64(info.EndMonotimeNs),
 		Status:        int(info.Status),
-		ServiceID:     svc.ID{Name: info.Comm},
+		ServiceID:     info.Service,
 		Traceparent:   info.Traceparent,
 	}
 }

--- a/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
@@ -42,7 +42,7 @@ func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint
 		Peer:        peer,
 		URL:         path,
 		Host:        host,
-		Service:     svc.ID{Name: comm, SDKLanguage: "c++"},
+		Service:     svc.ID{Name: comm, SDKLanguage: svc.InstrumentableRuby},
 	}
 
 	i.ConnInfo.D_port = uint16(hostPort)
@@ -59,7 +59,7 @@ func assertMatchesInfo(t *testing.T, span *request.Span, method, path, peer, hos
 	assert.Equal(t, peer, span.Peer)
 	assert.Equal(t, status, span.Status)
 	assert.Equal(t, comm, span.ServiceID.Name)
-	assert.Equal(t, "c++", span.ServiceID.SDKLanguage)
+	assert.Equal(t, svc.InstrumentableRuby, span.ServiceID.SDKLanguage)
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.Start))
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.RequestStart))
 }

--- a/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
@@ -42,7 +42,7 @@ func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint
 		Peer:        peer,
 		URL:         path,
 		Host:        host,
-		Service:     svc.ID{Name: comm, Technology: "c++"},
+		Service:     svc.ID{Name: comm, SDKLanguage: "c++"},
 	}
 
 	i.ConnInfo.D_port = uint16(hostPort)
@@ -59,7 +59,7 @@ func assertMatchesInfo(t *testing.T, span *request.Span, method, path, peer, hos
 	assert.Equal(t, peer, span.Peer)
 	assert.Equal(t, status, span.Status)
 	assert.Equal(t, comm, span.ServiceID.Name)
-	assert.Equal(t, "c++", span.ServiceID.Technology)
+	assert.Equal(t, "c++", span.ServiceID.SDKLanguage)
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.Start))
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.RequestStart))
 }

--- a/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_transform_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func TestHTTPInfoParsing(t *testing.T) {
@@ -41,7 +42,7 @@ func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint
 		Peer:        peer,
 		URL:         path,
 		Host:        host,
-		Comm:        comm,
+		Service:     svc.ID{Name: comm, Technology: "c++"},
 	}
 
 	i.ConnInfo.D_port = uint16(hostPort)
@@ -58,6 +59,7 @@ func assertMatchesInfo(t *testing.T, span *request.Span, method, path, peer, hos
 	assert.Equal(t, peer, span.Peer)
 	assert.Equal(t, status, span.Status)
 	assert.Equal(t, comm, span.ServiceID.Name)
+	assert.Equal(t, "c++", span.ServiceID.Technology)
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.Start))
 	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.RequestStart))
 }

--- a/pkg/internal/exec/proclang.go
+++ b/pkg/internal/exec/proclang.go
@@ -1,0 +1,33 @@
+package exec
+
+import (
+	"strings"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
+)
+
+func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
+	if strings.Contains(moduleName, "libcoreclr.so") {
+		return svc.InstrumentableDotnet
+	} else if strings.Contains(moduleName, "libjvm.so") {
+		return svc.InstrumentableJava
+	} else if strings.HasSuffix(moduleName, "/node") || moduleName == "node" {
+		return svc.InstrumentableNodejs
+	} else if strings.HasSuffix(moduleName, "/ruby") || moduleName == "ruby" {
+		return svc.InstrumentableRuby
+	} else if strings.Contains(moduleName, "/python") || moduleName == "python" || moduleName == "python3" {
+		return svc.InstrumentablePython
+	}
+
+	return svc.InstrumentableGeneric
+}
+
+func instrumentableFromSymbolName(symbol string) svc.InstrumentableType {
+	if strings.Contains(symbol, "rust_panic") {
+		return svc.InstrumentableRust
+	} else if strings.HasPrefix(symbol, "JVM_") || strings.HasPrefix(symbol, "graal_") {
+		return svc.InstrumentableJava
+	}
+
+	return svc.InstrumentableGeneric
+}

--- a/pkg/internal/exec/proclang_darwin.go
+++ b/pkg/internal/exec/proclang_darwin.go
@@ -2,9 +2,11 @@ package exec
 
 import (
 	"debug/elf"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
-func FindProcLanguage(pid int32, elfF *elf.File) string {
+func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 	return ""
 }
 

--- a/pkg/internal/exec/proclang_darwin.go
+++ b/pkg/internal/exec/proclang_darwin.go
@@ -2,12 +2,10 @@ package exec
 
 import (
 	"debug/elf"
-
-	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
-func FindProcLanguage(pid int32) string {
-	return svc.Unknown
+func FindProcLanguage(pid int32, elfF *elf.File) string {
+	return ""
 }
 
 func FindExeSymbols(f *elf.File) (map[string]Sym, error) {

--- a/pkg/internal/exec/proclang_darwin.go
+++ b/pkg/internal/exec/proclang_darwin.go
@@ -1,0 +1,15 @@
+package exec
+
+import (
+	"debug/elf"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
+)
+
+func FindProcLanguage(pid int32) string {
+	return svc.Unknown
+}
+
+func FindExeSymbols(f *elf.File) (map[string]Sym, error) {
+	return nil
+}

--- a/pkg/internal/exec/proclang_linux.go
+++ b/pkg/internal/exec/proclang_linux.go
@@ -1,0 +1,105 @@
+package exec
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+	"strings"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+func FindProcLanguage(pid int32, elfF *elf.File) string {
+	maps, err := FindLibMaps(pid)
+
+	if err != nil {
+		return ""
+	}
+
+	for _, m := range maps {
+		if strings.Contains(m.Pathname, "libcoreclr.so") {
+			return semconv.TelemetrySDKLanguageDotnet.Value.AsString()
+		} else if strings.Contains(m.Pathname, "libjvm.so") {
+			return semconv.TelemetrySDKLanguageJava.Value.AsString()
+		} else if strings.HasSuffix(m.Pathname, "/node") {
+			return semconv.TelemetrySDKLanguageNodejs.Value.AsString()
+		} else if strings.HasSuffix(m.Pathname, "/ruby") {
+			return semconv.TelemetrySDKLanguageRuby.Value.AsString()
+		} else if strings.Contains(m.Pathname, "/python") {
+			return semconv.TelemetrySDKLanguagePython.Value.AsString()
+		}
+	}
+
+	if elfF == nil {
+		pidPath := fmt.Sprintf("/proc/%d/exe", pid)
+		elfF, err = elf.Open(pidPath)
+
+		if err != nil || elfF == nil {
+			return ""
+		}
+	}
+
+	return findLanguageFromElf(elfF)
+}
+
+func findLanguageFromElf(elfF *elf.File) string {
+	gosyms := elfF.Section(".gosymtab")
+
+	if gosyms != nil {
+		return semconv.TelemetrySDKLanguageGo.Value.AsString()
+	}
+
+	if allSyms, err := FindExeSymbols(elfF); err == nil {
+		for name := range allSyms {
+			if strings.Contains(name, "rust_panic") {
+				return "rust"
+			} else if strings.HasPrefix(name, "JVM_") || strings.HasPrefix(name, "graal_") {
+				return semconv.TelemetrySDKLanguageJava.Value.AsString()
+			}
+		}
+	}
+
+	return ""
+}
+
+func FindExeSymbols(f *elf.File) (map[string]Sym, error) {
+	addresses := map[string]Sym{}
+	syms, err := f.Symbols()
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return nil, err
+	}
+
+	dynsyms, err := f.DynamicSymbols()
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return nil, err
+	}
+
+	syms = append(syms, dynsyms...)
+
+	for _, s := range syms {
+		if elf.ST_TYPE(s.Info) != elf.STT_FUNC {
+			// Symbol not associated with a function or other executable code.
+			continue
+		}
+
+		address := s.Value
+		var p *elf.Prog
+
+		// Loop over ELF segments.
+		for _, prog := range f.Progs {
+			// Skip uninteresting segments.
+			if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
+				continue
+			}
+
+			if prog.Vaddr <= s.Value && s.Value < (prog.Vaddr+prog.Memsz) {
+				address = s.Value - prog.Vaddr + prog.Off
+				p = prog
+				break
+			}
+		}
+		addresses[s.Name] = Sym{Off: address, Len: s.Size, Prog: p}
+	}
+
+	return addresses, nil
+}

--- a/pkg/internal/exec/proclang_test.go
+++ b/pkg/internal/exec/proclang_test.go
@@ -3,8 +3,9 @@ package exec
 import (
 	"testing"
 
-	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func TestModuleDetection(t *testing.T) {

--- a/pkg/internal/exec/proclang_test.go
+++ b/pkg/internal/exec/proclang_test.go
@@ -1,0 +1,34 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleDetection(t *testing.T) {
+	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromModuleMap("/usr/lib\\//libcoreclr.so/dklksjdf"))
+	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromModuleMap("libcoreclr.so"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromModuleMap("/usr/lib\\//clr.so/dklksjdf"))
+	assert.Equal(t, svc.InstrumentableJava, instrumentableFromModuleMap("/usr/lib\\//libjvm.so/dklksjdf"))
+	assert.Equal(t, svc.InstrumentableJava, instrumentableFromModuleMap("libjvm.so"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromModuleMap("/usr/lib\\//libj9vm25.so/dklksjdf")) // OpenJDK only for now
+	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("/usr/bin/node"))
+	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("node"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("ruby"))
+	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("/usr/bin/python3.18"))
+	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("python"))
+	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("/usr/bin/python"))
+	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("python3"))
+}
+
+func TestSymbolDetection(t *testing.T) {
+	assert.Equal(t, svc.InstrumentableRust, instrumentableFromSymbolName("rust_panic"))
+	assert.Equal(t, svc.InstrumentableRust, instrumentableFromSymbolName("ZN387639_rust_panic_.NAME"))
+	assert.Equal(t, svc.InstrumentableJava, instrumentableFromSymbolName("JVM_2398743897"))
+	assert.Equal(t, svc.InstrumentableJava, instrumentableFromSymbolName("graal_testing"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("graal"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("rust"))
+}

--- a/pkg/internal/exec/procsym.go
+++ b/pkg/internal/exec/procsym.go
@@ -1,0 +1,9 @@
+package exec
+
+import "debug/elf"
+
+type Sym struct {
+	Off  uint64
+	Len  uint64
+	Prog *elf.Prog
+}

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -51,14 +51,19 @@ var DefaultBuckets = Buckets{
 }
 
 func otelResource(service svc.ID) *resource.Resource {
+	telemetrySDK := semconv.TelemetrySDKLanguageGo
+
+	if service.Technology != "" {
+		telemetrySDK = semconv.TelemetrySDKLanguageKey.String(service.Technology)
+	}
+
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(service.Name),
 		// SpanMetrics requires an extra attribute besides service name
 		// to generate the traces_target_info metric,
 		// so the service is visible in the ServicesList
 		// This attribute also allows that App O11y plugin shows this app as a Go application.
-		// TODO: detect the runtime of the target executable and set this value accordingly
-		semconv.TelemetrySDKLanguageGo,
+		telemetrySDK,
 	}
 
 	if service.Namespace != "" {

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -51,11 +51,7 @@ var DefaultBuckets = Buckets{
 }
 
 func otelResource(service svc.ID) *resource.Resource {
-	telemetrySDK := semconv.TelemetrySDKLanguageGo
-
-	if service.SDKLanguage != "" {
-		telemetrySDK = semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage)
-	}
+	telemetrySDK := semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String())
 
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(service.Name),

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -53,8 +53,8 @@ var DefaultBuckets = Buckets{
 func otelResource(service svc.ID) *resource.Resource {
 	telemetrySDK := semconv.TelemetrySDKLanguageGo
 
-	if service.Technology != "" {
-		telemetrySDK = semconv.TelemetrySDKLanguageKey.String(service.Technology)
+	if service.SDKLanguage != "" {
+		telemetrySDK = semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage)
 	}
 
 	attrs := []attribute.KeyValue{

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -334,10 +334,6 @@ func (r *TracesReporter) traceAttributes(span *request.Span) []attribute.KeyValu
 		}
 	}
 
-	if span.ServiceID.Name != "" { // we don't have service name set, system wide instrumentation
-		attrs = append(attrs, semconv.ServiceName(span.ServiceID.Name))
-	}
-
 	// append extra metadata
 	for key, val := range span.Metadata {
 		attrs = append(attrs, attribute.String(key, val))

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -111,7 +111,7 @@ func TestTracerPipeline(t *testing.T) {
 	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
 	matchInnerTraceEvent(t, "processing", event)
 	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
-	matchTraceEvent(t, "bar-svc", "GET", event)
+	matchTraceEvent(t, "GET", event)
 }
 
 func TestRouteConsolidation(t *testing.T) {
@@ -263,7 +263,7 @@ func TestTraceGRPCPipeline(t *testing.T) {
 	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
 	matchInnerGRPCTraceEvent(t, "processing", event)
 	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
-	matchGRPCTraceEvent(t, "svc", "foo.bar", event)
+	matchGRPCTraceEvent(t, "foo.bar", event)
 }
 
 func TestNestedSpanMatching(t *testing.T) {
@@ -405,11 +405,10 @@ func getHostname() string {
 	return hostname
 }
 
-func matchTraceEvent(t require.TestingT, svcName, name string, event collector.TraceRecord) {
+func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecord) {
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
 		Attributes: map[string]string{
-			string(semconv.ServiceNameKey):              svcName,
 			string(semconv.HTTPMethodKey):               "GET",
 			string(semconv.HTTPStatusCodeKey):           "404",
 			string(semconv.HTTPTargetKey):               "/foo/bar",
@@ -435,11 +434,10 @@ func matchInnerTraceEvent(t require.TestingT, name string, event collector.Trace
 	}, event)
 }
 
-func matchGRPCTraceEvent(t *testing.T, svcName, name string, event collector.TraceRecord) {
+func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
 		Attributes: map[string]string{
-			string(semconv.ServiceNameKey):       svcName,
 			string(semconv.RPCSystemKey):         "grpc",
 			string(semconv.RPCGRPCStatusCodeKey): "3",
 			string(semconv.RPCMethodKey):         "foo.bar",
@@ -503,9 +501,8 @@ func matchInfoEvent(t *testing.T, name string, event collector.TraceRecord) {
 			string(semconv.NetHostNameKey):              getHostname(),
 			string(semconv.NetHostPortKey):              "8080",
 			string(semconv.HTTPRequestContentLengthKey): "0",
-			"span_id":                      event.Attributes["span_id"],
-			"parent_span_id":               "",
-			string(semconv.ServiceNameKey): "comm",
+			"span_id":        event.Attributes["span_id"],
+			"parent_span_id": "",
 		},
 		Kind: ptrace.SpanKindServer,
 	}, event)

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -1,11 +1,49 @@
 package svc
 
+import semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+
+type InstrumentableType int
+
+const (
+	InstrumentableGolang = InstrumentableType(iota)
+	InstrumentableJava
+	InstrumentableDotnet
+	InstrumentablePython
+	InstrumentableRuby
+	InstrumentableNodejs
+	InstrumentableRust
+	InstrumentableGeneric
+)
+
+func (it InstrumentableType) String() string {
+	switch it {
+	case InstrumentableGolang:
+		return semconv.TelemetrySDKLanguageGo.Value.AsString()
+	case InstrumentableJava:
+		return semconv.TelemetrySDKLanguageJava.Value.AsString()
+	case InstrumentableDotnet:
+		return semconv.TelemetrySDKLanguageDotnet.Value.AsString()
+	case InstrumentablePython:
+		return semconv.TelemetrySDKLanguagePython.Value.AsString()
+	case InstrumentableRuby:
+		return semconv.TelemetrySDKLanguageRuby.Value.AsString()
+	case InstrumentableNodejs:
+		return semconv.TelemetrySDKLanguageNodejs.Value.AsString()
+	case InstrumentableRust:
+		return "rust"
+	case InstrumentableGeneric:
+		return "generic"
+	default:
+		return "unknown(bug!)"
+	}
+}
+
 // ID stores the coordinates that uniquely identifies a service:
 // its name and optionally a namespace
 type ID struct {
 	Name        string
 	Namespace   string
-	SDKLanguage string
+	SDKLanguage InstrumentableType
 }
 
 func (i *ID) String() string {

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -3,8 +3,9 @@ package svc
 // ID stores the coordinates that uniquely identifies a service:
 // its name and optionally a namespace
 type ID struct {
-	Name      string
-	Namespace string
+	Name       string
+	Namespace  string
+	Technology string
 }
 
 func (i *ID) String() string {

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -3,9 +3,9 @@ package svc
 // ID stores the coordinates that uniquely identifies a service:
 // its name and optionally a namespace
 type ID struct {
-	Name       string
-	Namespace  string
-	Technology string
+	Name        string
+	Namespace   string
+	SDKLanguage string
 }
 
 func (i *ID) String() string {

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -101,7 +101,6 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "rust"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
-		{Key: "service.name", Type: "string", Value: comm},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -99,8 +99,9 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url string, comm string, por
 	assert.Equal(t, comm, process.ServiceName)
 	sd = jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
-		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
+		{Key: "telemetry.sdk.language", Type: "string", Value: "rust"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
+		{Key: "service.name", Type: "string", Value: comm},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -57,28 +57,6 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		trace = traces[0]
 	}, test.Interval(100*time.Millisecond))
 
-	require.NotNil(t, trace)
-
-	var proc jaeger.Process
-
-	for _, p := range trace.Processes {
-		proc = p
-		break
-	}
-
-	require.Equal(t, "testserver", proc.ServiceName)
-
-	var sdk jaeger.Tag
-
-	for _, t := range proc.Tags {
-		if t.Key == "telemetry.sdk.language" {
-			sdk = t
-		}
-	}
-
-	require.NotNil(t, sdk)
-	require.Equal(t, "go", sdk.Value)
-
 	// Check the information of the parent span
 	res := trace.FindByOperationName("GET /" + slug)
 	require.Len(t, res, 1)
@@ -161,6 +139,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
+		{Key: "service.name", Type: "string", Value: "testserver"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 }
@@ -266,7 +245,6 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 		jaeger.Tag{Key: "rpc.method", Type: "string", Value: "/routeguide.RouteGuide/Debug"},
 		jaeger.Tag{Key: "rpc.system", Type: "string", Value: "grpc"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
-		jaeger.Tag{Key: "service.name", Type: "string", Value: svcName},
 	)
 	assert.Empty(t, sd, sd.String())
 
@@ -318,6 +296,7 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
+		{Key: "service.name", Type: "string", Value: svcName},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
@@ -389,28 +368,6 @@ func testHTTPTracesKProbes(t *testing.T) {
 		trace = traces[0]
 	}, test.Interval(100*time.Millisecond))
 
-	require.NotNil(t, trace)
-
-	var proc jaeger.Process
-
-	for _, p := range trace.Processes {
-		proc = p
-		break
-	}
-
-	require.Equal(t, "node", proc.ServiceName)
-
-	var sdk jaeger.Tag
-
-	for _, t := range proc.Tags {
-		if t.Key == "telemetry.sdk.language" {
-			sdk = t
-		}
-	}
-
-	require.NotNil(t, sdk)
-	require.Equal(t, "nodejs", sdk.Value)
-
 	// Check the information of the parent span
 	res := trace.FindByOperationName("GET /bye")
 	require.Len(t, res, 1)
@@ -438,8 +395,9 @@ func testHTTPTracesKProbes(t *testing.T) {
 	assert.Equal(t, "node", process.ServiceName)
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
-		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
+		{Key: "telemetry.sdk.language", Type: "string", Value: "nodejs"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
+		{Key: "service.name", Type: "string", Value: "node"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 }

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -139,7 +139,6 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
-		{Key: "service.name", Type: "string", Value: "testserver"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 }
@@ -296,7 +295,6 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
-		{Key: "service.name", Type: "string", Value: svcName},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
@@ -397,7 +395,6 @@ func testHTTPTracesKProbes(t *testing.T) {
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "nodejs"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
-		{Key: "service.name", Type: "string", Value: "node"},
 	}, process.Tags)
 	assert.Empty(t, sd, sd.String())
 }

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -57,6 +57,28 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		trace = traces[0]
 	}, test.Interval(100*time.Millisecond))
 
+	require.NotNil(t, trace)
+
+	var proc jaeger.Process
+
+	for _, p := range trace.Processes {
+		proc = p
+		break
+	}
+
+	require.Equal(t, "testserver", proc.ServiceName)
+
+	var sdk jaeger.Tag
+
+	for _, t := range proc.Tags {
+		if t.Key == "telemetry.sdk.language" {
+			sdk = t
+		}
+	}
+
+	require.NotNil(t, sdk)
+	require.Equal(t, "go", sdk.Value)
+
 	// Check the information of the parent span
 	res := trace.FindByOperationName("GET /" + slug)
 	require.Len(t, res, 1)
@@ -366,6 +388,28 @@ func testHTTPTracesKProbes(t *testing.T) {
 		require.Len(t, traces, 1)
 		trace = traces[0]
 	}, test.Interval(100*time.Millisecond))
+
+	require.NotNil(t, trace)
+
+	var proc jaeger.Process
+
+	for _, p := range trace.Processes {
+		proc = p
+		break
+	}
+
+	require.Equal(t, "node", proc.ServiceName)
+
+	var sdk jaeger.Tag
+
+	for _, t := range proc.Tags {
+		if t.Key == "telemetry.sdk.language" {
+			sdk = t
+		}
+	}
+
+	require.NotNil(t, sdk)
+	require.Equal(t, "nodejs", sdk.Value)
 
 	// Check the information of the parent span
 	res := trace.FindByOperationName("GET /bye")


### PR DESCRIPTION
This PR introduces logic to automatically determine the programming language/technology used in the instrumented application.

The logic looks for some common shared libraries first that are found in dotnet, java, node, python and ruby. If none are detected we resort to a deeper inspection of the elf file, looking for specific symbols or symbol sections.

We don't auto set Go when we know we are instrumenting a Go executable, because we can still have a Go executable with the option of disabled Go support.

Closes https://github.com/grafana/beyla/issues/351