### PR TITLE
Remove Go tracers when they become unused

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/beyla/pkg/internal/ebpf"
 	"github.com/grafana/beyla/pkg/internal/goexec"
+	"github.com/grafana/beyla/pkg/internal/helpers"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/pipe"
 	"github.com/grafana/beyla/pkg/internal/svc"
@@ -25,8 +26,14 @@ type TraceAttacher struct {
 	Cfg               *pipe.Config
 	Ctx               context.Context
 	DiscoveredTracers chan *ebpf.ProcessTracer
+	DeleteTracers     chan *Instrumentable
 	Metrics           imetrics.Reporter
 	pinPath           string
+
+	// processInstances keeps track of the instances of each process. This will help making sure
+	// that we don't remove the BPF resources of an executable until all their instances are removed
+	// are stopped
+	processInstances helpers.MultiCounter[uint64]
 
 	// keeps a copy of all the tracers for a given executable path
 	existingTracers map[uint64]*ebpf.ProcessTracer
@@ -37,6 +44,7 @@ type TraceAttacher struct {
 func TraceAttacherProvider(ta TraceAttacher) (node.TerminalFunc[[]Event[Instrumentable]], error) {
 	ta.log = slog.With("component", "discover.TraceAttacher")
 	ta.existingTracers = map[uint64]*ebpf.ProcessTracer{}
+	ta.processInstances = helpers.MultiCounter[uint64]{}
 	ta.pinPath = BuildPinPath(ta.Cfg)
 
 	if err := ta.init(); err != nil {
@@ -51,6 +59,7 @@ func TraceAttacherProvider(ta TraceAttacher) (node.TerminalFunc[[]Event[Instrume
 				ta.log.Debug("Instrumentable", "len", len(instrumentables), "inst", instr)
 				switch instr.Type {
 				case EventCreated:
+					ta.processInstances.Inc(instr.Obj.FileInfo.Ino)
 					if pt, ok := ta.getTracer(&instr.Obj); ok {
 						ta.DiscoveredTracers <- pt
 						if ta.Cfg.Discovery.SystemWide {
@@ -181,6 +190,14 @@ func (ta *TraceAttacher) notifyProcessDeletion(ie *Instrumentable) {
 		// to avoid that a new process reusing this PID could send traces
 		// unless explicitly allowed
 		tracer.BlockPID(uint32(ie.FileInfo.Pid))
+
+		// if there are no more trace instances for a Go program, we need to notify that
+		// the tracer needs to be stopped and deleted.
+		// We don't remove kernel-based traces as there is only one tracer per host
+		if tracer.Type != ebpf.Generic && ta.processInstances.Dec(ie.FileInfo.Ino) == 0 {
+			delete(ta.existingTracers, ie.FileInfo.Ino)
+			ta.DeleteTracers <- ie
+		}
 	}
 }
 

--- a/pkg/internal/ebpf/common/pids.go
+++ b/pkg/internal/ebpf/common/pids.go
@@ -140,7 +140,11 @@ func (pf *PIDsFilter) removePID(pid uint32) {
 	nsid, err := readNamespace(int32(pid))
 
 	if err != nil {
-		pf.log.Error("Error looking up namespace for removing PID", "pid", pid, "error", err)
+		// this will always happen on process removal, as /proc/<pid>/ns/pid won't be found
+		// the code is kept here as a placeholder for a future fix (e.g. using eBPF notifications
+		// to get both the PID and the nsid)
+		// TODO: fix
+		pf.log.Debug("Error looking up namespace for removing PID", "pid", pid, "error", err)
 		return
 	}
 

--- a/pkg/internal/helpers/multicounter.go
+++ b/pkg/internal/helpers/multicounter.go
@@ -1,0 +1,31 @@
+package helpers
+
+// MultiCounter maps a counter to a given key
+type MultiCounter[K comparable] map[K]*int
+
+// Inc increments the counter associated to the given key and returns the new count.
+func (m MultiCounter[K]) Inc(key K) int {
+	n, ok := m[key]
+	if !ok {
+		z := 1
+		m[key] = &z
+		return 1
+	}
+	*n++
+	return *n
+}
+
+// Dec decrements the counter associated to the given key and returns the new count.
+func (m MultiCounter[K]) Dec(key K) int {
+	n, ok := m[key]
+	if !ok {
+		z := -1
+		m[key] = &z
+		return -1
+	}
+	*n--
+	if *n == 0 {
+		delete(m, key)
+	}
+	return *n
+}

--- a/pkg/internal/helpers/multicounter_test.go
+++ b/pkg/internal/helpers/multicounter_test.go
@@ -1,0 +1,27 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiCounter(t *testing.T) {
+	mc := MultiCounter[string]{}
+
+	assert.Equal(t, 1, mc.Inc("foo"))
+	assert.Equal(t, 2, mc.Inc("foo"))
+	assert.Equal(t, 3, mc.Inc("foo"))
+
+	assert.Equal(t, 1, mc.Inc("bar"))
+	assert.Equal(t, 2, mc.Inc("bar"))
+	assert.Equal(t, 3, mc.Inc("bar"))
+
+	assert.Equal(t, 2, mc.Dec("foo"))
+	assert.Equal(t, 1, mc.Dec("foo"))
+	assert.Equal(t, 0, mc.Dec("foo"))
+
+	assert.Equal(t, -1, mc.Dec("baz"))
+	assert.Equal(t, -2, mc.Dec("baz"))
+	assert.Equal(t, -3, mc.Dec("baz"))
+}


### PR DESCRIPTION
When all the instances of an instrumented executable are stopped, we remove both the BPF probes and the ProcessTracer associated to it.

This way, we prevent memory leaks either in Beyla or in the BPF side.

Addresses: #498 #313 #253 

