### PR TITLE
Improve Ruby and Python executable detection

### DIFF
--- a/pkg/internal/exec/proclang.go
+++ b/pkg/internal/exec/proclang.go
@@ -1,10 +1,14 @@
 package exec
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
+
+var rubyModule = regexp.MustCompile(`^(.*/)?ruby[\d.]*$`)
+var pythonModule = regexp.MustCompile(`^(.*/)?python[\d.]*$`)
 
 func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	if strings.Contains(moduleName, "libcoreclr.so") {
@@ -16,10 +20,10 @@ func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	if strings.HasSuffix(moduleName, "/node") || moduleName == "node" {
 		return svc.InstrumentableNodejs
 	}
-	if strings.HasSuffix(moduleName, "/ruby") || moduleName == "ruby" {
+	if rubyModule.MatchString(moduleName) {
 		return svc.InstrumentableRuby
 	}
-	if strings.Contains(moduleName, "/python") || moduleName == "python" || moduleName == "python3" {
+	if pythonModule.MatchString(moduleName) {
 		return svc.InstrumentablePython
 	}
 

--- a/pkg/internal/exec/proclang_test.go
+++ b/pkg/internal/exec/proclang_test.go
@@ -18,11 +18,18 @@ func TestModuleDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("/usr/bin/node"))
 	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("node"))
 	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby3"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby3.0"))
 	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("ruby"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("ruby3"))
+	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("ruby3.1.2"))
 	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("/usr/bin/python3.18"))
 	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("python"))
 	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("/usr/bin/python"))
 	assert.Equal(t, svc.InstrumentablePython, instrumentableFromModuleMap("python3"))
+
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromModuleMap("/usr/lib/rubybutnotreallyruby"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromModuleMap("/usr/lib/pythonbutnotreallypython"))
 }
 
 func TestSymbolDetection(t *testing.T) {


### PR DESCRIPTION
I was testing a scenario where Ruby services were not properly detected when they included the version suffix in the module name with the path, e.g.:

```
mmacias@lima-ubuntu-lts:~$ cat /proc/15165/maps
aaaab3630000-aaaab3631000 r-xp 00000000 fc:01 7810                       /usr/bin/ruby3.0
aaaab3641000-aaaab3642000 r--p 00001000 fc:01 7810                       /usr/bin/ruby3.0
aaaab3642000-aaaab3643000 rw-p 00002000 fc:01 7810                       /usr/bin/ruby3.0
```