### PR TITLE
Automatic name/namespace setting from K8s metadata

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -131,7 +131,7 @@ func (ta *TraceAttacher) getTracer(ie *Instrumentable) (*ebpf.ProcessTracer, boo
 		return nil, false
 	}
 
-	ie.FileInfo.Service = svc.ID{Name: ie.FileInfo.Service.Name, Namespace: ie.FileInfo.Service.Namespace, SDKLanguage: ie.Type}
+	ie.FileInfo.Service.SDKLanguage = ie.Type
 
 	// Instead of the executable file in the disk, we pass the /proc/<pid>/exec
 	// to allow loading it from different container/pods in containerized environments

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -36,6 +36,9 @@ func (pt *ProcessTracer) Run(ctx context.Context, out chan<- []request.Span) {
 	// executable will be dynamically set for each traced http request call.
 	if service.Name == "" && !pt.SystemWide {
 		service.Name = pt.ELFInfo.ExecutableName()
+		// we mark the service ID as automatically named in case we want to look,
+		// in later stages of the pipeline, for better automatic service name
+		service.AutoName = true
 	}
 
 	for _, t := range trcrs {

--- a/pkg/internal/export/debug/debug.go
+++ b/pkg/internal/export/debug/debug.go
@@ -32,7 +32,7 @@ func PrinterNode(_ PrintEnabled) (node.TerminalFunc[[]request.Span], error) {
 					spans[i].Host,
 					spans[i].HostPort,
 					spans[i].ContentLength,
-					spans[i].ServiceID,
+					&spans[i].ServiceID,
 					traceparent(&spans[i]),
 				)
 			}

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -103,7 +103,7 @@ func (rp *ReporterPool[T]) For(service svc.ID) (T, error) {
 	m, err := rp.itemConstructor(service)
 	if err != nil {
 		var t T
-		return t, fmt.Errorf("creating resource for service %q: %w", service, err)
+		return t, fmt.Errorf("creating resource for service %q: %w", &service, err)
 	}
 	rp.pool.Add(service, m)
 	return m, nil

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -41,7 +41,11 @@ func (it InstrumentableType) String() string {
 // ID stores the coordinates that uniquely identifies a service:
 // its name and optionally a namespace
 type ID struct {
-	Name        string
+	Name string
+	// AutoName is true if the Name has been automatically set by Beyla (e.g. executable name when
+	// the Name is empty). This will allow later refinement of the Name value (e.g. to override it
+	// again with Kubernetes metadata).
+	AutoName    bool
 	Namespace   string
 	SDKLanguage InstrumentableType
 	Instance    string

--- a/pkg/internal/svc/svc_test.go
+++ b/pkg/internal/svc/svc_test.go
@@ -1,0 +1,12 @@
+package svc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToString(t *testing.T) {
+	assert.Equal(t, "thens/thename", (&ID{Namespace: "thens", Name: "thename"}).String())
+	assert.Equal(t, "thename", (&ID{Name: "thename"}).String())
+}

--- a/pkg/internal/transform/k8s_test.go
+++ b/pkg/internal/transform/k8s_test.go
@@ -1,0 +1,134 @@
+package transform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/beyla/pkg/internal/kube"
+	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
+	"github.com/grafana/beyla/pkg/internal/testutil"
+)
+
+const timeout = 5 * time.Second
+
+func TestDecoration(t *testing.T) {
+	// pre-populated kubernetes metadata database
+	dec := metadataDecorator{db: fakeDatabase{
+		12: &kube.PodInfo{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "pod-12", Namespace: "the-ns", UID: "uid-12",
+			},
+			NodeName:       "the-node",
+			StartTimeStr:   "2020-01-02 12:12:56",
+			DeploymentName: "deployment-12",
+			ReplicaSetName: "rs-12",
+		},
+		34: &kube.PodInfo{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "pod-34", Namespace: "the-ns", UID: "uid-34",
+			},
+			NodeName:       "the-node",
+			StartTimeStr:   "2020-01-02 12:34:56",
+			ReplicaSetName: "rs-34",
+		},
+		56: &kube.PodInfo{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "the-pod", Namespace: "the-ns", UID: "uid-56",
+			},
+			NodeName:     "the-node",
+			StartTimeStr: "2020-01-02 12:56:56",
+		},
+	}}
+	inputCh, outputhCh := make(chan []request.Span, 10), make(chan []request.Span, 10)
+	defer close(inputCh)
+	go dec.nodeLoop(inputCh, outputhCh)
+
+	t.Run("complete pod info should set deployment as name", func(t *testing.T) {
+		inputCh <- []request.Span{{
+			Pid: request.PidInfo{Namespace: 12}, ServiceID: svc.ID{AutoName: true},
+		}}
+		deco := testutil.ReadChannel(t, outputhCh, timeout)
+		require.Len(t, deco, 1)
+		assert.Equal(t, "the-ns", deco[0].ServiceID.Namespace)
+		assert.Equal(t, "deployment-12", deco[0].ServiceID.Name)
+		assert.Equal(t, map[string]string{
+			"k8s.node.name":       "the-node",
+			"k8s.namespace.name":  "the-ns",
+			"k8s.pod.name":        "pod-12",
+			"k8s.pod.uid":         "uid-12",
+			"k8s.deployment.name": "deployment-12",
+			"k8s.pod.start_time":  "2020-01-02 12:12:56",
+		}, deco[0].Metadata)
+	})
+	t.Run("pod info without deployment should set replicaset as name", func(t *testing.T) {
+		inputCh <- []request.Span{{
+			Pid: request.PidInfo{Namespace: 34}, ServiceID: svc.ID{AutoName: true},
+		}}
+		deco := testutil.ReadChannel(t, outputhCh, timeout)
+		require.Len(t, deco, 1)
+		assert.Equal(t, "the-ns", deco[0].ServiceID.Namespace)
+		assert.Equal(t, "rs-34", deco[0].ServiceID.Name)
+		assert.Equal(t, map[string]string{
+			"k8s.node.name":      "the-node",
+			"k8s.namespace.name": "the-ns",
+			"k8s.pod.name":       "pod-34",
+			"k8s.pod.uid":        "uid-34",
+			"k8s.pod.start_time": "2020-01-02 12:34:56",
+		}, deco[0].Metadata)
+	})
+	t.Run("pod info with only pod name should set pod name as name", func(t *testing.T) {
+		inputCh <- []request.Span{{
+			Pid: request.PidInfo{Namespace: 56}, ServiceID: svc.ID{AutoName: true},
+		}}
+		deco := testutil.ReadChannel(t, outputhCh, timeout)
+		require.Len(t, deco, 1)
+		assert.Equal(t, "the-ns", deco[0].ServiceID.Namespace)
+		assert.Equal(t, "the-pod", deco[0].ServiceID.Name)
+		assert.Equal(t, map[string]string{
+			"k8s.node.name":      "the-node",
+			"k8s.namespace.name": "the-ns",
+			"k8s.pod.name":       "the-pod",
+			"k8s.pod.uid":        "uid-56",
+			"k8s.pod.start_time": "2020-01-02 12:56:56",
+		}, deco[0].Metadata)
+	})
+	t.Run("process without pod Info won't be decorated", func(t *testing.T) {
+		inputCh <- []request.Span{{
+			Pid: request.PidInfo{Namespace: 78}, ServiceID: svc.ID{Name: "exec", AutoName: true},
+		}}
+		deco := testutil.ReadChannel(t, outputhCh, timeout)
+		require.Len(t, deco, 1)
+		assert.Empty(t, deco[0].ServiceID.Namespace)
+		assert.Equal(t, "exec", deco[0].ServiceID.Name)
+		assert.Empty(t, deco[0].Metadata)
+	})
+	t.Run("if service name or namespace are manually specified, don't override them", func(t *testing.T) {
+		inputCh <- []request.Span{{
+			Pid: request.PidInfo{Namespace: 12}, ServiceID: svc.ID{Name: "tralari", Namespace: "tralara"},
+		}}
+		deco := testutil.ReadChannel(t, outputhCh, timeout)
+		require.Len(t, deco, 1)
+		assert.Equal(t, "tralara", deco[0].ServiceID.Namespace)
+		assert.Equal(t, "tralari", deco[0].ServiceID.Name)
+		assert.Equal(t, map[string]string{
+			"k8s.node.name":       "the-node",
+			"k8s.namespace.name":  "the-ns",
+			"k8s.pod.name":        "pod-12",
+			"k8s.pod.uid":         "uid-12",
+			"k8s.deployment.name": "deployment-12",
+			"k8s.pod.start_time":  "2020-01-02 12:12:56",
+		}, deco[0].Metadata)
+	})
+}
+
+type fakeDatabase map[uint32]*kube.PodInfo
+
+func (f fakeDatabase) OwnerPodInfo(pidNamespace uint32) (*kube.PodInfo, bool) {
+	pi, ok := f[pidNamespace]
+	return pi, ok
+}

