### PR TITLE
Update and document Beyla requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [Documentation](https://grafana.com/docs/beyla/) and the [quickstart tutoria
 
 ## Requirements
 
-- Linux with Kernel 4.18 or higher with [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)
+- Linux with Kernel 5.8 or higher with [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)
   enabled. BTF became enabled by default on most Linux distributions with kernel 5.14 or higher. 
   You can check if your kernel has BTF enabled by verifying if `/sys/kernel/btf/vmlinux` exists on your system.
   If you need to recompile your kernel to enable BTF, the configuration option `CONFIG_DEBUG_INFO_BTF=y` must be

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -32,6 +32,19 @@ Beyla offers the following features:
 - listen to the Kubernetes API to decorate metrics and traces with Pods and Services metadata
 - simple setup for Grafana customers already using Grafana Agent
 
+## Requirements
+
+- Linux with Kernel 5.8 or higher with [BTF](https://www.kernel.org/doc/html/latest/bpf/btf.html)
+  enabled. BTF became enabled by default on most Linux distributions with kernel 5.14 or higher.
+  You can check if your kernel has BTF enabled by verifying if `/sys/kernel/btf/vmlinux` exists on your system.
+  If you need to recompile your kernel to enable BTF, the configuration option `CONFIG_DEBUG_INFO_BTF=y` must be
+  set.
+- eBPF enabled in the host.
+- For instrumenting Go programs, they must have been compiled with at least Go 1.17. We currently
+  support Go applications built with a major **Go version no earlier than 3 versions** behind the current
+  stable major release.
+- Administrative access rights to execute Beyla.
+
 ## Get started
 
 Follow the [setup]({{< relref "./setup/_index.md" >}}) documentation to get started with Beyla either as a standalone


### PR DESCRIPTION
The official docs did not show any requirements section. Also, the README requirements were outdated. We need version 5.8 because we are using [BPF_MAP_TYPE_RINGBUF](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md)