### PR TITLE
Fix escaping in quoted regexp

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -33,8 +33,8 @@ jobs:
         uses: ./actions/has-matching-release-tag
         with:
           ref_name: ${{ github.ref_name }}
-          release_tag_regexp: '^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'
-          release_branch_regexp: '^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'
+          release_tag_regexp: '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+          release_branch_regexp: '^release-(0|[1-9]\d*)\.(0|[1-9]\d*)$'
 
       - name: Determine technical documentation version
         if: steps.has-matching-release-tag.outputs.bool == 'true'


### PR DESCRIPTION
Double quotes requires escaping the backslashes but single quotes does not: https://yaml.org/spec/1.2.2/#double-quoted-style