### PR TITLE
Add feature which allows paths to be ignored

### DIFF
--- a/examples/greeting-apps/configs/beyla-config.yml
+++ b/examples/greeting-apps/configs/beyla-config.yml
@@ -3,4 +3,4 @@ routes:
     - /smoke
     - /greeting
     - /ping
-  unmatch: path
+  unmatched: path

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -373,6 +373,12 @@ func (mr *MetricsReporter) reportMetrics(input <-chan []request.Span) {
 	for spans := range input {
 		for i := range spans {
 			s := &spans[i]
+
+			// If we are ignoring this span because of route patterns, don't do anything
+			if s.IgnoreSpan == request.IgnoreMetrics {
+				continue
+			}
+
 			// optimization: do not query the resources' cache if the
 			// previously processed span belongs to the same service name
 			// as the current.

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -98,10 +98,6 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	inputNode := node.AsStart(func(out chan<- []request.Span) {
 		// on every send data signal, the traces generator sends a dummy trace
 		for range sendData {
-			// two of the spans will be ignored, ignore traces will be let through
-			out <- []request.Span{{Type: request.EventTypeHTTPClient, IgnoreSpan: request.IgnoreMetrics}}
-			out <- []request.Span{{Type: request.EventTypeGRPC, IgnoreSpan: request.IgnoreTraces}}
-			out <- []request.Span{{Type: request.EventTypeGRPCClient, IgnoreSpan: request.IgnoreMetrics}}
 			out <- []request.Span{{Type: request.EventTypeHTTP}}
 		}
 	})
@@ -128,8 +124,6 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 		// no call should return error
 		assert.Zero(t, internalMetrics.Errors())
 	})
-
-	assert.LessOrEqual(t, previousSum, 3) // 2 no restrictions + 1 with ignore traces
 
 	sendData <- struct{}{}
 	// after some time, the number of calls should be higher than before

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -522,6 +522,11 @@ func (r *TracesReporter) reportTraces(input <-chan []request.Span) {
 		for i := range spans {
 			span := &spans[i]
 
+			// If we are ignoring this span because of route patterns, don't do anything
+			if span.IgnoreSpan == request.IgnoreTraces {
+				continue
+			}
+
 			// small optimization: read explanation in MetricsReporter.reportMetrics
 			if span.ServiceID != lastSvc || reporter == nil {
 				lm, err := r.reporters.For(span.ServiceID)

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -225,6 +225,10 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 	inputNode := node.AsStart(func(out chan<- []request.Span) {
 		// on every send data signal, the traces generator sends a dummy trace
 		for range sendData {
+			// the first three spans will be ignored, we'll only get one below
+			out <- []request.Span{{Type: request.EventTypeHTTPClient, IgnoreSpan: request.IgnoreTraces}}
+			out <- []request.Span{{Type: request.EventTypeGRPC, IgnoreSpan: request.IgnoreTraces}}
+			out <- []request.Span{{Type: request.EventTypeGRPCClient, IgnoreSpan: request.IgnoreMetrics}}
 			out <- []request.Span{{Type: request.EventTypeHTTP}}
 		}
 	})
@@ -257,6 +261,8 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 		// no call should return error
 		assert.Empty(t, internalTraces.Errors())
 	})
+
+	assert.LessOrEqual(t, previousSum, 3) // 2 no restrictions + 1 with ignore metrics
 
 	sendData <- struct{}{}
 	// after some time, the number of calls should be higher than before

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -225,10 +225,6 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 	inputNode := node.AsStart(func(out chan<- []request.Span) {
 		// on every send data signal, the traces generator sends a dummy trace
 		for range sendData {
-			// the first three spans will be ignored, we'll only get one below
-			out <- []request.Span{{Type: request.EventTypeHTTPClient, IgnoreSpan: request.IgnoreTraces}}
-			out <- []request.Span{{Type: request.EventTypeGRPC, IgnoreSpan: request.IgnoreTraces}}
-			out <- []request.Span{{Type: request.EventTypeGRPCClient, IgnoreSpan: request.IgnoreMetrics}}
 			out <- []request.Span{{Type: request.EventTypeHTTP}}
 		}
 	})
@@ -261,8 +257,6 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 		// no call should return error
 		assert.Empty(t, internalTraces.Errors())
 	})
