### PR TITLE
Fix 'grafana-agent' URL on Kubernetes docs

### DIFF
--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -214,7 +214,7 @@ spec:
             - name: BEYLA_EXECUTABLE_NAME
               value: "goblog"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "grafana-agent:4318"
+              value: "http://grafana-agent:4318"
               # required if you want kubernetes metadata decoration
             - name: BEYLA_KUBE_METADATA_ENABLE
               value: "true"


### PR DESCRIPTION
As reported on #466, the [documented Kubernetes `DaemonSet` manifest][1] is lacking the `http://` prefix for the `grafana-agent` service URL, which results in the following error:

```
time=2023-12-04T19:17:20.297Z level=ERROR msg="Beyla couldn't start read and
forwarding" error="can't instantiate instrumentation pipeline: instantiating
terminal instance \"Metrics\": instantiating OTEL metrics reporter: can't
instantiate OTEL HTTP metrics exporter: URL \"grafana-agent:4318\" must have a
scheme and a host"
```

Closes #466.

[1]: https://grafana.com/docs/grafana-cloud/monitor-applications/beyla/setup/kubernetes/#deploy-beyla-as-a-daemonset