### PR TITLE
Grafana cloud authentication

### DIFF
--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -1,10 +1,14 @@
 package otel
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 
+	"github.com/go-logr/logr"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -111,6 +115,7 @@ type otlpOptions struct {
 	Insecure      bool
 	URLPath       string
 	SkipTLSVerify bool
+	HTTPHeaders   map[string]string
 }
 
 func (o *otlpOptions) AsMetricHTTP() []otlpmetrichttp.Option {
@@ -125,6 +130,9 @@ func (o *otlpOptions) AsMetricHTTP() []otlpmetrichttp.Option {
 	}
 	if o.SkipTLSVerify {
 		opts = append(opts, otlpmetrichttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
+	}
+	if len(o.HTTPHeaders) > 0 {
+		opts = append(opts, otlpmetrichttp.WithHeaders(o.HTTPHeaders))
 	}
 	return opts
 }
@@ -155,6 +163,9 @@ func (o *otlpOptions) AsTraceHTTP() []otlptracehttp.Option {
 	if o.SkipTLSVerify {
 		opts = append(opts, otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
 	}
+	if len(o.HTTPHeaders) > 0 {
+		opts = append(opts, otlptracehttp.WithHeaders(o.HTTPHeaders))
+	}
 	return opts
 }
 
@@ -169,4 +180,48 @@ func (o *otlpOptions) AsTraceGRPC() []otlptracegrpc.Option {
 		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
 	}
 	return opts
+}
+
+// LogrAdaptor allows using our on logger to peek any warning or error in the OTEL exporters
+type LogrAdaptor struct {
+	inner *slog.Logger
+}
+
+func SetupInternalOTELSDKLogger() {
+	otel.SetLogger(logr.New(&LogrAdaptor{inner: slog.With("component", "otel.BatchSpanProcessor")}))
+}
+
+func (l *LogrAdaptor) Init(_ logr.RuntimeInfo) {}
+
+// Enabled returns, according to OTEL internal description:
+// To see Warn messages use a logger with `l.V(1).Enabled() == true`
+// To see Info messages use a logger with `l.V(4).Enabled() == true`
+// To see Debug messages use a logger with `l.V(8).Enabled() == true`.
+// However, we will "degrade" their info messages to our log level,
+// as they leak many internal information that is not interesting for the final user.
+func (l *LogrAdaptor) Enabled(level int) bool {
+	if level < 4 {
+		return l.inner.Enabled(context.TODO(), slog.LevelWarn)
+	}
+	return l.inner.Enabled(context.TODO(), slog.LevelDebug)
+}
+
+func (l *LogrAdaptor) Info(level int, msg string, keysAndValues ...interface{}) {
+	if level > 1 {
+		l.inner.Debug(msg, keysAndValues...)
+	} else {
+		l.inner.Warn(msg, keysAndValues...)
+	}
+}
+
+func (l *LogrAdaptor) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.inner.Error(msg, append(keysAndValues, "error", err)...)
+}
+
+func (l *LogrAdaptor) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return &LogrAdaptor{inner: l.inner.With(keysAndValues...)}
+}
+
+func (l *LogrAdaptor) WithName(name string) logr.LogSink {
+	return &LogrAdaptor{inner: l.inner.With("name", name)}
 }

