### PR TITLE
Update go offsets tracker version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/goccy/go-json v0.10.2
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/go-offsets-tracker v0.1.2
+	github.com/grafana/go-offsets-tracker v0.1.5
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
 	github.com/mariomac/pipes v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/go-offsets-tracker v0.1.2 h1:f3OBkgYlsOzk+1x/ld06g8OUn5xG/nFbwxGkdr+iUFM=
-github.com/grafana/go-offsets-tracker v0.1.2/go.mod h1:kMOoQRWLsRz5tecLQXB3skxgEqexj6bWwySL9nZSohw=
+github.com/grafana/go-offsets-tracker v0.1.5 h1:abTdxqjjWYlAYxJSBDgoI4DvgmHJjERRD7eUbrDQ7e8=
+github.com/grafana/go-offsets-tracker v0.1.5/go.mod h1:kMOoQRWLsRz5tecLQXB3skxgEqexj6bWwySL9nZSohw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=

--- a/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/input.go
+++ b/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/input.go
@@ -12,6 +12,15 @@ type LibQuery struct {
 	// it will analyse an empty main file that forces the inclusion of the inspected library.
 	Inspect string `json:"inspect"`
 
+	// Branch will force downloading the branch name specified here, ignoring the
+	// Versions field. This is useful for source repositories without release tags.
+	Branch string `json:"branch"`
+
+	// Packages overrides the packages that need to be downloaded for inspection. If empty, it will
+	// download the root package (same as the library URL). Setting this value is useful for libraries that do
+	// not have any root package and the download would fail (e.g. google.golang.org/genproto)
+	Packages []string `json:"packages"`
+
 	// Versions constraint. E.g. ">= 1.12" will only download versions
 	// larger or equal to 1.12
 	Versions string `json:"versions"`

--- a/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/schema.go
+++ b/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/schema.go
@@ -21,8 +21,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/grafana/go-offsets-tracker/pkg/versions"
 	"github.com/hashicorp/go-version"
+
+	"github.com/grafana/go-offsets-tracker/pkg/versions"
 )
 
 type Track struct {
@@ -95,6 +96,7 @@ func (to *Track) Find(structName, fieldName, libVersion string) (uint64, bool) {
 
 // GetOffset assumes that the fields offsets list is sorted from older to newer version
 func (field *Field) GetOffset(libVersion string) (uint64, bool) {
+	libVersion = versions.CleanVersion(libVersion)
 	target, err := version.NewVersion(libVersion)
 	if err != nil {
 		// shouldn't happen unless a bug in our code/files

--- a/vendor/github.com/grafana/go-offsets-tracker/pkg/utils/cmd.go
+++ b/vendor/github.com/grafana/go-offsets-tracker/pkg/utils/cmd.go
@@ -7,16 +7,15 @@ import (
 
 const ShellToUse = "bash"
 
-func RunCommand(command string, dir string) (error, string, string) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+func RunCommand(command string, dir string) (string, error) {
+	var output bytes.Buffer
 	cmd := exec.Command(ShellToUse, "-c", command)
 	if dir != "" {
 		cmd.Dir = dir
 	}
 
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = &output
+	cmd.Stderr = &output
 	err := cmd.Run()
-	return err, stdout.String(), stderr.String()
+	return output.String(), err
 }

--- a/vendor/github.com/grafana/go-offsets-tracker/pkg/versions/go_list.go
+++ b/vendor/github.com/grafana/go-offsets-tracker/pkg/versions/go_list.go
@@ -3,6 +3,8 @@ package versions
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/grafana/go-offsets-tracker/pkg/utils"
 )
 
@@ -12,8 +14,9 @@ type goListResponse struct {
 }
 
 func FindVersionsUsingGoList(moduleName string) ([]string, error) {
-	err, stdout, _ := utils.RunCommand(fmt.Sprintf("go list -m -mod=readonly -json -versions %s", moduleName), "")
+	stdout, err := utils.RunCommand(fmt.Sprintf("go list -m -mod=readonly -json -versions %s", moduleName), "")
 	if err != nil {
+		log.Println("error running go list:\n", stdout)
 		return nil, err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/google/uuid
 # github.com/gorilla/mux v1.8.0
 ## explicit; go 1.12
 github.com/gorilla/mux
-# github.com/grafana/go-offsets-tracker v0.1.2
+# github.com/grafana/go-offsets-tracker v0.1.5
 ## explicit; go 1.20
 github.com/grafana/go-offsets-tracker/pkg/offsets
 github.com/grafana/go-offsets-tracker/pkg/utils


### PR DESCRIPTION
Should fix https://github.com/grafana/beyla/issues/443

I haven't been able to reproduce the original issue, as I haven't found any Go distribution with that weird version name. Neither manually installing boringcrypto version nor running with `GOEXPERIMENT=boringcrypto`.