### PR TITLE
Use standard OTEL configuration for sampling

### DIFF
--- a/pkg/internal/export/otel/sampler.go
+++ b/pkg/internal/export/otel/sampler.go
@@ -1,0 +1,50 @@
+package otel
+
+import (
+	"log/slog"
+	"strconv"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Sampler standard configuration
+// https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler
+// We don't support, yet, the jaeger and xray samplers.
+type Sampler struct {
+	Name string `yaml:"name" env:"OTEL_TRACES_SAMPLER"`
+	Arg  string `yaml:"arg" env:"OTEL_TRACES_SAMPLER_ARG"`
+}
+
+func (s *Sampler) Implementation() trace.Sampler {
+	var defaultSampler = func() trace.Sampler {
+		return trace.ParentBased(trace.AlwaysSample())
+	}
+	log := slog.With("component", "otel.Sampler", "name", s.Name, "arg", s.Arg)
+	switch s.Name {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		ratio, err := strconv.ParseFloat(s.Arg, 64)
+		if err != nil {
+			log.Warn("can't parse sampler argument. Defaulting to parentbased_always_on", "error", err)
+			return defaultSampler()
+		}
+		return trace.TraceIDRatioBased(ratio)
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		ratio, err := strconv.ParseFloat(s.Arg, 64)
+		if err != nil {
+			log.Warn("can't parse sampler argument. Defaulting to parentbased_always_on", "error", err)
+			return defaultSampler()
+		}
+		return trace.ParentBased(trace.TraceIDRatioBased(ratio))
+	case "parentbased_always_on", "":
+		return defaultSampler()
+	default:
+		log.Warn("unsupported sampler name. Defaulting to parentbased_always_on")
+		return defaultSampler()
+	}
+}

--- a/pkg/internal/export/otel/sampler_test.go
+++ b/pkg/internal/export/otel/sampler_test.go
@@ -1,0 +1,52 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestSamplerImplementation(t *testing.T) {
+	type testCase struct {
+		in  Sampler
+		out trace.Sampler
+	}
+
+	for _, tc := range []testCase{{
+		// default sampler
+		out: trace.ParentBased(trace.AlwaysSample()),
+	}, {
+		in:  Sampler{Name: "invalid_sampler", Arg: "0.33"},
+		out: trace.ParentBased(trace.AlwaysSample()),
+	}, {
+		in:  Sampler{Name: "always_on"},
+		out: trace.AlwaysSample(),
+	}, {
+		in:  Sampler{Name: "always_off"},
+		out: trace.NeverSample(),
+	}, {
+		in:  Sampler{Name: "traceidratio", Arg: "0.33"},
+		out: trace.TraceIDRatioBased(0.33),
+	}, {
+		// wrong argument: using default sampler
+		in:  Sampler{Name: "traceidratio", Arg: "fofofofoof"},
+		out: trace.ParentBased(trace.AlwaysSample()),
+	}, {
+		in:  Sampler{Name: "parentbased_always_off", Arg: "0.33"},
+		out: trace.ParentBased(trace.NeverSample()),
+	}, {
+		in:  Sampler{Name: "parentbased_always_on", Arg: "0.33"},
+		out: trace.ParentBased(trace.AlwaysSample()),
+	}, {
+		in:  Sampler{Name: "parentbased_traceidratio", Arg: "0.3"},
+		out: trace.ParentBased(trace.TraceIDRatioBased(0.3)),
+	}, {
+		in:  Sampler{Name: "parentbased_traceidratio", Arg: "wrong argument"},
+		out: trace.ParentBased(trace.AlwaysSample()),
+	}} {
+		t.Run(tc.in.Name+"/"+tc.in.Arg, func(t *testing.T) {
+			assert.Equal(t, tc.out, tc.in.Implementation())
+		})
+	}
+}

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -52,7 +52,7 @@ type TracesConfig struct {
 	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"BEYLA_OTEL_INSECURE_SKIP_VERIFY"`
 
-	SamplingRatio float64 `yaml:"sampling_ratio" env:"BEYLA_OTEL_TRACE_SAMPLING_RATIO"`
+	Sampler Sampler `yaml:"sampler"`
 
 	// Configuration options below this line will remain undocumented at the moment,
 	// but can be useful for performance-tuning of some customers.
@@ -561,7 +561,7 @@ func (r *TracesReporter) newTracers(service svc.ID) (*Tracers, error) {
 		provider: trace.NewTracerProvider(
 			trace.WithResource(otelResource(service)),
 			trace.WithSpanProcessor(r.bsp),
-			trace.WithSampler(trace.ParentBased(trace.TraceIDRatioBased(r.cfg.SamplingRatio))),
+			trace.WithSampler(r.cfg.Sampler.Implementation()),
 		),
 	}
 	tracers.tracer = tracers.provider.Tracer(reporterName)

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -69,21 +69,21 @@ func testHTTPTracesOptions(t *testing.T, expected otlpOptions, tcfg *TracesConfi
 
 func TestMissingSchemeInHTTPTracesEndpoint(t *testing.T) {
 	defer restoreEnvAfterExecution()()
-	opts, err := getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "http://foo:3030", SamplingRatio: 1.0})
+	opts, err := getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "http://foo:3030"})
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 
-	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3030", SamplingRatio: 1.0})
+	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3030"})
 	require.Error(t, err)
 
-	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo", SamplingRatio: 1.0})
+	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo"})
 	require.Error(t, err)
 }
 
 func TestGRPCTracesEndpointOptions(t *testing.T) {
 	defer restoreEnvAfterExecution()()
 	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
-		_, err := getGRPCTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3939", SamplingRatio: 1.0})
+		_, err := getGRPCTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3939"})
 		assert.Error(t, err)
 	})
 	tcfg := TracesConfig{
@@ -165,7 +165,6 @@ func TestTracesSetupHTTP_Protocol(t *testing.T) {
 				TracesEndpoint: tc.Endpoint,
 				Protocol:       tc.ProtoVal,
 				TracesProtocol: tc.TraceProtoVal,
-				SamplingRatio:  1.0,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
@@ -184,7 +183,6 @@ func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 			CommonEndpoint: "http://host:3333",
 			Protocol:       "foo",
 			TracesProtocol: "bar",
-			SamplingRatio:  1.0,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
@@ -196,7 +194,6 @@ func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 		_, err := getHTTPTracesEndpointOptions(&TracesConfig{
 			CommonEndpoint: "http://host:3333",
 			Protocol:       "foo",
-			SamplingRatio:  1.0,
 		})
 		require.NoError(t, err)
 		_, ok := os.LookupEnv(envTracesProtocol)
@@ -234,7 +231,6 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 			CommonEndpoint:    coll.URL,
 			BatchTimeout:      10 * time.Millisecond,
 			ExportTimeout:     5 * time.Second,
-			SamplingRatio:     1.0,
 			ReportersCacheLen: 16,
 		},
 		&global.ContextInfo{
@@ -326,7 +322,7 @@ func TestTraces_InternalInstrumentationSampling(t *testing.T) {
 			CommonEndpoint:    coll.URL,
 			BatchTimeout:      10 * time.Millisecond,
 			ExportTimeout:     5 * time.Second,
-			SamplingRatio:     0.0, // sampling 0 means we won't generate any samples
+			Sampler:           Sampler{Name: "always_off"}, // we won't send any trace
 			ReportersCacheLen: 16,
 		},
 		&global.ContextInfo{

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -37,7 +37,6 @@ var defaultConfig = Config{
 		TracesProtocol:     otel.ProtocolUnset,
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
-		SamplingRatio:      1.0,
 		ReportersCacheLen:  16,
 	},
 	Prometheus: prom.PrometheusConfig{

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -88,7 +88,6 @@ kubernetes:
 			TracesEndpoint:     "localhost:3232",
 			MaxQueueSize:       4096,
 			MaxExportBatchSize: 4096,
-			SamplingRatio:      1.0,
 			ReportersCacheLen:  16,
 		},
 		Prometheus: prom.PrometheusConfig{

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -87,8 +87,8 @@ func TestTracerPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &Config{
 		Traces: otel.TracesConfig{
-			BatchTimeout:   10 * time.Millisecond,
-			TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0,
+			BatchTimeout:      10 * time.Millisecond,
+			TracesEndpoint:    tc.ServerEndpoint,
 			ReportersCacheLen: 16,
 		},
 	}, gctx(), make(<-chan []request.Span))
@@ -123,8 +123,8 @@ func TestTracerPipelineBadTimestamps(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &Config{
 		Traces: otel.TracesConfig{
-			BatchTimeout:   10 * time.Millisecond,
-			TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0,
+			BatchTimeout:      10 * time.Millisecond,
+			TracesEndpoint:    tc.ServerEndpoint,
 			ReportersCacheLen: 16,
 		},
 	}, gctx(), make(<-chan []request.Span))
@@ -272,8 +272,8 @@ func TestTraceGRPCPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &Config{
 		Traces: otel.TracesConfig{
-			TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0,
-			BatchTimeout: time.Millisecond, ReportersCacheLen: 16,
+			TracesEndpoint: tc.ServerEndpoint,
+			BatchTimeout:   time.Millisecond, ReportersCacheLen: 16,
 		},
 	}, gctx(), make(<-chan []request.Span))
 	// Override eBPF tracer to send some fake data
@@ -306,7 +306,7 @@ func TestNestedSpanMatching(t *testing.T) {
 	require.NoError(t, err)
 
 	gb := newGraphBuilder(ctx, &Config{
-		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0, ReportersCacheLen: 16},
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ReportersCacheLen: 16},
 	}, gctx(), make(<-chan []request.Span))
 	// Override eBPF tracer to send some fake data with nested client span
 	graph.RegisterStart(gb.builder, func(_ traces.Reader) (node.StartFunc[[]request.Span], error) {
@@ -584,7 +584,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	gb := newGraphBuilder(ctx, &Config{
-		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, SamplingRatio: 1.0, ReportersCacheLen: 16},
+		Traces: otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ReportersCacheLen: 16},
 	}, gctx(), make(<-chan []request.Span))
 	// Override eBPF tracer to send some fake data
 	graph.RegisterStart(gb.builder, func(_ traces.Reader) (node.StartFunc[[]request.Span], error) {


### PR DESCRIPTION
Addresses issue: https://github.com/grafana/beyla/issues/392

**Breaking change**: we remove the previous sampling configuration option.

Documentation will be added when we do the next release.