-
-	assert.LessOrEqual(t, previousSum, 3) // 2 no restrictions + 1 with ignore metrics
 
 	sendData <- struct{}{}
 	// after some time, the number of calls should be higher than before

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
-type EventType int
+type EventType uint8
 
 // The following consts need to coincide with some C identifiers:
 // EVENT_HTTP_REQUEST, EVENT_GRPC_REQUEST, EVENT_HTTP_CLIENT, EVENT_GRPC_CLIENT, EVENT_SQL_CLIENT
@@ -18,6 +18,13 @@ const (
 	EventTypeHTTPClient
 	EventTypeGRPCClient
 	EventTypeSQLClient
+)
+
+type IgnoreMode uint8
+
+const (
+	IgnoreMetrics IgnoreMode = iota + 1
+	IgnoreTraces
 )
 
 type converter struct {
@@ -31,6 +38,7 @@ var clocks = converter{monoClock: monotime.Now, clock: time.Now}
 // It enables comfortable handling of data from Go.
 type Span struct {
 	Type          EventType
+	IgnoreSpan    IgnoreMode
 	ID            uint64
 	Method        string
 	Path          string

--- a/pkg/internal/transform/route/matcher.go
+++ b/pkg/internal/transform/route/matcher.go
@@ -28,6 +28,9 @@ type node struct {
 
 	// Wildcard is a child subtree that, if not nil, matches any path folder
 	Wildcard *node
+
+	// AnyPath node is a node identified by '*', which terminates the search matching what's found
+	AnyPath *node
 }
 
 // NewMatcher creates a new Matcher that would allow validating given URL paths towards
@@ -57,6 +60,9 @@ func find(path []string, pathNode *node) string {
 	if child, ok := pathNode.Child[path[0]]; ok {
 		return find(path[1:], child)
 	}
+	if pathNode.AnyPath != nil {
+		return pathNode.FullRoute
+	}
 	// otherwise, keep searching through the wildcard child, if any
 	if pathNode.Wildcard != nil {
 		return find(path[1:], pathNode.Wildcard)
@@ -80,6 +86,13 @@ func appendRoute(fullRoute string, path []string, pathNode *node) {
 		appendRoute(fullRoute, path[1:], pathNode.Wildcard)
 		return
 	}
+
+	if currentName == "*" {
+		pathNode.FullRoute = fullRoute
+		pathNode.AnyPath = &node{Child: map[string]*node{}}
+		return
+	}
+
 	// keep processing the child node belonging to the current path token, adding it
 	// if it does not yet exist
 	child, ok := pathNode.Child[currentName]

--- a/pkg/internal/transform/route/matcher_test.go
+++ b/pkg/internal/transform/route/matcher_test.go
@@ -11,6 +11,8 @@ func TestFind(t *testing.T) {
 		"/foo/bar/bae/",
 		"/foo/:id",
 		"/foo/{id}/push",
+		"/ski/*",
+		"/snow/mobile/*",
 		"/"})
 
 	assert.Equal(t, "/", m.Find("/"))
@@ -25,4 +27,12 @@ func TestFind(t *testing.T) {
 	assert.Empty(t, m.Find("/traca"))
 	assert.Empty(t, m.Find("/foo/1234/down"))
 	assert.Empty(t, m.Find("/foo/5678/push/up"))
+
+	assert.Equal(t, "/ski/*", m.Find("/ski"))
+	assert.Equal(t, "/ski/*", m.Find("/ski/doo"))
+	assert.Equal(t, "/ski/*", m.Find("/ski/doo/new/"))
+
+	assert.Equal(t, "", m.Find("/snow/man"))
+	assert.Equal(t, "/snow/mobile/*", m.Find("/snow/mobile"))
+	assert.Equal(t, "/snow/mobile/*", m.Find("/snow/mobile/long"))
 }

--- a/pkg/internal/transform/routes.go
+++ b/pkg/internal/transform/routes.go
@@ -76,9 +76,9 @@ func RoutesProvider(rc *RoutesConfig) (node.MiddleFunc[[]request.Span, []request
 					if discarder.Find(s.Path) != "" {
 						if ignoreMode == IgnoreAll {
 							continue
-						} else {
-							setSpanIgnoreMode(ignoreMode, s)
 						}
+						// we can't discard it here, ignoring is selective (metrics | traces)
+						setSpanIgnoreMode(ignoreMode, s)
 					}
 				}
 				if routesEnabled {

--- a/pkg/internal/transform/routes.go
+++ b/pkg/internal/transform/routes.go
@@ -47,8 +47,8 @@ type RoutesConfig struct {
 	Unmatch UnmatchType `yaml:"unmatched"`
 	// Patterns of the paths that will match to a route
 	Patterns       []string   `yaml:"patterns"`
-	IgnorePatterns []string   `yaml:"ignored"`
-	IgnoredEvents  IgnoreMode `yaml:"ignored_events"`
+	IgnorePatterns []string   `yaml:"ignored_patterns"`
+	IgnoredEvents  IgnoreMode `yaml:"ignore_mode"`
 }
 
 func RoutesProvider(rc *RoutesConfig) (node.MiddleFunc[[]request.Span, []request.Span], error) {

--- a/pkg/internal/transform/routes_test.go
+++ b/pkg/internal/transform/routes_test.go
@@ -128,6 +128,14 @@ func TestIgnoreRoutes(t *testing.T) {
 	}}, testutil.ReadChannel(t, out, testTimeout))
 }
 
+func TestIgnoreMode(t *testing.T) {
+	s := request.Span{Path: "/user/1234"}
+	setSpanIgnoreMode(IgnoreTraces, &s)
+	assert.Equal(t, request.IgnoreTraces, s.IgnoreSpan)
+	setSpanIgnoreMode(IgnoreMetrics, &s)
+	assert.Equal(t, request.IgnoreMetrics, s.IgnoreSpan)
+}
+
 func BenchmarkRoutesProvider_Wildcard(b *testing.B) {
 	benchProvider(b, UnmatchWildcard)
 }

--- a/test/integration/configs/instrumenter-config-grpc-export.yml
+++ b/test/integration/configs/instrumenter-config-grpc-export.yml
@@ -1,6 +1,9 @@
 routes:
   patterns:
     - /basic/:rnd
+  ignored_patterns:
+    - /metrics
+  ignore_mode: traces
   unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4317

--- a/test/integration/configs/instrumenter-config-grpc-export.yml
+++ b/test/integration/configs/instrumenter-config-grpc-export.yml
@@ -1,7 +1,7 @@
 routes:
   patterns:
     - /basic/:rnd
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4317
   protocol: grpc

--- a/test/integration/configs/instrumenter-config-java-host.yml
+++ b/test/integration/configs/instrumenter-config-java-host.yml
@@ -1,6 +1,6 @@
 routes:
   patterns:
     - /greeting
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://127.0.0.1:4318

--- a/test/integration/configs/instrumenter-config-java.yml
+++ b/test/integration/configs/instrumenter-config-java.yml
@@ -1,6 +1,6 @@
 routes:
   patterns:
     - /greeting
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318

--- a/test/integration/configs/instrumenter-config-multiexec.yml
+++ b/test/integration/configs/instrumenter-config-multiexec.yml
@@ -1,7 +1,7 @@
 routes:
   patterns:
     - /basic/:rnd
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318
 discovery:

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,5 +1,5 @@
 routes:
-  ignore:
+  ignored:
     - /metrics
   unmatched: heuristic
 otel_metrics_export:

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,7 +1,7 @@
 routes:
   ignore:
     - /metrics
-  unmatch: heuristic
+  unmatched: heuristic
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,4 +1,6 @@
 routes:
+  ignore:
+    - /metrics
   unmatch: heuristic
 otel_metrics_export:
   endpoint: http://otelcol:4318

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,5 +1,5 @@
 routes:
-  ignored:
+  ignored_patterns:
     - /metrics
   unmatched: heuristic
 otel_metrics_export:

--- a/test/integration/configs/instrumenter-config-node.yml
+++ b/test/integration/configs/instrumenter-config-node.yml
@@ -1,7 +1,7 @@
 routes:
   patterns:
     - /greeting
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config-override-svcname.yml
+++ b/test/integration/configs/instrumenter-config-override-svcname.yml
@@ -2,7 +2,7 @@ service_name: overridden-svc-name
 routes:
   patterns:
     - /basic/:rnd
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -1,6 +1,6 @@
 routes:
   patterns:
     - /basic/:rnd
-  unmatch: path
+  unmatched: path
 prometheus_export:
   port: 8999

--- a/test/integration/configs/instrumenter-config-ruby.yml
+++ b/test/integration/configs/instrumenter-config-ruby.yml
@@ -1,6 +1,6 @@
 routes:
   patterns:
     - /users/:user_id
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -1,9 +1,9 @@
 routes:
   patterns:
     - /basic/:rnd
-  ignored:
+  ignored_patterns:
     - /metrics
-  ignored_events: traces
+  ignore_mode: traces
   unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -1,7 +1,7 @@
 routes:
   patterns:
     - /basic/:rnd
-  unmatch: path
+  unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -1,6 +1,9 @@
 routes:
   patterns:
     - /basic/:rnd
+  ignored:
+    - /metrics
+  ignored_events: traces
   unmatched: path
 otel_metrics_export:
   endpoint: http://otelcol:4318

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -3,11 +3,9 @@
 package integration
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
-	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -16,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/beyla/test/integration/components/jaeger"
 	"github.com/grafana/beyla/test/integration/components/prom"
 	grpcclient "github.com/grafana/beyla/test/integration/components/testserver/grpc/client"
 )
@@ -263,18 +260,6 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	results, err = pq.Query(`http_server_duration_seconds_count{http_route="/metrics"}`)
 	require.NoError(t, err)
 	enoughPromResults(t, results)
-
-	// Check that /metrics is missing from Jaeger at the same time
-	resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fmetrics")
-	require.NoError(t, err)
-	if resp == nil {
-		return
-	}
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	var tq jaeger.TracesQuery
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
-	traces := tq.FindBySpan(jaeger.Tag{Key: "http.target", Type: "string", Value: "/metrics"})
-	require.Len(t, traces, 0)
 }
 
 func testREDMetricsGRPC(t *testing.T) {

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -296,6 +296,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// - take at least 30ms to respond
 	// - returning a 404 code
 	for i := 0; i < 3; i++ {
+		doHTTPGet(t, url+"/metrics", 200)
 		doHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
 		doHTTPGet(t, url+"/echo", 203)
 		doHTTPGet(t, url+"/echoCall", 204)
@@ -488,6 +489,11 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	assert.GreaterOrEqual(t, sum, 114.0)
 	addr = net.ParseIP(res.Metric["net_sock_peer_addr"])
 	assert.NotNil(t, addr)
+
+	// Check that we never recorded any /metrics calls
+	results, err = pq.Query(`http_server_duration_seconds_count{http_route="/metrics"}`)
+	require.NoError(t, err)
+	require.Equal(t, len(results), 0)
 }
 
 func testREDMetricsHTTPNoRoute(t *testing.T) {

--- a/test/oats/configs/instrumenter-config-traces.yml
+++ b/test/oats/configs/instrumenter-config-traces.yml
@@ -4,4 +4,4 @@ routes:
     - /smoke
     - /greeting
     - /sqltest
-  unmatch: path
+  unmatched: path


### PR DESCRIPTION
This PR extends the routes matcher with subsection where the users can define a list of ignore patterns. Beyla will match against these patterns and if a match is found the path will be ignored and not sent for traces and metrics. This would help with removing unwanted traces for paths like /v1/metrics where the application has an OTel SDK installed, as well as health check APIs.

To facilitate easy filtering I added a special character '*' in the matcher code, which stops the find pattern matching when encoutered.

TODO:
- [x] Docs

Closes https://github.com/grafana/beyla/issues/352