### PR TITLE
Add utility helper to determine the kernel lockdown mode

### DIFF
--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -142,12 +142,12 @@ func KernelLockdownMode() KernelLockdown {
 				return KernelLockdownConfidentiality
 			}
 			return KernelLockdownOther
-		} else {
-			plog.Warn("file /sys/kernel/security/lockdown is empty, assuming lockdown [integrity]")
-			return KernelLockdownIntegrity
 		}
-	} else {
-		plog.Debug("can't find /sys/kernel/security/lockdown, assuming no lockdown")
-		return KernelLockdownNone
+
+		plog.Warn("file /sys/kernel/security/lockdown is empty, assuming lockdown [integrity]")
+		return KernelLockdownIntegrity
 	}
+
+	plog.Debug("can't find /sys/kernel/security/lockdown, assuming no lockdown")
+	return KernelLockdownNone
 }

--- a/pkg/internal/ebpf/common/common_test.go
+++ b/pkg/internal/ebpf/common/common_test.go
@@ -8,12 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setIntegrity(path, text string) {
-	os.WriteFile(path, []byte(text), 0644)
+func setIntegrity(t *testing.T, path, text string) {
+	err := os.WriteFile(path, []byte(text), 0644)
+	assert.NoError(t, err)
 }
 
-func setNotReadable(path string) {
-	os.Chmod(path, 000)
+func setNotReadable(t *testing.T, path string) {
+	err := os.Chmod(path, 000)
+	assert.NoError(t, err)
 }
 
 func TestLockdownParsing(t *testing.T) {
@@ -38,22 +40,22 @@ func TestLockdownParsing(t *testing.T) {
 	// Setup for testing
 	lockdownPath = path
 
-	setIntegrity(path, "none [integrity] confidentiality\n")
+	setIntegrity(t, path, "none [integrity] confidentiality\n")
 	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
 
-	setIntegrity(path, "[none] integrity confidentiality\n")
+	setIntegrity(t, path, "[none] integrity confidentiality\n")
 	assert.Equal(t, KernelLockdownNone, KernelLockdownMode())
 
-	setIntegrity(path, "none integrity [confidentiality]\n")
+	setIntegrity(t, path, "none integrity [confidentiality]\n")
 	assert.Equal(t, KernelLockdownConfidentiality, KernelLockdownMode())
 
-	setIntegrity(path, "whatever\n")
+	setIntegrity(t, path, "whatever\n")
 	assert.Equal(t, KernelLockdownOther, KernelLockdownMode())
 
-	setIntegrity(path, "")
+	setIntegrity(t, path, "")
 	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
 
-	setIntegrity(path, "[none] integrity confidentiality\n")
-	setNotReadable(path)
+	setIntegrity(t, path, "[none] integrity confidentiality\n")
+	setNotReadable(t, path)
 	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
 }

--- a/pkg/internal/ebpf/common/common_test.go
+++ b/pkg/internal/ebpf/common/common_test.go
@@ -1,0 +1,59 @@
+package ebpfcommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setIntegrity(path, text string) {
+	os.WriteFile(path, []byte(text), 0644)
+}
+
+func setNotReadable(path string) {
+	os.Chmod(path, 000)
+}
+
+func TestLockdownParsing(t *testing.T) {
+	noFile, err := os.CreateTemp("", "not_existent_fake_lockdown")
+	assert.NoError(t, err)
+	notPath, err := filepath.Abs(noFile.Name())
+	assert.NoError(t, err)
+	noFile.Close()
+	os.Remove(noFile.Name())
+
+	// Setup for testing file that doesn't exist
+	lockdownPath = notPath
+	assert.Equal(t, KernelLockdownNone, KernelLockdownMode())
+
+	tempFile, err := os.CreateTemp("", "fake_lockdown")
+	assert.NoError(t, err)
+	path, err := filepath.Abs(tempFile.Name())
+	assert.NoError(t, err)
+	tempFile.Close()
+
+	defer os.Remove(tempFile.Name())
+	// Setup for testing
+	lockdownPath = path
+
+	setIntegrity(path, "none [integrity] confidentiality\n")
+	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
+
+	setIntegrity(path, "[none] integrity confidentiality\n")
+	assert.Equal(t, KernelLockdownNone, KernelLockdownMode())
+
+	setIntegrity(path, "none integrity [confidentiality]\n")
+	assert.Equal(t, KernelLockdownConfidentiality, KernelLockdownMode())
+
+	setIntegrity(path, "whatever\n")
+	assert.Equal(t, KernelLockdownOther, KernelLockdownMode())
+
+	setIntegrity(path, "")
+	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
+
+	setIntegrity(path, "[none] integrity confidentiality\n")
+	setNotReadable(path)
+	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
+}


### PR DESCRIPTION
This utility function is not used anywhere yet, I'm adding it so that we can tell if the kernel is in lockdown mode, and if not in the future we can write user memory, e.g. write the `traceparent` in outgoing client calls.