### PR TITLE
Send K8s metadata as resource metadata

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters-settings:
     go: "1.21"
   gocritic:
     enabled-checks:
-      - hugeParam
       - rangeExprCopy
       - rangeValCopy
       - indexAlloc

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -312,12 +312,12 @@ func appendK8sLabelNames(names []string) []string {
 func appendK8sLabelValues(values []string, span *request.Span) []string {
 	// must follow the order in appendK8sLabelNames
 	values = append(values,
-		span.Metadata[transform.NamespaceName],
-		span.Metadata[transform.DeploymentName],
-		span.Metadata[transform.PodName],
-		span.Metadata[transform.NodeName],
-		span.Metadata[transform.PodUID],
-		span.Metadata[transform.PodStartTime],
+		span.ServiceID.Metadata[transform.NamespaceName],
+		span.ServiceID.Metadata[transform.DeploymentName],
+		span.ServiceID.Metadata[transform.PodName],
+		span.ServiceID.Metadata[transform.NodeName],
+		span.ServiceID.Metadata[transform.PodUID],
+		span.ServiceID.Metadata[transform.PodStartTime],
 	)
 	return values
 }

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -63,8 +63,7 @@ type Span struct {
 	RequestStart  int64
 	Start         int64
 	End           int64
-	ServiceID     svc.ID
-	Metadata      map[string]string
+	ServiceID     svc.ID // TODO: rename to Service or ResourceAttrs
 	TraceID       trace2.TraceID
 	SpanID        trace2.SpanID
 	ParentSpanID  trace2.SpanID

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -38,9 +38,18 @@ func (it InstrumentableType) String() string {
 	}
 }
 
-// ID stores the coordinates that uniquely identifies a service:
-// its name and optionally a namespace
+// UID uniquely identifies a service instance
+type UID string
+
+// ID stores the metadata attributes of a service/resource
+// TODO: rename to svc.Attributes
 type ID struct {
+	// UID might coincide with other fields (usually, Instance), but UID
+	// can't be overriden by the user, so it's the only field that can be
+	// used for internal differentiation of the users.
+	// UID is not exported in the metrics or traces.
+	UID UID
+
 	Name string
 	// AutoName is true if the Name has been automatically set by Beyla (e.g. executable name when
 	// the Name is empty). This will allow later refinement of the Name value (e.g. to override it
@@ -49,6 +58,8 @@ type ID struct {
 	Namespace   string
 	SDKLanguage InstrumentableType
 	Instance    string
+
+	Metadata map[string]string
 }
 
 func (i *ID) String() string {

--- a/pkg/internal/transform/k8s_test.go
+++ b/pkg/internal/transform/k8s_test.go
@@ -63,7 +63,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.pod.uid":         "uid-12",
 			"k8s.deployment.name": "deployment-12",
 			"k8s.pod.start_time":  "2020-01-02 12:12:56",
-		}, deco[0].Metadata)
+		}, deco[0].ServiceID.Metadata)
 	})
 	t.Run("pod info without deployment should set replicaset as name", func(t *testing.T) {
 		inputCh <- []request.Span{{
@@ -79,7 +79,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.pod.name":       "pod-34",
 			"k8s.pod.uid":        "uid-34",
 			"k8s.pod.start_time": "2020-01-02 12:34:56",
-		}, deco[0].Metadata)
+		}, deco[0].ServiceID.Metadata)
 	})
 	t.Run("pod info with only pod name should set pod name as name", func(t *testing.T) {
 		inputCh <- []request.Span{{
@@ -95,7 +95,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.pod.name":       "the-pod",
 			"k8s.pod.uid":        "uid-56",
 			"k8s.pod.start_time": "2020-01-02 12:56:56",
-		}, deco[0].Metadata)
+		}, deco[0].ServiceID.Metadata)
 	})
 	t.Run("process without pod Info won't be decorated", func(t *testing.T) {
 		inputCh <- []request.Span{{
@@ -105,7 +105,7 @@ func TestDecoration(t *testing.T) {
 		require.Len(t, deco, 1)
 		assert.Empty(t, deco[0].ServiceID.Namespace)
 		assert.Equal(t, "exec", deco[0].ServiceID.Name)
-		assert.Empty(t, deco[0].Metadata)
+		assert.Empty(t, deco[0].ServiceID.Metadata)
 	})
 	t.Run("if service name or namespace are manually specified, don't override them", func(t *testing.T) {
 		inputCh <- []request.Span{{
@@ -122,7 +122,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.pod.uid":         "uid-12",
 			"k8s.deployment.name": "deployment-12",
 			"k8s.pod.start_time":  "2020-01-02 12:12:56",
-		}, deco[0].Metadata)
+		}, deco[0].ServiceID.Metadata)
 	})
 }
 

--- a/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
@@ -70,7 +70,7 @@ func TestBasicTracing(t *testing.T) {
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.deployment.name", Type: "string", Value: "^otherinstance"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-					}, parent.Tags)
+					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd)
 
 				}, test.Interval(100*time.Millisecond))

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -54,13 +54,14 @@ func TestPythonBasicTracing(t *testing.T) {
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd, sd.String())
 
+					// check the process information
 					sd = jaeger.DiffAsRegexp([]jaeger.Tag{
 						{Key: "k8s.pod.name", Type: "string", Value: "^pytestserver$"},
 						{Key: "k8s.node.name", Type: "string", Value: ".+-control-plane$"},
 						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-					}, parent.Tags)
+					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd, sd.String())
 				}, test.Interval(100*time.Millisecond))
 				return ctx


### PR DESCRIPTION
A member of the community realized that we weren't sending the OTEL K8s attributes in the correct place:

> hello team, first of all thanks for the all the excellent work beyla, this is a fascinating project, I think it is hugely benefical. the first questions is about how the k8s attribute decorator is populating its metadata.
reading the current code
https://github.com/grafana/beyla/blob/main/pkg/internal/transform/k8s.go#L121
it is setting resource metadata on the spans instead of the resource
https://github.com/grafana/beyla/blob/main/pkg/internal/export/otel/traces.go#L482
based on the semantic conventions (and for example the otel collector example),
https://opentelemetry.io/docs/specs/semconv/resource/k8s/#pod
is there a consideration to follow the resource attribute conventions?