### PR TITLE
Fix how we track user pids, more tests

### DIFF
--- a/pkg/internal/ebpf/common/pids_darwin.go
+++ b/pkg/internal/ebpf/common/pids_darwin.go
@@ -1,4 +1,4 @@
-package httpfltr
+package ebpfcommon
 
 func findNamespace(_ int32) (uint32, error) {
 	// convenience method to allow unit tests compiling in Darwin

--- a/pkg/internal/ebpf/common/pids_linux.go
+++ b/pkg/internal/ebpf/common/pids_linux.go
@@ -1,4 +1,4 @@
-package httpfltr
+package ebpfcommon
 
 import (
 	"bufio"
@@ -10,7 +10,7 @@ import (
 	"syscall"
 )
 
-func findNamespace(pid int32) (uint32, error) {
+func FindNamespace(pid int32) (uint32, error) {
 	pidPath := fmt.Sprintf("/proc/%d/ns/pid", pid)
 	f, err := os.Open(pidPath)
 
@@ -49,7 +49,7 @@ func findNamespace(pid int32) (uint32, error) {
 	return 0, fmt.Errorf("couldn't find ns pid in the symlink [%s]", nsPid)
 }
 
-func findNamespacedPids(pid int32) ([]uint32, error) {
+func FindNamespacedPids(pid int32) ([]uint32, error) {
 	statusPath := fmt.Sprintf("/proc/%d/status", pid)
 	f, err := os.Open(statusPath)
 

--- a/test/integration/components/pythonserver/Dockerfile_8083
+++ b/test/integration/components/pythonserver/Dockerfile_8083
@@ -1,0 +1,14 @@
+# Dockerfile that will build a container that runs python flask with gunicorn on port 8080
+FROM python:3.11.6-slim
+EXPOSE 8083
+RUN pip install flask gunicorn
+# Alternative: RUN pip install flask uwsgi
+
+# Set the working directory to /build
+WORKDIR /
+
+# Copy the source code into the image for building
+COPY test/integration/components/pythonserver .
+
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8083", "main_8083:app"]
+# CMD uwsgi --http 0.0.0.0:8080 --master -p 4 -w main:app

--- a/test/integration/components/pythonserver/main_8083.py
+++ b/test/integration/components/pythonserver/main_8083.py
@@ -1,0 +1,33 @@
+from flask import Flask, request, Response
+import os
+import click
+
+app = Flask(__name__)
+
+
+@app.cli.command("hello")
+@click.argument("name")
+def create_user(name):
+    print(f"Hello {name}")
+
+@app.cli.command("migrate")
+@click.argument("name")
+def create_user(name):
+    print(f"Nothing to migrate for {name}")
+
+@app.route("/smoke")
+def smoke():
+    return Response(status=200)
+
+@app.route("/greeting")
+def ping():
+    return "PONG!"
+
+@app.route("/users", methods=['POST'])
+def users():
+    content = request.json
+    return content
+
+if __name__ == '__main__':
+    print(f"Server running: port={8083} process_id={os.getpid()}")
+    app.run(host="localhost", port=8083, debug=False)

--- a/test/integration/k8s/common/k8s_common.go
+++ b/test/integration/k8s/common/k8s_common.go
@@ -10,9 +10,10 @@ var (
 	PathComponents      = path.Join(PathIntegrationTest, "components")
 	PathManifests       = path.Join(PathIntegrationTest, "k8s", "manifests")
 
-	DockerfileTestServer = path.Join(PathComponents, "testserver", "Dockerfile")
-	DockerfileBeyla      = path.Join(PathComponents, "beyla", "Dockerfile")
-	DockerfilePinger     = path.Join(PathComponents, "grpcpinger", "Dockerfile")
+	DockerfileTestServer       = path.Join(PathComponents, "testserver", "Dockerfile")
+	DockerfileBeyla            = path.Join(PathComponents, "beyla", "Dockerfile")
+	DockerfilePinger           = path.Join(PathComponents, "grpcpinger", "Dockerfile")
+	DockerfilePythonTestServer = path.Join(PathComponents, "pythonserver", "Dockerfile_8083")
 
 	PingerManifest     = path.Join(PathManifests, "/06-instrumented-client.template.yml")
 	GrpcPingerManifest = path.Join(PathManifests, "/06-instrumented-grpc-client.template.yml")

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package otel
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/beyla/test/integration/components/docker"
+	"github.com/grafana/beyla/test/integration/components/kube"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/tools"
+)
+
+const (
+	testTimeout = 2 * time.Minute
+
+	jaegerQueryURL = "http://localhost:36686/api/traces"
+)
+
+var cluster *kube.Kind
+
+func TestMain(m *testing.M) {
+	if err := docker.Build(os.Stdout, tools.ProjectDir(),
+		docker.ImageBuild{Tag: "pythontestserver:dev", Dockerfile: k8s.DockerfilePythonTestServer},
+		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
+	); err != nil {
+		slog.Error("can't build docker images", err)
+		os.Exit(-1)
+	}
+
+	cluster = kube.NewKind("test-kind-cluster-otel-python",
+		kube.ExportLogs(k8s.PathKindLogs),
+		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.LocalImage("pythontestserver:dev"),
+		kube.LocalImage("beyla:dev"),
+		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
+		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
+		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
+		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service-python.yml"),
+		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset-python.yml"),
+	)
+
+	cluster.Run(m)
+}

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package otel
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/grafana/beyla/test/integration/components/jaeger"
+)
+
+// For the DaemonSet scenario, we only check that Beyla is able to instrument any
+// process in the system. We just check that traces are properly generated without
+// entering in too many details
+func TestBasicTracing(t *testing.T) {
+	feat := features.New("Beyla is able to instrument an arbitrary process").
+		Assess("it sends traces for that service",
+			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+				var trace jaeger.Trace
+				test.Eventually(t, testTimeout, func(t require.TestingT) {
+					resp, err := http.Get("http://localhost:38083/greeting")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+
+					resp, err = http.Get(jaegerQueryURL + "?service=python3.11&operation=GET%20%2Fgreeting")
+					require.NoError(t, err)
+					if resp == nil {
+						return
+					}
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+					var tq jaeger.TracesQuery
+					require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+					traces := tq.FindBySpan(jaeger.Tag{Key: "http.target", Type: "string", Value: "/greeting"})
+					require.NotEmpty(t, traces)
+					trace = traces[0]
+					require.NotEmpty(t, trace.Spans)
+
+					// Check the information of the parent span
+					res := trace.FindByOperationName("GET /greeting")
+					require.Len(t, res, 1)
+					parent := res[0]
+					sd := jaeger.Diff([]jaeger.Tag{
+						{Key: "service.namespace", Type: "string", Value: "integration-test"},
+						{Key: "telemetry.sdk.language", Type: "string", Value: "python"},
+					}, trace.Processes[parent.ProcessID].Tags)
+					require.Empty(t, sd, sd.String())
+				}, test.Interval(100*time.Millisecond))
+				return ctx
+			},
+		).Feature()
+	cluster.TestEnv().Test(t, feat)
+}

--- a/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pytestserver
+spec:
+  selector:
+    app: pytestserver
+  ports:
+    - port: 8083
+      name: http0
+      targetPort: http0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pytestserver
+  labels:
+    app: pytestserver
+spec:
+  containers:
+    - name: pytestserver
+      image: pythontestserver:dev
+      imagePullPolicy: Never # loaded into Kind from localhost
+      ports:
+        # exposing hostports to enable operation from tests
+        - containerPort: 8083
+          hostPort: 8083
+          name: http0
+      env:
+        - name: LOG_LEVEL
+          value: "DEBUG"

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -8,14 +8,10 @@ data:
     log_level: debug
     discovery:
       services:
-        - exe_path_regexp: testserver
+        - open_ports: 8083
           namespace: integration-test
     routes:
-      patterns:
-        - /pingpong
-      ignored_patterns:
-        - /metrics
-      unmatched: path
+      unmatched: heuristic
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -1,0 +1,122 @@
+# TODO: Need to document the ServiceAccount needs. Beyla requires to setup a service account
+# and roles to watch and get information about Nodes, Services, ReplicaSets and Pods
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: beyla
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: beyla
+rules:
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["services", "pods", "nodes"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: beyla
+subjects:
+  - kind: ServiceAccount
+    name: beyla
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: beyla
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testserver
+spec:
+  selector:
+    app: testserver
+  ports:
+    - port: 8080
+      name: http0
+      targetPort: http0
+    - port: 8081
+      name: http1
+      targetPort: http1
+    - port: 8082
+      name: http2
+      targetPort: http2
+    - port: 8083
+      name: http
+      targetPort: http3
+    - port: 50051
+      name: grpc
+      targetPort: grpc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testserver
+  labels:
+    app: testserver
+spec:
+  shareProcessNamespace: true
+  serviceAccountName: beyla
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+    - name: testoutput
+      persistentVolumeClaim:
+        claimName: testoutput
+  containers:
+    - name: testserver
+      image: pythontestserver:dev
+      imagePullPolicy: Never # loaded into Kind from localhost
+      ports:
+        # exposing hostports to enable operation from tests
+        - containerPort: 8080
+          hostPort: 8080
+          name: http0
+      env:
+        - name: LOG_LEVEL
+          value: "DEBUG"
+    - name: beyla
+      image: beyla:dev
+      imagePullPolicy: Never # loaded into Kind from localhost
+      securityContext:
+        privileged: true
+      command: ["/beyla", "--config=/configs/instrumenter-config.yml"]
+      volumeMounts:
+        - mountPath: /configs
+          name: configs
+        - mountPath: /testoutput
+          name: testoutput
+      env:
+        - name: GOCOVERDIR
+          value: "/testoutput"
+        - name: PRINT_TRACES
+          value: "true"
+        - name: OPEN_PORT
+          value: "8080"
+        - name: DISCOVERY_POLL_INTERVAL
+          value: "500ms"
+        - name: SERVICE_NAMESPACE
+          value: "integration-test"
+        - name: METRICS_INTERVAL
+          value: "10ms"
+        - name: BPF_BATCH_TIMEOUT
+          value: "10ms"
+        - name: LOG_LEVEL
+          value: "DEBUG"
+        - name: BPF_DEBUG
+          value: "TRUE"
+        - name: METRICS_REPORT_TARGET
+          value: "true"
+        - name: METRICS_REPORT_PEER
+          value: "true"
+        - name: INTERNAL_METRICS_PROMETHEUS_PORT
+          value: "8999"
+        - name: KUBE_METADATA_ENABLE
+          value: "autodetect"


### PR DESCRIPTION
This PR updates the userspace PID filtering to match what we do on the kernel side, to support running as a daemonset in k8s. Added a test for python and k8s.