### PR TITLE
Increase tracers LRU size and clean-up on free

### DIFF
--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -154,7 +153,11 @@ func newMetricsReporter(ctx context.Context, cfg *MetricsConfig, ctxInfo *global
 		func(id svc.ID, v *Metrics) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")
-			// a finalizer shuts down the metrics provider
+			go func() {
+				if err := v.provider.ForceFlush(ctx); err != nil {
+					llog.Warn("error flushing evicted metrics provider", "error", err)
+				}
+			}()
 		}, mr.newMetricSet)
 	// Instantiate the OTLP HTTP or GRPC metrics exporter
 	exporter, err := instantiateMetricsExporter(ctx, cfg, log)
@@ -164,16 +167,6 @@ func newMetricsReporter(ctx context.Context, cfg *MetricsConfig, ctxInfo *global
 	mr.exporter = instrumentMetricsExporter(ctxInfo.Metrics, exporter)
 
 	return &mr, nil
-}
-
-func (r *Metrics) release() error {
-	go func() {
-		if err := r.provider.Shutdown(r.ctx); err != nil {
-			mlog().Warn("error shutting down metrics provider", "error", err)
-		}
-	}()
-	runtime.SetFinalizer(r, nil)
-	return nil
 }
 
 func (mr *MetricsReporter) newMetricSet(service svc.ID) (*Metrics, error) {
@@ -194,7 +187,6 @@ func (mr *MetricsReporter) newMetricSet(service svc.ID) (*Metrics, error) {
 			metric.WithView(otelHistogramBuckets(HTTPClientRequestSize, mr.cfg.Buckets.RequestSizeHistogram)),
 		),
 	}
-	runtime.SetFinalizer(&m, (*Metrics).release)
 	// time units for HTTP and GRPC durations are in seconds, according to the OTEL specification:
 	// https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions
 	// TODO: set ExplicitBucketBoundaries here and in prometheus from the previous specification

--- a/pkg/internal/pipe/config.go
+++ b/pkg/internal/pipe/config.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/beyla/pkg/internal/transform"
 )
 
