### PR TITLE
Avoid instrumenting service managers

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -112,6 +112,10 @@ func (ta *TraceAttacher) getTracer(ie *Instrumentable) (*ebpf.ProcessTracer, boo
 		PinPath:    ta.buildPinPath(ie),
 		SystemWide: ta.Cfg.Discovery.SystemWide,
 	}
+	ta.log.Debug("new executable for discovered process",
+		"pid", ie.FileInfo.Pid,
+		"child", ie.ChildPids,
+		"exec", ie.FileInfo.CmdExePath)
 	// allowing the tracer to forward traces from the discovered PID and its children processes
 	tracer.AllowPID(uint32(ie.FileInfo.Pid))
 	for _, pid := range ie.ChildPids {


### PR DESCRIPTION
We always look for the parent/grandparent PID to avoid instrumenting many times the same executable when it is forked into many processes.

However, looking indiscriminately for the parent/grandparent PIDs without making sure they are all the same executable, might lead to end up instrumenting service managers such as systemd, if they launched the discovered process.