### PR TITLE
Report Beyla as SDK name

### DIFF
--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -64,6 +64,8 @@ func otelResource(service svc.ID) *resource.Resource {
 		// so the service is visible in the ServicesList
 		// This attribute also allows that App O11y plugin shows this app as a Go application.
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
+		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
+		semconv.TelemetrySDKNameKey.String("beyla"),
 	}
 
 	if service.Namespace != "" {

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -111,6 +111,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	sd = jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "rust"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "beyla"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,
 	}, process.Tags)

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -147,6 +147,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "beyla"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,
 	}, process.Tags)
@@ -361,6 +362,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "nodejs"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "beyla"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,
 	}, process.Tags)


### PR DESCRIPTION
Change the sdk name so that we can easily detect beyla events in databases.