### PR TITLE
Open source redirects

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -11,6 +11,8 @@ keywords:
   - Beyla
   - eBPF
   - instrumentation
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/
 ---
 
 # Grafana Beyla

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -6,6 +6,8 @@ weight: 2
 keywords:
   - Beyla
   - eBPF
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/configure/
 ---
 
 ![Grafana Beyla Logo](https://grafana.com/media/docs/grafana-cloud/beyla/beyla-logo-2.png)
@@ -19,7 +21,7 @@ Beyla can be configured in the following ways:
 
 For information on the metrics Beyla exports, see the [exported metrics]({{< relref "../metrics.md" >}}) documentation.
 
-**Note**: If you will be using Beyla to generate traces, please make sure you've read our documentation section on configuring 
+**Note**: If you will be using Beyla to generate traces, please make sure you've read our documentation section on configuring
 the [Routes Decorator]({{< relref "../configure/options#routes-decorator" >}}). Since Beyla is auto-instrumenting your application without any
 special language level support, configuring the low cardinality routes decorator is very important for optimal results.
 

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -6,6 +6,8 @@ weight: 2
 keywords:
   - Beyla
   - eBPF
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/configure/export-modes/
 ---
 
 # Beyla export modes

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -6,6 +6,8 @@ weight: 1
 keywords:
   - Beyla
   - eBPF
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/configure/options/
 ---
 
 # Beyla configuration options
@@ -103,7 +105,7 @@ For example, specifying the following property:
 ```
 open_port: 80,443,8000-8999
 ```
-Would make Beyla to select any executable that opens port 80, 443, or any of the ports between 8000 and 8999 included. 
+Would make Beyla to select any executable that opens port 80, 443, or any of the ports between 8000 and 8999 included.
 
 This property is used to select a single process to instrument, or a group of processes of
 similar characteristics. For more fine-grained process selection and grouping, you can
@@ -218,7 +220,7 @@ service, Beyla will take the service name attribute from the executable name. Th
 service namespace for all the processes matching this group will be `MyApplication`.
 
 The second group in the above example YAML will select any executable whose path contains
-`regexp`, but instead of taking the service name from the executable name, it will override 
+`regexp`, but instead of taking the service name from the executable name, it will override
 the service name with `TestLoadGenerator`.
 
 The rest of this section describes the properties that are accepted in each entry of the
@@ -234,7 +236,7 @@ Each `services` entry is a map where the properties can be grouped according to 
 |--------|---------|--------|-------------------|
 | `name` | --      | string | (see description) |
 
-Defines a name for the matching instrumented service. It will be used to populate the `service.name` 
+Defines a name for the matching instrumented service. It will be used to populate the `service.name`
 OTEL property and/or the `service_name` prometheus property in the exported metrics/traces.
 
 If the property is not set, it will default to any of the following properties, in order of
@@ -370,14 +372,14 @@ add a noticeable delay in the time the metrics are submitted and become external
 | `track_request_headers` | `BEYLA_BPF_TRACK_REQUEST_HEADERS` | boolean | (false) |
 
 Enables tracking of request headers for the purposes of processing any incoming 'Traceparent'
-header values. If this option is enabled, when Beyla encounters an incoming server request with 
+header values. If this option is enabled, when Beyla encounters an incoming server request with
 a 'Traceparent' header value, it will use the provided 'trace id' to create its own trace spans.
 
-This option does not have an effect on Go applications, where the 'Traceparent' field is always 
+This option does not have an effect on Go applications, where the 'Traceparent' field is always
 processed, without additional tracking of the request headers.
 
 Enabling this option may increase Beyla's performance overhead in high request volume scenarios.
-Please note that this option is only useful when generating Beyla traces, it does not affect 
+Please note that this option is only useful when generating Beyla traces, it does not affect
 generation of Beyla metrics.
 
 ## Configuration of metrics and traces attributes
@@ -515,7 +517,7 @@ property:
 /user/456/basket/3
 ```
 
-Additionally, the route matcher also supports the wildcard character `*`, which can be used to 
+Additionally, the route matcher also supports the wildcard character `*`, which can be used to
 match path prefixes. For example, if you define the following pattern:
 
 ```yaml
@@ -552,7 +554,7 @@ routes:
 
 Any event paths which have a prefix of `/v1` or are equal to `/health` will be ignored.
 
-This option is very useful if you want to prevent certain paths used development or service health monitoring, to be 
+This option is very useful if you want to prevent certain paths used development or service health monitoring, to be
 recorded as traces or metrics.
 
 | YAML          | Env var | Type   | Default    |
@@ -570,7 +572,7 @@ Possible values for the `ignore_mode` property are:
 Selectively ignoring only certain type of events might be useful in certain scenarios. For example, you may want to
 know the performance metrics of your health check API, but you wouldn't want the overhead of those trace records in
 your target traces database. In this this example scenario, you would set the `ignore_mode` property to `traces`, such
-that only traces matching the `ignored_patterns` will be discarded, while metrics will still be recorded. 
+that only traces matching the `ignored_patterns` will be discarded, while metrics will still be recorded.
 
 | YAML        | Env var | Type   | Default    |
 | ----------- | ------- | ------ | ---------- |
@@ -821,7 +823,7 @@ In addition, you can configure the sampling under the `sampler` YAML subsection 
 otel_traces_export:
   sampler:
     name: "traceidratio"
-    arg: "0.1" 
+    arg: "0.1"
 ```
 
 If you are using the Grafana Agent as your OTEL collector, you can configure the sampling

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -7,6 +7,8 @@ keywords:
   - Beyla
   - eBPF
   - metrics
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/metrics/
 ---
 
 # Beyla exported metrics

--- a/docs/sources/requesttime.md
+++ b/docs/sources/requesttime.md
@@ -8,6 +8,8 @@ keywords:
   - eBPF
   - request timing
   - service time
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/requesttime/
 ---
 
 # Measuring total request times, instead of service times

--- a/docs/sources/setup/_index.md
+++ b/docs/sources/setup/_index.md
@@ -6,6 +6,8 @@ weight: 1
 keywords:
   - Beyla
   - eBPF
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/setup/
 ---
 
 ![Grafana Beyla Logo](https://grafana.com/media/docs/grafana-cloud/beyla/beyla-logo-2.png)
@@ -20,6 +22,6 @@ There are different options to set up and run Beyla:
 
 For information on configuration options and data export modes, see the [Configure Beyla]({{< relref "../configure/_index.md" >}}) documentation.
 
-**Note**: If you will be using Beyla to generate traces, please make sure you've read our documentation section on configuring 
+**Note**: If you will be using Beyla to generate traces, please make sure you've read our documentation section on configuring
 the [Routes Decorator]({{< relref "../configure/options#routes-decorator" >}}). Since Beyla is auto-instrumenting your application without any
 special language level support, configuring the low cardinality routes decorator is very important for optimal results.

--- a/docs/sources/setup/docker.md
+++ b/docs/sources/setup/docker.md
@@ -7,6 +7,8 @@ keywords:
   - Beyla
   - eBPF
   - Docker
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/setup/docker/
 ---
 
 # Run Beyla as a Docker container

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -7,6 +7,8 @@ keywords:
   - Beyla
   - eBPF
   - Kubernetes
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/setup/kubernetes/
 ---
 
 # Deploy Beyla in Kubernetes

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -6,6 +6,8 @@ weight: 1
 keywords:
   - Beyla
   - eBPF
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/setup/standalone/
 ---
 
 ![Grafana Beyla Logo](https://grafana.com/media/docs/grafana-cloud/beyla/beyla-logo-2.png)

--- a/docs/sources/stability.md
+++ b/docs/sources/stability.md
@@ -7,11 +7,13 @@ keywords:
   - Beyla
   - Stability
   - Compatibility
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/stability/
 ---
 
 # Stability Guarantees
 
-Beyla promises configuration and exposition format stability within a major version, and strives to avoid breaking changes for key features. 
+Beyla promises configuration and exposition format stability within a major version, and strives to avoid breaking changes for key features.
 Some features, which are of cosmetic nature, experimental or still under development, are not covered by this. We can only guarantee stability
 for Linux kernel, or eBPF features of the Linux kernel, versions released at the time the Beyla major version was released.
 
@@ -21,11 +23,11 @@ for Linux kernel, or eBPF features of the Linux kernel, versions released at the
   New configuration options might be added in minor releases, but we'll never
   remove or rename an existing option within a major release.
 - The configuration environment variable names and their format.
-- The externally perceived behaviour of the configuration options, regardless if 
-  the option was supplied via the configuration file or the environment variables. 
+- The externally perceived behaviour of the configuration options, regardless if
+  the option was supplied via the configuration file or the environment variables.
 - The OpenTelemetry and Prometheus exposition formats. If we need to add support
-  for newer exposition formats, we'll provide an opt-in way to enable those. The 
-  only exception to this rule is the `telemetry.sdk.language` resource attribute 
+  for newer exposition formats, we'll provide an opt-in way to enable those. The
+  only exception to this rule is the `telemetry.sdk.language` resource attribute
   (see "detection of new programming languages" below).
 - The type of telemetry data we produce, e.g. metrics and traces.
 
@@ -37,7 +39,7 @@ for Linux kernel, or eBPF features of the Linux kernel, versions released at the
 - The log output of Beyla, or which messages will appear at
   which logging levels.
 - The number or types of eBPF probes that we'll install
-  in each Beyla version. 
+  in each Beyla version.
 - The detection of new programming languages. We may add support for detecting
   new programming languages, so the reported telemetry SDK language field may
   change between minors for previously undetected languages.

--- a/docs/sources/tutorial/index.md
+++ b/docs/sources/tutorial/index.md
@@ -10,6 +10,8 @@ keywords:
   - Grafana Cloud
   - tutorial
   - RED metrics
+aliases:
+  - /docs/grafana-cloud/monitor-applications/beyla/tutorial/
 ---
 
 ![Grafana Beyla Logo](https://grafana.com/media/docs/grafana-cloud/beyla/beyla-logo-2.png)
@@ -146,7 +148,7 @@ The output format is:
 
 ```
 Request_time (response_duration) status_code http_method path
-  source->destination request_size service_id 
+  source->destination request_size service_id
 ```
 
 Experiment with the `curl` command and make additional requests to see how it affects the trace output. For example, the following request would send a 6-bytes POST request and the service will take 200ms to respond:


### PR DESCRIPTION
This PR redirects cloud docs to open source docs now that the open source docs are deployed https://github.com/grafana/beyla/issues/319 https://grafana.com/docs/beyla/latest/

@jdbaldry do we need to unmount the cloud docs too? 