### PR TITLE
Cut some integration test time

### DIFF
--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -35,7 +35,6 @@ func doHTTPPost(t *testing.T, path string, status int, jsonBody []byte) {
 	r, err := testHTTPClient.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, status, r.StatusCode)
-	time.Sleep(300 * time.Millisecond)
 }
 
 func doHTTPGet(t *testing.T, path string, status int) {
@@ -49,7 +48,6 @@ func doHTTPGet(t *testing.T, path string, status int) {
 	r, err := testHTTPClient.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, status, r.StatusCode)
-	time.Sleep(300 * time.Millisecond)
 }
 
 func doHTTPGetWithTraceparent(t *testing.T, path string, status int, traceparent string) {
@@ -64,7 +62,6 @@ func doHTTPGetWithTraceparent(t *testing.T, path string, status int, traceparent
 	r, err := testHTTPClient.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, status, r.StatusCode)
-	time.Sleep(300 * time.Millisecond)
 }
 
 func createTraceID() string {

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -55,6 +55,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 		traces := tq.FindBySpan(jaeger.Tag{Key: "http.target", Type: "string", Value: "/" + slug})
 		require.Len(t, traces, 1)
 		trace = traces[0]
+		require.Len(t, trace.Spans, 3) // parent - in queue - processing
 	}, test.Interval(100*time.Millisecond))
 
 	// Check the information of the parent span
@@ -237,6 +238,7 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 		traces := tq.FindBySpan(jaeger.Tag{Key: "rpc.method", Type: "string", Value: "/routeguide.RouteGuide/Debug"})
 		require.Len(t, traces, 1)
 		trace = traces[0]
+		require.Len(t, trace.Spans, 3) // parent - in queue - processing
 	}, test.Interval(100*time.Millisecond))
 
 	// Check the information of the parent span


### PR DESCRIPTION
The `TestSuite/HTTP_traces_(bad_traceparent)` test took 100s. I reorganized it to take around 5 seconds.

Removed some `thread.Sleep` that should not be necessary.

We cut around ~2 minutes.
<img width="136" alt="image" src="https://github.com/grafana/beyla/assets/939550/a46eb0dd-8947-416c-8e03-973869d797d4">


