### PR TITLE
Fix nil-pointer panics on missing executable sections

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -157,6 +157,9 @@ func (ta *TraceAttacher) notifyProcessDeletion(ie *Instrumentable) {
 // filterNotFoundPrograms will filter these programs whose required functions (as
 // returned in the Offsets method) haven't been found in the offsets
 func filterNotFoundPrograms(programs []ebpf.Tracer, offsets *goexec.Offsets) []ebpf.Tracer {
+	if offsets == nil {
+		return nil
+	}
 	var filtered []ebpf.Tracer
 	funcs := offsets.Funcs
 programs:

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -130,7 +130,12 @@ func findGoSymbolTable(elfF *elf.File) (*gosym.Table, error) {
 			return nil, fmt.Errorf("acquiring .gopclntab data: %w", err)
 		}
 	}
-	pcln := gosym.NewLineTable(pclndat, elfF.Section(".text").Addr)
+	txtSection := elfF.Section(".text")
+	if txtSection == nil {
+		return nil, fmt.Errorf("can't find .text section in ELF file")
+	}
+
+	pcln := gosym.NewLineTable(pclndat, txtSection.Addr)
 	// First argument accepts the .gosymtab ELF section.
 	// Since Go 1.3, .gosymtab is empty so we just pass an nil slice
 	symTab, err := gosym.NewTable(nil, pcln)


### PR DESCRIPTION
Running in DaemonSet mode and trying to instrument all the executables in the system, Beyla can find some executables with missing parts or sections that would make Beyla crash when accessing to their handler structs.