### PR TITLE
Avoid duplication/triplication/n-plication of traces for the same process

### DIFF
--- a/pkg/internal/discover/typer.go
+++ b/pkg/internal/discover/typer.go
@@ -109,7 +109,10 @@ func (t *typer) FilterClassify(evs []Event[ProcessMatch]) []Event[Instrumentable
 		// if we found a process and returned its parent, it might be already
 		// instrumented. We skip it in that case
 		if _, ok := t.instrumentedPids[inst.FileInfo.Pid]; !ok {
-			t.log.Info("instrumenting process", "cmd", inst.FileInfo.CmdExePath, "pid", inst.FileInfo.Pid)
+			t.log.Debug(
+				"found an instrumentable process",
+				"type", inst.Type.String(),
+				"exec", inst.FileInfo.CmdExePath, "pid", inst.FileInfo.Pid)
 			out = append(out, Event[Instrumentable]{Type: EventCreated, Obj: inst})
 			t.instrumentedPids[inst.FileInfo.Pid] = struct{}{}
 		}

--- a/test/integration/components/testserver/Dockerfile_duplicate
+++ b/test/integration/components/testserver/Dockerfile_duplicate
@@ -1,0 +1,28 @@
+# Build the testserver binary
+# Docker command must be invoked from the projec root directory
+FROM golang:1.21 as builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# Copy the go manifests and source
+COPY vendor/ vendor/
+COPY test/ test/
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Build
+RUN go build -o testserver ./test/integration/components/testserver/testserver.go
+
+# Create final image from minimal + built binary
+FROM debian:bookworm-slim
+
+WORKDIR /
+COPY --from=builder /src/test/integration/components/testserver/duplicate_testserver.sh .
+COPY --from=builder /src/testserver dupe_testserver
+USER 0:0
+
+CMD [ "sh", "/duplicate_testserver.sh" ]

--- a/test/integration/components/testserver/duplicate_testserver.sh
+++ b/test/integration/components/testserver/duplicate_testserver.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+run_testserver()
+{
+  # prefix for start ports. E.g. 808
+  sp=$1
+  STD_PORT=${1}0 GIN_PORT=${1}1 GORILLA_PORT=${1}2 GORILLA_MID_PORT=${1}3 ./dupe_testserver -port ${1}4
+}
+
+# runs testserver twice
+run_testserver 1808 &
+run_testserver 1809

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -10,6 +10,14 @@ services:
       - "8080:8080"
     environment:
       LOG_LEVEL: DEBUG
+  # another instance of the above image. Used to test the deduplication
+  # of metrics when they come from the same executable file
+  testserver-unused:
+    image: hatest-testserver
+    ports:
+      - "38080:8080"
+    environment:
+      LOG_LEVEL: DEBUG
 
   testserver1:
     build:
@@ -18,6 +26,20 @@ services:
     image: hatest-testserver1
     ports:
       - "8900:8900"
+    environment:
+      LOG_LEVEL: DEBUG
+      
+  # image that runs two instances of the 'testserver' executable
+  # Used to test the deduplication
+  # of metrics when they come from the same executable file
+  testserver-duplicate:
+    build:
+      context: ../..
+      dockerfile: test/integration/components/testserver/Dockerfile_duplicate
+    image: hatest-testserver-duplicate
+    ports:
+      - "18080:18080"
+      - "18090:18090"
     environment:
       LOG_LEVEL: DEBUG
 

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -41,7 +41,12 @@ func TestMultiProcess(t *testing.T) {
 		checkReportedOnlyOnce(t, "http://localhost:18080", "dupe_testserver")
 	})
 
