### PR TITLE
Fix host parsing bug

### DIFF
--- a/pkg/internal/ebpf/httpfltr/httpfltr.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr.go
@@ -435,7 +435,7 @@ func (event *BPFHTTPInfo) method() string {
 }
 
 func (event *BPFHTTPInfo) hostFromBuf() (string, int) {
-	buf := string(event.Buf[:])
+	buf := cstr(event.Buf[:])
 	idx := strings.Index(buf, "Host: ")
 
 	if idx < 0 {
@@ -445,6 +445,10 @@ func (event *BPFHTTPInfo) hostFromBuf() (string, int) {
 	buf = buf[idx+6:]
 
 	rIdx := strings.Index(buf, "\r")
+
+	if rIdx < 0 {
+		rIdx = len(buf)
+	}
 
 	host, portStr, err := net.SplitHostPort(buf[:rIdx])
 

--- a/pkg/internal/ebpf/httpfltr/httpfltr_test.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr_test.go
@@ -244,3 +244,64 @@ func TestExtractTraceParent(t *testing.T) {
 			"Content-Type:application/json\r\n"+
 			"TraceParent: \r\n\r\n")))
 }
+
+func TestToRequestTrace_BadHost(t *testing.T) {
+	var record BPFHTTPInfo
+	record.Type = 1
+	record.StartMonotimeNs = 123456
+	record.EndMonotimeNs = 789012
+	record.Status = 200
+	record.ConnInfo.D_port = 0
+	record.ConnInfo.S_port = 0
+	record.ConnInfo.S_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 0, 1}
+	record.ConnInfo.D_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8}
+	copy(record.Buf[:], "GET /hello HTTP/1.1\r\nHost: example.c")
+
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.LittleEndian, &record)
+	assert.NoError(t, err)
+
+	tracer := Tracer{cfg: &pipe.Config{}}
+	result, _, err := tracer.readHTTPInfoIntoSpan(&ringbuf.Record{RawSample: buf.Bytes()})
+	assert.NoError(t, err)
+
+	expected := request.Span{
+		Host:         "",
+		Peer:         "",
+		Path:         "/hello",
+		Method:       "GET",
+		Status:       200,
+		Type:         request.EventTypeHTTP,
+		RequestStart: 123456,
+		Start:        123456,
+		End:          789012,
+		HostPort:     0,
+		ServiceID:    svc.ID{SDKLanguage: svc.InstrumentableGeneric},
+	}
+	assert.Equal(t, expected, result)
+
+	s, p := record.hostFromBuf()
+	assert.Equal(t, s, "")
+	assert.Equal(t, p, -1)
+
+	var record1 BPFHTTPInfo
+	copy(record1.Buf[:], "GET /hello HTTP/1.1\r\nHost: example.c:23")
+
+	s, p = record1.hostFromBuf()
+	assert.Equal(t, s, "example.c")
+	assert.Equal(t, p, 23)
+
+	var record2 BPFHTTPInfo
+	copy(record2.Buf[:], "GET /hello HTTP/1.1\r\nHost: ")
+
+	s, p = record2.hostFromBuf()
+	assert.Equal(t, s, "")
+	assert.Equal(t, p, -1)
+
+	var record3 BPFHTTPInfo
+	copy(record3.Buf[:], "GET /hello HTTP/1.1\r\nHost")
+
+	s, p = record3.hostFromBuf()
+	assert.Equal(t, s, "")
+	assert.Equal(t, p, -1)
+}


### PR DESCRIPTION
This PR fixes a bug in the host parsing fallback path for the HTTP request parser. In SSL mode we sometimes can't find the connection information, because of internal process threading models, so we have a fallback path to look for "Host: " in the headers. However, the code didn't anticipate our limited buffer size of 160 characters, so the '\r' may not be in the string. 