### PR TITLE
use privileged: true by default in some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ See [Documentation](https://grafana.com/docs/beyla/) and the [quickstart tutoria
   support Go applications built with a major **Go version no earlier than 3 versions** behind the current
   stable major release.  
 - Administrative access to execute the instrumenter
-    - Or execute it from a user enabling the `SYS_ADMIN` capability.
+    - Or execute it from a user enabling the `SYS_ADMIN` capability. This might not work in some
+      container environments.
 
 | Library                                       | Working  |
 |-----------------------------------------------|----------|

--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -33,12 +33,8 @@ spec:
           image: grafana/beyla:latest
           imagePullPolicy: IfNotPresent
           securityContext:
+            privileged: true
             runAsUser: 0
-            # uncomment the following line if the logs still show permission errors:
-            # privileged: true
-            capabilities:
-              add:
-                - SYS_ADMIN
           env:
             - name: BEYLA_SERVICE_NAME
               value: "goblog"

--- a/docs/sources/setup/docker.md
+++ b/docs/sources/setup/docker.md
@@ -21,7 +21,8 @@ grafana/beyla:latest
 
 The Beyla container must be configured in following way:
 
-- run as a **privileged** container, or as a container with the `SYS_ADMIN` capability
+- run as a **privileged** container, or as a container with the `SYS_ADMIN` capability (but
+  this last option might not work in some container environments)
 - share the PID space with the container that is being instrumented
 
 ## Docker CLI example
@@ -43,7 +44,8 @@ export BEYLA_OPEN_PORT=8443
 
 Beyla needs to be run with the following settings:
 
-- in `--privileged` mode, or with `SYS_ADMIN` capability
+- in `--privileged` mode, or with `SYS_ADMIN` capability (despite `SYS_ADMIN` might
+  not be enough privileges in some container environments)
 - a container PID namespace, with the option `--pid="container:goblog"`.
 
 ```sh
@@ -90,8 +92,7 @@ services:
   autoinstrumenter:
     image: grafana/beyla:latest
     pid: "service:goblog"
-    cap_add:
-      - SYS_ADMIN
+    privileged: true
     # If using the above capability fails to instrument your service, remove it
     # and uncomment the line below
     # privileged: true

--- a/docs/sources/tutorial/index.md
+++ b/docs/sources/tutorial/index.md
@@ -288,7 +288,7 @@ part of the code to be instrumented, putting the focus on your critical operatio
 Another limitation to consider is that Beyla requires
 elevated privileges; not actually a `root` user, but at least it has to run with the
 `CAP_SYS_ADMIN` capability. If you run the tool as a container (Docker, Kubernetes...), it
-has to be privileged, or configured with the `CAP_SYS_ADMIN` capability.
+has to be privileged.
 
 In the future, we plan to add metrics about other well-established protocols, like
 database or message queuing connections.


### PR DESCRIPTION
During the first contact with Beyla, many users copy directly the deployment examples that we provide.

Since they often use Kind or Docker Desktop from their laptops, the defaulted `CAP_SYS_ADMIN` configuration might not work and they struggle guessing what's failing.

From the quickstart examples, we replace the capabilities configuration by `privileged: true`.

In the rest of the documentation, we clarify that `SYS_ADMIN` might not work in some runtime configurations.