### PR TITLE
Fix integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/goccy/go-json v0.10.2
 	github.com/gorilla/mux v1.8.0
-	github.com/grafana/go-offsets-tracker v0.1.5
+	github.com/grafana/go-offsets-tracker v0.1.6
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/mariomac/guara v0.0.0-20230621100729-42bd7716e524
 	github.com/mariomac/pipes v0.9.0
@@ -35,7 +35,8 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.41.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/arch v0.3.0
-	golang.org/x/mod v0.8.0
+	golang.org/x/mod v0.14.0
+	golang.org/x/net v0.12.0
 	golang.org/x/sys v0.12.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/protobuf v1.31.0
@@ -100,7 +101,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
-	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/go-offsets-tracker v0.1.5 h1:abTdxqjjWYlAYxJSBDgoI4DvgmHJjERRD7eUbrDQ7e8=
-github.com/grafana/go-offsets-tracker v0.1.5/go.mod h1:kMOoQRWLsRz5tecLQXB3skxgEqexj6bWwySL9nZSohw=
+github.com/grafana/go-offsets-tracker v0.1.6 h1:zCFkH2CslFfxkmH3dBYSFDKQhKbgXI9/T6l1jpuKr3I=
+github.com/grafana/go-offsets-tracker v0.1.6/go.mod h1:qcQdu7zlUKIFNUdBJlLyNHuJGW0SKWKjkrN6jtt+jds=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -268,8 +268,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
-golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -317,8 +317,8 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/integration/k8s/common/k8s_common.go
+++ b/test/integration/k8s/common/k8s_common.go
@@ -15,8 +15,9 @@ var (
 	DockerfilePinger           = path.Join(PathComponents, "grpcpinger", "Dockerfile")
 	DockerfilePythonTestServer = path.Join(PathComponents, "pythonserver", "Dockerfile_8083")
 
-	PingerManifest     = path.Join(PathManifests, "/06-instrumented-client.template.yml")
-	GrpcPingerManifest = path.Join(PathManifests, "/06-instrumented-grpc-client.template.yml")
+	PingerManifest               = path.Join(PathManifests, "/06-instrumented-client.template.yml")
+	GrpcPingerManifest           = path.Join(PathManifests, "/06-instrumented-grpc-client.template.yml")
+	UninstrumentedPingerManifest = path.Join(PathManifests, "/06-uninstrumented-client.template.yml")
 )
 
 // Pinger stores the configuration data of a local pod that will be used to

