### PR TITLE
Fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo -E ./beyla
 
 Now, you should see metrics on [http://localhost:9400/metrics](http://localhost:9400/metrics).
 
-See [Documentation](https://grafana.com/docs/grafana-cloud/monitor-applications/beyla/) and the [quickstart tutorial](docs/sources/tutorial/index.md) for more info.
+See [Documentation](https://grafana.com/docs/beyla/) and the [quickstart tutorial](docs/sources/tutorial/index.md) for more info.
 
 ## Requirements
 

--- a/pkg/internal/transform/routes.go
+++ b/pkg/internal/transform/routes.go
@@ -108,7 +108,7 @@ func chooseUnmatchPolicy(rc *RoutesConfig) (func(span *request.Span), error) {
 					"route for trace span names. For optimal experience, please define your application " +
 					"HTTP route patterns or enable the route 'heuristic' mode. " +
 					"For more information please see the documentation at: " +
-					"https://grafana.com/docs/grafana-cloud/monitor-applications/beyla/configure/options/#routes-decorator. " +
+					"https://grafana.com/docs/beyla/latest/configure/options/#routes-decorator . " +
 					"If your application is only using gRPC you can ignore this warning.")
 		}
 	case UnmatchUnset:


### PR DESCRIPTION
Changes some links to the new, versioned site of the Grafana documentation:
https://grafana.com/docs/beyla/latest

It doesn't change the links to the static assets (e.g. images), as they remain immutable.