+const ReporterLRUSize = 256
+
 var defaultConfig = Config{
 	ChannelBufferLen: 10,
 	LogLevel:         "INFO",
@@ -37,14 +39,14 @@ var defaultConfig = Config{
 		MetricsProtocol:   otel.ProtocolUnset,
 		Interval:          5 * time.Second,
 		Buckets:           otel.DefaultBuckets,
-		ReportersCacheLen: 16,
+		ReportersCacheLen: ReporterLRUSize,
 	},
 	Traces: otel.TracesConfig{
 		Protocol:           otel.ProtocolUnset,
 		TracesProtocol:     otel.ProtocolUnset,
 		MaxQueueSize:       4096,
 		MaxExportBatchSize: 4096,
-		ReportersCacheLen:  16,
+		ReportersCacheLen:  ReporterLRUSize,
 	},
 	Prometheus: prom.PrometheusConfig{
 		Path:    "/metrics",

--- a/pkg/internal/pipe/config_test.go
+++ b/pkg/internal/pipe/config_test.go
@@ -90,7 +90,7 @@ attributes:
 			CommonEndpoint:    "localhost:3131",
 			MetricsEndpoint:   "localhost:3030",
 			Protocol:          otel.ProtocolUnset,
-			ReportersCacheLen: 16,
+			ReportersCacheLen: ReporterLRUSize,
 			Buckets: otel.Buckets{
 				DurationHistogram:    []float64{0, 1, 2},
 				RequestSizeHistogram: otel.DefaultBuckets.RequestSizeHistogram,
@@ -102,7 +102,7 @@ attributes:
 			TracesEndpoint:     "localhost:3232",
 			MaxQueueSize:       4096,
 			MaxExportBatchSize: 4096,
-			ReportersCacheLen:  16,
+			ReportersCacheLen:  ReporterLRUSize,
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path: "/metrics",

--- a/test/integration/docker-compose-java-system-wide.yml
+++ b/test/integration/docker-compose-java-system-wide.yml
@@ -1,0 +1,96 @@
+version: '3.8'
+
+services:
+  testserver:
+    image: ghcr.io/grafana/beyla-test/greeting-java-native/0.0.1
+    ports:
+      - "8086:8085"
+    environment:
+      LOG_LEVEL: DEBUG
+    depends_on:
+      otelcol:
+        condition: service_started
+ 
+  testserverjar:
+    image: ghcr.io/grafana/beyla-test/greeting-java-jar/0.0.1
+    ports:
+      - "8087:8085"
+    environment:
+      LOG_LEVEL: DEBUG
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  autoinstrumenter:
+    build:
+      context: ../..
+      dockerfile: ./test/integration/components/beyla/Dockerfile
+    command:
+      - /beyla
+      - --config=/configs/instrumenter-config-java.yml
+    volumes:
+      - ./configs/:/configs
+      - ../../testoutput:/coverage
+      - ../../testoutput/run:/var/run/beyla
+    image: hatest-javaautoinstrumenter
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      BEYLA_PRINT_TRACES: "true"
+      BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"
+      BEYLA_EXECUTABLE_NAME: "${JAVA_EXECUTABLE_NAME}"
+      BEYLA_SYSTEM_WIDE: "${BEYLA_SYSTEM_WIDE}"
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME}"
+      BEYLA_SERVICE_NAMESPACE: "integration-test"
+      BEYLA_METRICS_INTERVAL: "10ms"
+      BEYLA_BPF_BATCH_TIMEOUT: "10ms"
+      BEYLA_LOG_LEVEL: "DEBUG"
+      BEYLA_BPF_DEBUG: "TRUE"
+      BEYLA_METRICS_REPORT_TARGET: "true"
+      BEYLA_METRICS_REPORT_PEER: "true"
+      BEYLA_HOSTNAME: "beyla"
+      BEYLA_TRACES_REPORT_CACHE_LEN: 1 # bad setting, used for testing only
+      BEYLA_METRICS_REPORT_CACHE_LEN: 1 # bad setting, used for testing only
+    depends_on:
+      testserver:
+        condition: service_started
+      testserverjar:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.77.0
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: [ "--config=/etc/otelcol-config/otelcol-config.yml" ]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317"          # OTLP over gRPC receiver
+      - "4318:4318"     # OTLP over HTTP receiver
+      - "9464"          # Prometheus exporter
+      - "8888"          # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v2.34.0
+    container_name: prometheus
+    command:
+      - --storage.tsdb.retention.time=1m
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -177,8 +177,8 @@ func TestSuite_Java_PID(t *testing.T) {
 // same as Test suite for java, but using the system_wide instrumentation
 // TODO: Fix the service name, mimir seems to work with what we have, but not Prometheus
 func TestSuite_Java_SystemWide(t *testing.T) {
-	compose, err := docker.ComposeSuite("docker-compose-java.yml", path.Join(pathOutput, "test-suite-java-system-wide.log"))
-	compose.Env = append(compose.Env, `BEYLA_SYSTEM_WIDE=TRUE`, `JAVA_EXECUTABLE_NAME=`, `JAVA_TEST_MODE=-native`)
+	compose, err := docker.ComposeSuite("docker-compose-java-system-wide.yml", path.Join(pathOutput, "test-suite-java-system-wide.log"))
+	compose.Env = append(compose.Env, `BEYLA_SYSTEM_WIDE=TRUE`, `JAVA_EXECUTABLE_NAME=`)
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", testREDMetricsJavaHTTPSystemWide)


### PR DESCRIPTION
Tracking more than the LRU size of the processes can cause no events to come through, if all processes regularly generate events. So, with this PR I'm changing the cleanup of the exporters to be done with a Go finalizer when we are sure that there are no more uses of an evicted exporter, as well as increasing the exporters size to support larger number of services.

Closes https://github.com/grafana/beyla/issues/496

Waiting to see if it's confirmed.