### PR TITLE
Refactor: clean code for else if

### DIFF
--- a/pkg/internal/exec/proclang.go
+++ b/pkg/internal/exec/proclang.go
@@ -9,13 +9,17 @@ import (
 func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	if strings.Contains(moduleName, "libcoreclr.so") {
 		return svc.InstrumentableDotnet
-	} else if strings.Contains(moduleName, "libjvm.so") {
+	}
+	if strings.Contains(moduleName, "libjvm.so") {
 		return svc.InstrumentableJava
-	} else if strings.HasSuffix(moduleName, "/node") || moduleName == "node" {
+	}
+	if strings.HasSuffix(moduleName, "/node") || moduleName == "node" {
 		return svc.InstrumentableNodejs
-	} else if strings.HasSuffix(moduleName, "/ruby") || moduleName == "ruby" {
+	}
+	if strings.HasSuffix(moduleName, "/ruby") || moduleName == "ruby" {
 		return svc.InstrumentableRuby
-	} else if strings.Contains(moduleName, "/python") || moduleName == "python" || moduleName == "python3" {
+	}
+	if strings.Contains(moduleName, "/python") || moduleName == "python" || moduleName == "python3" {
 		return svc.InstrumentablePython
 	}
 
@@ -25,7 +29,8 @@ func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 func instrumentableFromSymbolName(symbol string) svc.InstrumentableType {
 	if strings.Contains(symbol, "rust_panic") {
 		return svc.InstrumentableRust
-	} else if strings.HasPrefix(symbol, "JVM_") || strings.HasPrefix(symbol, "graal_") {
+	}
+	if strings.HasPrefix(symbol, "JVM_") || strings.HasPrefix(symbol, "graal_") {
 		return svc.InstrumentableJava
 	}
 


### PR DESCRIPTION
Get rid of `else if` in early return statement, it may seems more cleaner.