### PR TITLE
Enable Kubernetes autodetection by default

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -376,9 +376,9 @@ It is IMPORTANT to consider that enabling this feature requires a previous step 
 providing some extra permissions to the Beyla Pod. Please check the
 ["Configuring Kubernetes metadata decoration section" in the "Running Beyla in Kubernetes"]({{< relref "../setup/kubernetes.md" >}}) page.
 
-| YAML     | Env var                      | Type    | Default |
-|----------|------------------------------|---------|---------|
-| `enable` | `BEYLA_KUBE_METADATA_ENABLE` | boolean | `false` |
+| YAML     | Env var                      | Type   | Default      |
+|----------|------------------------------|--------|--------------|
+| `enable` | `BEYLA_KUBE_METADATA_ENABLE` | string | `autodetect` |
 
 If set to `true`, Beyla will decorate the metrics and traces with Kubernetes metadata.
 

--- a/pkg/internal/transform/k8s.go
+++ b/pkg/internal/transform/k8s.go
@@ -19,7 +19,7 @@ const (
 	EnabledTrue       = KubeEnableFlag("true")
 	EnabledFalse      = KubeEnableFlag("false")
 	EnabledAutodetect = KubeEnableFlag("autodetect")
-	EnabledDefault    = EnabledFalse
+	EnabledDefault    = EnabledAutodetect
 
 	// TODO: let the user decide which attributes to add, as in https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-attributes-processor
 	NamespaceName  = "k8s.namespace.name"

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -107,5 +107,3 @@ spec:
               value: "true"
             - name: BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT
               value: "8999"
-            - name: BEYLA_KUBE_METADATA_ENABLE
-              value: "autodetect"

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -118,8 +118,6 @@ spec:
               value: "true"
             - name: BEYLA_METRICS_REPORT_PEER
               value: "true"
-            - name: BEYLA_KUBE_METADATA_ENABLE
-              value: "autodetect"
           ports:
             - containerPort: 8999
               hostPort: 8999

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -4,9 +4,6 @@ metadata:
   name: beyla-config
 data:
   beyla-config.yml: |
-    attributes:
-      kubernetes:
-        enable: true    
     print_traces: true
     log_level: debug
     discovery:

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -4,9 +4,6 @@ metadata:
   name: beyla-config
 data:
   beyla-config.yml: |
-    attributes:
-      kubernetes:
-        enable: true
     print_traces: true
     log_level: debug
     discovery:

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -118,5 +118,3 @@ spec:
           value: "true"
         - name: BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT
           value: "8999"
-        - name: BEYLA_KUBE_METADATA_ENABLE
-          value: "autodetect"


### PR DESCRIPTION
Now that we have a definitive solution for Kubernetes discovery and decoration, we should let Beyla to automatically enable it when it detects it is running inside a Kubernetes cluster.

The `BEYLA_KUBE_METADATA_ENABLE` default value goes from `false` to `autodetect`.