--- a/pkg/internal/export/otel/grafana.go
+++ b/pkg/internal/export/otel/grafana.go
@@ -1,0 +1,105 @@
+package otel
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+func gclog() *slog.Logger {
+	return slog.With("component", "otel.GrafanaConfig")
+}
+
+const (
+	submitMetrics = "metrics"
+	submitTraces  = "traces"
+)
+
+const (
+	grafanaOTLP = "https://otlp-gateway-%s.grafana.net/otlp"
+)
+
+// GrafanaConfig simplifies the submission of information to Grafana Cloud, but it can
+// be actually used for any OTEl endpoint, as it uses the standard OTEL authentication
+// under the hood
+type GrafanaConfig struct {
+	// OTLP endpoint from Grafana Cloud.
+	OTLP GrafanaOTLP `yaml:"otlp"`
+}
+
+type GrafanaOTLP struct {
+	// Submit accepts a comma-separated list of the kind of data that will be submit to the
+	// OTLP endpoint. It accepts `metrics` and/or `traces` as values.
+	Submit []string `yaml:"submit" env:"GRAFANA_OTLP_SUBMIT"`
+
+	// CloudZone of your Grafana Endpoint. For example: prod-eu-west-0.
+	CloudZone string `yaml:"cloud_zone" env:"GRAFANA_OTLP_CLOUD_ZONE"`
+
+	// InstanceID is your Grafana user name. It is usually a number but it must be set as a
+	// string inside the YAML file.
+	InstanceID string `yaml:"instance_id" env:"GRAFANA_OTLP_CLOUD_INSTANCE_ID"`
+
+	// APIKey of your Grafana Cloud account.
+	APIKey string `yaml:"api_key" env:"GRAFANA_OTLP_CLOUD_API_KEY"`
+}
+
+func (cfg *GrafanaOTLP) MetricsEnabled() bool {
+	return cfg.endpointEnabled() && cfg.submits(submitMetrics)
+}
+
+func (cfg *GrafanaOTLP) TracesEnabled() bool {
+	return cfg.endpointEnabled() && cfg.submits(submitTraces)
+}
+
+func (cfg *GrafanaOTLP) endpointEnabled() bool {
+	if cfg == nil {
+		return false
+	}
+	// we could force an AND condition below, but the error could
+	// remain unnoticed. This way, if the user forgets a field, they will
+	// see an error log during the metrics submission
+	return cfg.InstanceID != "" || cfg.APIKey != "" || cfg.CloudZone != ""
+}
+
+func (cfg *GrafanaOTLP) submits(s string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, sb := range cfg.Submit {
+		if strings.ToLower(strings.TrimSpace(sb)) == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (cfg *GrafanaOTLP) Endpoint() string {
+	return fmt.Sprintf(grafanaOTLP, cfg.CloudZone)
+}
+
+func (cfg *GrafanaOTLP) AuthHeader() string {
+	encodedKey := bytes.Buffer{}
+	encodedKey.WriteString("Basic ")
+	encoder := base64.NewEncoder(base64.StdEncoding, &encodedKey)
+	_, err := encoder.Write([]byte(cfg.InstanceID + ":" + cfg.APIKey))
+	if err != nil {
+		// This should never happen, as the bytes.Buffer reader will never return error on Write
+		gclog().Error("can't encode Grafana OTLP Authorization header. Leaving empty", "error", err)
+		return ""
+	}
+	return encodedKey.String()
+}
+
+func (cfg *GrafanaOTLP) setupOptions(opt *otlpOptions) {
+	if cfg == nil {
+		return
+	}
+	if cfg.InstanceID != "" && cfg.APIKey != "" {
+		if opt.HTTPHeaders == nil {
+			opt.HTTPHeaders = map[string]string{}
+		}
+		opt.HTTPHeaders["Authorization"] = cfg.AuthHeader()
+	}
+}

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -63,6 +63,10 @@ type MetricsConfig struct {
 
 	ReportersCacheLen int `yaml:"reporters_cache_len" env:"BEYLA_METRICS_REPORT_CACHE_LEN"`
 
+	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
+	// and the Info messages leak internal details that are not usually valuable for the final user.
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"BEYLA_OTEL_SDK_LOG_LEVEL"`
+
 	// Grafana configuration needs to be explicitly set up before building the graph
 	Grafana *GrafanaOTLP `yaml:"-"`
 }
@@ -130,7 +134,7 @@ func ReportMetrics(
 	ctx context.Context, cfg *MetricsConfig, ctxInfo *global.ContextInfo,
 ) (node.TerminalFunc[[]request.Span], error) {
 
-	SetupInternalOTELSDKLogger()
+	SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
 	mr, err := newMetricsReporter(ctx, cfg, ctxInfo)
 	if err != nil {

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -62,13 +62,16 @@ type TracesConfig struct {
 	ExportTimeout      time.Duration `yaml:"export_timeout" env:"BEYLA_OTLP_TRACES_EXPORT_TIMEOUT"`
 
 	ReportersCacheLen int `yaml:"reporters_cache_len" env:"BEYLA_TRACES_REPORT_CACHE_LEN"`
+
+	// Grafana configuration needs to be explicitly set up before building the graph
+	Grafana *GrafanaOTLP `yaml:"-"`
 }
 
 // Enabled specifies that the OTEL traces node is enabled if and only if
 // either the OTEL endpoint and OTEL traces endpoint is defined.
 // If not enabled, this node won't be instantiated
 func (m TracesConfig) Enabled() bool { //nolint:gocritic
-	return m.CommonEndpoint != "" || m.TracesEndpoint != ""
+	return m.CommonEndpoint != "" || m.TracesEndpoint != "" || m.Grafana.TracesEnabled()
 }
 
 func (m *TracesConfig) GetProtocol() Protocol {
@@ -105,6 +108,9 @@ type TracesReporter struct {
 	traceExporter trace.SpanExporter
 	bsp           trace.SpanProcessor
 	reporters     ReporterPool[*Tracers]
+
+	// Grafana configuration needs to be explicitly set up before building the graph
+	Grafana *GrafanaOTLP
 }
 
 // Tracers handles the OTEL traces providers and exporters.
@@ -115,6 +121,9 @@ type Tracers struct {
 }
 
 func ReportTraces(ctx context.Context, cfg *TracesConfig, ctxInfo *global.ContextInfo) (node.TerminalFunc[[]request.Span], error) {
+
+	SetupInternalOTELSDKLogger()
+
 	tr, err := newTracesReporter(ctx, cfg, ctxInfo)
 	if err != nil {
 		slog.Error("can't instantiate OTEL traces reporter", err)
@@ -172,7 +181,6 @@ func newTracesReporter(ctx context.Context, cfg *TracesConfig, ctxInfo *global.C
 	}
 
 	r.bsp = trace.NewBatchSpanProcessor(r.traceExporter, opts...)
-
 	return &r, nil
 }
 
@@ -568,12 +576,21 @@ func (r *TracesReporter) newTracers(service svc.ID) (*Tracers, error) {
 	return &tracers, nil
 }
 
+// the HTTP path will be defined from one of the following sources, from highest to lowest priority
+// - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, if defined
+// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
+// - https://otlp-gateway-${GRAFANA_OTLP_CLOUD_ZONE}.grafana.net/otlp, if GRAFANA_OTLP_CLOUD_ZONE is defined
+// If, by some reason, Grafana changes its OTLP Gateway URL in a distant future, you can still point to the
+// correct URL with the OTLP_EXPORTER_... variables.
 func parseTracesEndpoint(cfg *TracesConfig) (*url.URL, bool, error) {
 	isCommon := false
 	endpoint := cfg.TracesEndpoint
 	if endpoint == "" {
 		isCommon = true
 		endpoint = cfg.CommonEndpoint
+		if endpoint == "" && cfg.Grafana != nil && cfg.Grafana.CloudZone != "" {
+			endpoint = cfg.Grafana.Endpoint()
+		}
 	}
 
 	murl, err := url.Parse(endpoint)
@@ -619,6 +636,8 @@ func getHTTPTracesEndpointOptions(cfg *TracesConfig) (otlpOptions, error) {
 		log.Debug("Setting InsecureSkipVerify")
 		opts.SkipTLSVerify = true
 	}
+
+	cfg.Grafana.setupOptions(&opts)
 
 	return opts, nil
 }

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -60,6 +60,37 @@ func TestHTTPTracesEndpoint(t *testing.T) {
 	})
 }
 
+func TestHTTPTracesWithGrafanaOptions(t *testing.T) {
+	defer restoreEnvAfterExecution()
+	mcfg := TracesConfig{Grafana: &GrafanaOTLP{
+		Submit:     []string{submitMetrics, submitTraces},
+		CloudZone:  "eu-west-23",
+		InstanceID: "12345",
+		APIKey:     "affafafaafkd",
+	}}
+	t.Run("testing basic Grafana Cloud options", func(t *testing.T) {
+		testHTTPTracesOptions(t, otlpOptions{
+			Endpoint: "otlp-gateway-eu-west-23.grafana.net",
+			URLPath:  "/otlp/v1/traces",
+			HTTPHeaders: map[string]string{
+				// Basic + output of: echo -n 12345:affafafaafkd | gbase64 -w 0
+				"Authorization": "Basic MTIzNDU6YWZmYWZhZmFhZmtk",
+			},
+		}, &mcfg)
+	})
+	mcfg.CommonEndpoint = "https://localhost:3939"
+	t.Run("Overriding endpoint URL", func(t *testing.T) {
+		testHTTPTracesOptions(t, otlpOptions{
+			Endpoint: "localhost:3939",
+			URLPath:  "/v1/traces",
+			HTTPHeaders: map[string]string{
+				// Base64 representation of 12345:affafafaafkd
+				"Authorization": "Basic MTIzNDU6YWZmYWZhZmFhZmtk",
+			},
+		}, &mcfg)
+	})
+}
+
 func testHTTPTracesOptions(t *testing.T, expected otlpOptions, tcfg *TracesConfig) {
 	defer restoreEnvAfterExecution()()
 	opts, err := getHTTPTracesEndpointOptions(tcfg)
@@ -350,6 +381,18 @@ func TestTraces_InternalInstrumentationSampling(t *testing.T) {
 		// no call should return error
 		assert.Empty(t, internalTraces.Errors())
 	})
+}
+
+func TestTracesConfig_Enabled(t *testing.T) {
+	assert.True(t, TracesConfig{CommonEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{MetricsEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
+}
+
+func TestTracesConfig_Disabled(t *testing.T) {
+	assert.False(t, TracesConfig{}.Enabled())
+	assert.False(t, TracesConfig{Grafana: &GrafanaOTLP{Submit: []string{"metrics"}, InstanceID: "33221"}}.Enabled())
+	assert.False(t, TracesConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces"}}}.Enabled())
 }
 
 type fakeInternalTraces struct {

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -25,6 +25,12 @@ var defaultConfig = Config{
 		BatchTimeout: time.Second,
 		BpfBaseDir:   "/var/run/beyla",
 	},
+	Grafana: otel.GrafanaConfig{
+		OTLP: otel.GrafanaOTLP{
+			// by default we will only submit traces, assuming span2metrics will do the metrics conversion
+			Submit: []string{"traces"},
+		},
+	},
 	Metrics: otel.MetricsConfig{
 		Protocol:          otel.ProtocolUnset,
 		MetricsProtocol:   otel.ProtocolUnset,
@@ -65,10 +71,15 @@ type Config struct {
 	// Routes is an optional node. If not set, data will be directly forwarded to exporters.
 	Routes     *transform.RoutesConfig       `yaml:"routes"`
 	Kubernetes transform.KubernetesDecorator `yaml:"kubernetes"`
-	Metrics    otel.MetricsConfig            `yaml:"otel_metrics_export"`
-	Traces     otel.TracesConfig             `yaml:"otel_traces_export"`
-	Prometheus prom.PrometheusConfig         `yaml:"prometheus_export"`
-	Printer    debug.PrintEnabled            `yaml:"print_traces" env:"BEYLA_PRINT_TRACES"`
+
+	// Grafana overrides some values of the otel.MetricsConfig and otel.TracesConfig below
+	// for a simpler submission of OTEL metrics to Grafana Cloud
+	Grafana otel.GrafanaConfig `yaml:"grafana"`
+
+	Metrics    otel.MetricsConfig    `yaml:"otel_metrics_export"`
+	Traces     otel.TracesConfig     `yaml:"otel_traces_export"`
+	Prometheus prom.PrometheusConfig `yaml:"prometheus_export"`
+	Printer    debug.PrintEnabled    `yaml:"print_traces" env:"BEYLA_PRINT_TRACES"`
 
 	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
 	Exec services.PathRegexp `yaml:"executable_name" env:"BEYLA_EXECUTABLE_NAME"`
@@ -125,11 +136,11 @@ func (c *Config) Validate() error {
 	}
 
 	if !c.Noop.Enabled() && !c.Printer.Enabled() &&
+		!c.Grafana.OTLP.MetricsEnabled() && !c.Grafana.OTLP.TracesEnabled() &&
 		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
 		!c.Prometheus.Enabled() {
-		return ConfigError("at least one of the following properties must be set: " +
-			"BEYLA_NOOP_TRACES, BEYLA_PRINT_TRACES, OTEL_EXPORTER_OTLP_ENDPOINT, " +
-			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, BEYLA_PROMETHEUS_PORT")
+		return ConfigError("you need to define at least one exporter: print_traces," +
+			" grafana, otel_metrics_export, otel_traces_export or prometheus_export")
 	}
 	return nil
 }

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -40,9 +40,10 @@ kubernetes:
 	require.NoError(t, os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:3131"))
 	require.NoError(t, os.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "localhost:3232"))
 	require.NoError(t, os.Setenv("BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT", "3210"))
+	require.NoError(t, os.Setenv("GRAFANA_OTLP_SUBMIT", "metrics,traces"))
 	defer unsetEnv(t, map[string]string{
 		"BEYLA_OPEN_PORT": "", "BEYLA_EXECUTABLE_NAME": "", "OTEL_SERVICE_NAME": "", "BEYLA_NOOP_TRACES": "",
-		"OTEL_EXPORTER_OTLP_ENDPOINT": "", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "", "GRAFANA_OTLP_SUBMIT": "",
 	})
 
 	cfg, err := LoadConfig(userConfig)
@@ -70,6 +71,11 @@ kubernetes:
 			BatchLength:  100,
 			BatchTimeout: time.Second,
 			BpfBaseDir:   "/var/run/beyla",
+		},
+		Grafana: otel.GrafanaConfig{
+			OTLP: otel.GrafanaOTLP{
+				Submit: []string{"metrics", "traces"},
+			},
 		},
 		Metrics: otel.MetricsConfig{
 			Interval:          5 * time.Second,

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -110,7 +110,11 @@ func (gb *graphFunctions) buildGraph() (*Instrumenter, error) {
 	// respective node providers
 
 	definedNodesMap := configToNodesMap(gb.config)
+	// wiring some unconnected node information
 	definedNodesMap.TracesReader.TracesInput = gb.tracesCh
+	definedNodesMap.Metrics.Grafana = &gb.config.Grafana.OTLP
+	definedNodesMap.Traces.Grafana = &gb.config.Grafana.OTLP
+
 	grp, err := gb.builder.Build(definedNodesMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Simplifies the direct submission of metrics and traces to the Grafana OTLP endpoint, by introducing the following variables, common to other Grafana instrumenters:

```
GRAFANA_OTLP_CLOUD_ZONE
GRAFANA_OTLP_CLOUD_INSTANCE_ID
GRAFANA_OTLP_CLOUD_API_KEY
```

The documentation will be added with the next Beyla release.