### PR TITLE
Add workflow to publish release documentation

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -3,11 +3,11 @@ name: publish-technical-documentation-release
 on:
   push:
     branches:
-      - <BRANCH GLOB>
+      - 'release-*'
     tags:
-      - <TAG GLOB>
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
-      - "docs/sources/**"
+      - 'docs/sources/**'
   workflow_dispatch:
 jobs:
   sync:
@@ -33,8 +33,8 @@ jobs:
         uses: ./actions/has-matching-release-tag
         with:
           ref_name: ${{ github.ref_name }}
-          release_tag_regexp: <TAG REGEXP>
-          release_branch_regexp: <BRANCH REGEXP>
+          release_tag_regexp: '^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'
+          release_branch_regexp: '^release-v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'
 
       - name: Determine technical documentation version
         if: steps.has-matching-release-tag.outputs.bool == 'true'

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,0 +1,74 @@
+name: publish-technical-documentation-release
+
+on:
+  push:
+    branches:
+      - <BRANCH GLOB>
+    tags:
+      - <TAG GLOB>
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: github.repository == 'grafana/grafana'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Grafana repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Actions library
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/grafana-github-actions
+          path: ./actions
+
+      - name: Install Actions from library
+        run: npm install --production --prefix ./actions
+
+      - name: Determine if there is a matching release tag
+        id: has-matching-release-tag
+        uses: ./actions/has-matching-release-tag
+        with:
+          ref_name: ${{ github.ref_name }}
+          release_tag_regexp: <TAG REGEXP>
+          release_branch_regexp: <BRANCH REGEXP>
+
+      - name: Determine technical documentation version
+        if: steps.has-matching-release-tag.outputs.bool == 'true'
+        uses: ./actions/docs-target
+        id: target
+        with:
+          ref_name: ${{ github.ref_name }}
+
+      - name: Clone website-sync Action
+        if: steps.has-matching-release-tag.outputs.bool == 'true'
+        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+
+      - name: Switch to HEAD of version branch for tags
+        # Tags aren't necessarily made to the HEAD of the version branch.
+        # The documentation to be published is always on the HEAD of the version branch.
+        if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
+        run: git switch --detach origin/${{ steps.target.output.target }}.x
+
+      - name: Publish to website repository (release)
+        if: steps.has-matching-release-tag.outputs.bool == 'true'
+        uses: ./.github/actions/website-sync
+        id: publish-release
+        with:
+          repository: grafana/website
+          branch: master
+          host: github.com
+          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+          # GitHub administrator to update the organization secret.
+          # The IT helpdesk can update the organization secret.
+          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
+          source_folder: docs/sources
+          target_folder: content/docs/beyla/${{ steps.target.outputs.target }}.x


### PR DESCRIPTION
Introduces an automated publishing workflow for docs committed to release branches.

It publishes documentation from release branches that have the `release-` prefix but only if there has been a matching tag made on that branch.
That way, you can work on a release branch to prepare documentation and code for the next release without worrying about prematurely publishing documentation.

For more information about the `docs-target` action, refer to https://github.com/grafana/grafana-github-actions/blob/main/docs-target/action.yaml.

For more information about the `has-matching-release-tag` action, refer to https://github.com/grafana/grafana-github-actions/blob/main/has-matching-release-tag/action.yaml.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

Close #319