--- a/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
@@ -37,7 +37,7 @@ func TestBasicTracing(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, http.StatusOK, resp.StatusCode)
 
-					resp, err = http.Get(jaegerQueryURL + "?service=testserver&?service=testserver&tags=%7B%22k8s.deployment.name%22%3A%22testserver%22%7D")
+					resp, err = http.Get(jaegerQueryURL + "?service=otherinstance")
 					require.NoError(t, err)
 					if resp == nil {
 						return
@@ -50,23 +50,33 @@ func TestBasicTracing(t *testing.T) {
 					trace := traces[0]
 					require.NotEmpty(t, trace.Spans)
 
+					// Check that the service.namespace is set from the K8s namespace
+					assert.Len(t, trace.Processes, 1)
+					for _, proc := range trace.Processes {
+						sd := jaeger.DiffAsRegexp([]jaeger.Tag{
+							{Key: "service.namespace", Type: "string", Value: "^default$"},
+						}, proc.Tags)
+						require.Empty(t, sd)
+					}
+
 					// Check the information of the parent span
 					res := trace.FindByOperationName("GET /pingpong")
 					require.Len(t, res, 1)
 					parent := res[0]
 					sd := jaeger.DiffAsRegexp([]jaeger.Tag{
-						{Key: "k8s.pod.name", Type: "string", Value: "^testserver-.*"},
+						{Key: "k8s.pod.name", Type: "string", Value: "^otherinstance-.*"},
 						{Key: "k8s.node.name", Type: "string", Value: ".+-control-plane$"},
 						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
-						{Key: "k8s.deployment.name", Type: "string", Value: "^testserver$"},
+						{Key: "k8s.deployment.name", Type: "string", Value: "^otherinstance"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
 					}, parent.Tags)
-					require.Empty(t, sd, sd.String())
+					require.Empty(t, sd)
+
 				}, test.Interval(100*time.Millisecond))
 
-				// Check that the "otherinstance" service is never instrumented
-				resp, err := http.Get(jaegerQueryURL + "?service=testserver&tags=%7B%22k8s.deployment.name%22%3A%22otherinstance%22%7D")
+				// Check that the "testserver" service is never instrumented
+				resp, err := http.Get(jaegerQueryURL + "?service=testserver")
 				require.NoError(t, err)
 				require.Equal(t, http.StatusOK, resp.StatusCode)
 				var tq jaeger.TracesQuery

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -31,7 +31,7 @@ func TestPythonBasicTracing(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, http.StatusOK, resp.StatusCode)
 
-					resp, err = http.Get(jaegerQueryURL + "?service=python3.11&operation=GET%20%2Fgreeting")
+					resp, err = http.Get(jaegerQueryURL + "?service=pytestserver&operation=GET%20%2Fgreeting")
 					require.NoError(t, err)
 					if resp == nil {
 						return

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -11,10 +11,10 @@ data:
     log_level: debug
     discovery:
       services:
-        # testing that K8s discovery only picks the testserver from a given
-        # deployment (ignoring the testserver in the other pod)
-        - k8s_deployment_name: testserver
-          namespace: integration-test
+        # testing that K8s discovery only picks the "otherinstance"
+        # deployment (ignoring the "testserver" in the other pod)
+        # name and namespace will be automatically set from the K8s metadata
+        - k8s_deployment_name: otherinstance
     routes:
       patterns:
         - /pingpong


### PR DESCRIPTION
If the user did not specify a service name configuration, the service.name property was automatically set from the executable name.

If the user did not specify a service namespace, the service.namespace OTEL property was automatically left empty.

From now on, if the above properties are left unset, they are automatically set from the Kubernetes metadata.