-	t.Run("BPF pinning folders mounted", func(t *testing.T) { testBPFPinningMountedWithCount(t, 5) })
+	t.Run("BPF pinning folders mounted", func(t *testing.T) {
+		// 1 pinned map for testserver and testserver-unused containers
+		// 1 pinned map for testserver1 container
+		// 1 pinned map for all the processes in testserver-duplicate container
+		testBPFPinningMountedWithCount(t, 3)
+	})
 
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
@@ -49,10 +54,10 @@ func TestMultiProcess(t *testing.T) {
 
 // Addresses bug https://github.com/grafana/beyla/issues/370 for Go executables
 // Prevents that two instances of the same process report traces or metrics by duplicate
-func checkReportedOnlyOnce(t *testing.T, baseURl, serviceName string) {
+func checkReportedOnlyOnce(t *testing.T, baseURL, serviceName string) {
 	const path = "/check-only-once"
 	for i := 0; i < 3; i++ {
-		resp, err := http.Get(baseURl + path)
+		resp, err := http.Get(baseURL + path)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/beyla/test/integration/components/docker"
+	"github.com/grafana/beyla/test/integration/components/prom"
+)
+
+func TestMultiProcess(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-multiexec.yml", path.Join(pathOutput, "test-suite-multiexec.log"))
+	// we are going to setup discovery directly in the configuration file
+	compose.Env = append(compose.Env, `EXECUTABLE_NAME=`, `OPEN_PORT=`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("Go RED metrics: usual service", func(t *testing.T) {
+		waitForTestComponents(t, instrumentedServiceStdURL)
+		testREDMetricsForHTTPLibrary(t, instrumentedServiceStdURL, "testserver", "initial-set")
+		// checks that, instrumenting the process from this container,
+		// it doesn't instrument too the process from the other container
+		checkReportedOnlyOnce(t, instrumentedServiceStdURL, "testserver")
+	})
+	t.Run("Go RED metrics: service 1", func(t *testing.T) {
+		waitForTestComponents(t, "http://localhost:8900")
+		testREDMetricsForHTTPLibrary(t, "http://localhost:8900", "rename1", "initial-set")
+		// checks that, instrumenting the process from this container,
+		// it doesn't instrument too the process from the other container
+		checkReportedOnlyOnce(t, "http://localhost:8900", "rename1")
+	})
+	t.Run("Processes in the same host are instrumented once and only once", func(t *testing.T) {
+		waitForTestComponents(t, "http://localhost:18080")
+		checkReportedOnlyOnce(t, "http://localhost:18080", "dupe_testserver")
+	})
+
+	t.Run("BPF pinning folders mounted", func(t *testing.T) { testBPFPinningMountedWithCount(t, 5) })
+
+	require.NoError(t, compose.Close())
+	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
+}
+
+// Addresses bug https://github.com/grafana/beyla/issues/370 for Go executables
+// Prevents that two instances of the same process report traces or metrics by duplicate
+func checkReportedOnlyOnce(t *testing.T, baseURl, serviceName string) {
+	const path = "/check-only-once"
+	for i := 0; i < 3; i++ {
+		resp, err := http.Get(baseURl + path)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`http_server_duration_seconds_count{` +
+			`http_method="GET",` +
+			`http_status_code="200",` +
+			`service_name="` + serviceName + `",` +
+			`http_target="` + path + `"}`)
+		require.NoError(t, err)
+		// check duration_count has 3 calls and all the arguments
+		require.Len(t, results, 1)
+		assert.Equal(t, 3, totalPromCount(t, results))
+	}, test.Interval(1000*time.Millisecond))
+
+}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -377,23 +377,3 @@ func TestSuiteNoRoutes(t *testing.T) {
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
-
-func TestSuite_MultiExec(t *testing.T) {
-	compose, err := docker.ComposeSuite("docker-compose-multiexec.yml", path.Join(pathOutput, "test-suite-multiexec.log"))
-	// we are going to setup discovery directly in the configuration file
-	compose.Env = append(compose.Env, `EXECUTABLE_NAME=`, `OPEN_PORT=`)
-	require.NoError(t, err)
-	require.NoError(t, compose.Up())
-	t.Run("Go RED metrics: usual service", func(t *testing.T) {
-		waitForTestComponents(t, instrumentedServiceStdURL)
-		testREDMetricsForHTTPLibrary(t, instrumentedServiceStdURL, "testserver", "initial-set")
-	})
-	t.Run("Go RED metrics: service 1", func(t *testing.T) {
-		waitForTestComponents(t, "http://localhost:8900")
-		testREDMetricsForHTTPLibrary(t, "http://localhost:8900", "rename1", "initial-set")
-	})
-	t.Run("BPF pinning folders mounted", func(t *testing.T) { testBPFPinningMountedWithCount(t, 2) })
-
-	require.NoError(t, compose.Close())
-	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
-}


### PR DESCRIPTION
Partially fixes bug #370 , by avoiding that the same executable is instrumented multiple times. Now metrics for the same process are not duplicated anymore.

This PR does not fix (will do in another PR):
- Avoid reporting traces from processes that do not match the discovery selection criteria, but their executable has been already instrumented by another process so Beyla keeps reporting information.