--- a/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
@@ -1,0 +1,70 @@
+# this file is actually a Go template that needs to be processed before deploying
+# Mandatory variables are PodName and TargetURL
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maincode
+  labels:
+    component: pinger
+data:
+  main.go: |
+    package main
+    import (
+      "fmt"
+      "net/http"
+      "time"
+    )
+    func main() {
+      for {
+        r, err := http.Get("{{.TargetURL}}")
+        if err != nil {
+          fmt.Println("error!", err)
+        }
+        if r != nil {
+          fmt.Println("response:", r.Status)
+        }
+        time.Sleep(time.Second)
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # this is the service name as expected by configs/prometheus-config-promscrape.yml
+  name: beyla-pinger
+spec:
+  selector:
+    component: pinger
+  ports:
+    - port: 8999
+      name: prometheus
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{.PodName}}"
+  labels:
+    component: pinger
+spec:
+  shareProcessNamespace: true
+  serviceAccountName: beyla
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+    - name: testoutput
+      persistentVolumeClaim:
+        claimName: testoutput
+    - name: maincode
+      configMap:
+        name: maincode
+  containers:
+    - name: pinger
+      image: golang:1.21
+      command:
+        - sh
+        - -c
+        - 'go build -o pinger-cmd /code/main.go && ./pinger-cmd '
+      volumeMounts:
+        - mountPath: /code
+          name: maincode

--- a/test/integration/k8s/otel/k8s_otel_traces_test.go
+++ b/test/integration/k8s/otel/k8s_otel_traces_test.go
@@ -23,7 +23,7 @@ import (
 // composition process is shared too with the rest of metrics decoration
 func TestTracesDecoration(t *testing.T) {
 	pinger := kube.Template[k8s.Pinger]{
-		TemplateFile: k8s.PingerManifest,
+		TemplateFile: k8s.UninstrumentedPingerManifest,
 		Data: k8s.Pinger{
 			PodName:   "internal-pinger",
 			TargetURL: "http://testserver:8080/traced-ping",

--- a/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/schema.go
+++ b/vendor/github.com/grafana/go-offsets-tracker/pkg/offsets/schema.go
@@ -98,26 +98,10 @@ func (to *Track) Find(structName, fieldName, libVersion string) (uint64, bool) {
 func (field *Field) GetOffset(libVersion string) (uint64, bool) {
 	libVersion = versions.CleanVersion(libVersion)
 	target, err := version.NewVersion(libVersion)
-
 	if err != nil {
 		// shouldn't happen unless a bug in our code/files
 		panic(err.Error())
 	}
-
-	newestVer := versions.CleanVersion(field.Versions.Newest)
-	newest, err := version.NewVersion(newestVer)
-
-	if err != nil {
-		// shouldn't happen unless a bug in our offsets tracker generator
-		panic(err.Error())
-	}
-
-	// If what we are looking in as library is newer than our remembered offsets
-	// don't play dice and don't read unknown offsets
-	if target.Compare(newest) > 0 {
-		return 0, false
-	}
-
 	// Search from the newest version (last in the slice)
 	for o := len(field.Offsets) - 1; o >= 0; o-- {
 		od := &field.Offsets[o]

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -140,7 +140,7 @@ func Compare(v, w string) int {
 // Max canonicalizes its arguments and then returns the version string
 // that compares greater.
 //
-// Deprecated: use Compare instead. In most cases, returning a canonicalized
+// Deprecated: use [Compare] instead. In most cases, returning a canonicalized
 // version is not expected or desired.
 func Max(v, w string) string {
 	v = Canonical(v)
@@ -151,7 +151,7 @@ func Max(v, w string) string {
 	return w
 }
 
-// ByVersion implements sort.Interface for sorting semantic version strings.
+// ByVersion implements [sort.Interface] for sorting semantic version strings.
 type ByVersion []string
 
 func (vs ByVersion) Len() int      { return len(vs) }
@@ -164,7 +164,7 @@ func (vs ByVersion) Less(i, j int) bool {
 	return vs[i] < vs[j]
 }
 
-// Sort sorts a list of semantic version strings using ByVersion.
+// Sort sorts a list of semantic version strings using [ByVersion].
 func Sort(list []string) {
 	sort.Sort(ByVersion(list))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/google/uuid
 # github.com/gorilla/mux v1.8.0
 ## explicit; go 1.12
 github.com/gorilla/mux
-# github.com/grafana/go-offsets-tracker v0.1.5
+# github.com/grafana/go-offsets-tracker v0.1.6
 ## explicit; go 1.20
 github.com/grafana/go-offsets-tracker/pkg/offsets
 github.com/grafana/go-offsets-tracker/pkg/utils
@@ -442,8 +442,8 @@ golang.org/x/crypto/sha3
 golang.org/x/exp/constraints
 golang.org/x/exp/maps
 golang.org/x/exp/slices
-# golang.org/x/mod v0.8.0
-## explicit; go 1.17
+# golang.org/x/mod v0.14.0
+## explicit; go 1.18
 golang.org/x/mod/semver
 # golang.org/x/net v0.12.0
 ## explicit; go 1.17


### PR DESCRIPTION
After upgrading to distributed tracing, server-side tracing integration tests failed 50% of the times because they included the client-side trace as a top-parent span.