### PR TITLE
Add BEYLA_CONFIG_PATH env var

### DIFF
--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -32,6 +32,10 @@ func main() {
 	configPath := flag.String("config", "", "path to the configuration file")
 	flag.Parse()
 
+	if cfg := os.Getenv("BEYLA_CONFIG"); cfg != "" {
+		configPath = &cfg
+	}
+
 	config := loadConfig(configPath)
 
 	if err := lvl.UnmarshalText([]byte(config.LogLevel)); err != nil {

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -32,7 +32,7 @@ func main() {
 	configPath := flag.String("config", "", "path to the configuration file")
 	flag.Parse()
 
-	if cfg := os.Getenv("BEYLA_CONFIG"); cfg != "" {
+	if cfg := os.Getenv("BEYLA_CONFIG_PATH"); cfg != "" {
 		configPath = &cfg
 	}
 

--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -64,7 +64,7 @@ spec:
             - mountPath: /sys/kernel/security
               name: system-config
           env:
-            - name: BEYLA_CONFIG
+            - name: BEYLA_CONFIG_PATH
               value: "/config/beyla-config.yml"
             - name: BEYLA_SERVICE_NAME
               value: "goblog"

--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -55,7 +55,6 @@ spec:
         - name: autoinstrumenter
           image: grafana/beyla:main
           imagePullPolicy: IfNotPresent
-          command: ["/beyla", "--config=/config/beyla-config.yml"]          
           securityContext:
             privileged: true
             runAsUser: 0
@@ -65,6 +64,8 @@ spec:
             - mountPath: /sys/kernel/security
               name: system-config
           env:
+            - name: BEYLA_CONFIG
+              value: "/config/beyla-config.yml"
             - name: BEYLA_SERVICE_NAME
               value: "goblog"
             - name: BEYLA_PRINT_TRACES

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -195,7 +195,7 @@ metrics or traces.
 
 To run the auto-instrumentation tool (previously downloaded from the [Beyla releases page](https://github.com/grafana/beyla/releases)),
 you will need to specify the path to the configuration YAML file, either with the
-`-config` command-line argument or the `BEYLA_CONFIG` environment variable.
+`-config` command-line argument or the `BEYLA_CONFIG_PATH` environment variable.
 For example `instrument-config.yml`:
 
 ```
@@ -203,6 +203,6 @@ beyla -config instrument-config.yml
 ```
 or
 ```
-BEYLA_CONFIG=instrument-config.yml beyla
+BEYLA_CONFIG_PATH=instrument-config.yml beyla
 ```
 

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -194,8 +194,15 @@ allow exporting both metrics and traces, or only one of them to export either
 metrics or traces.
 
 To run the auto-instrumentation tool (previously downloaded from the [Beyla releases page](https://github.com/grafana/beyla/releases)),
-you will need to specify the path to the configuration YAML file. For example `instrument-config.yml`:
+you will need to specify the path to the configuration YAML file, either with the
+`-config` command-line argument or the `BEYLA_CONFIG` environment variable.
+For example `instrument-config.yml`:
 
 ```
 beyla -config instrument-config.yml
 ```
+or
+```
+BEYLA_CONFIG=instrument-config.yml beyla
+```
+

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -14,7 +14,7 @@ aliases:
 
 Beyla can be configured via environment variables or via
 a YAML configuration file that is passed either with the `-config` command-line
-argument or the `BEYLA_CONFIG` environment variable.
+argument or the `BEYLA_CONFIG_PATH` environment variable.
 Environment variables have priority over the properties in the
 configuration file. For example, in the following command line, the BEYLA_OPEN_PORT option,
 is used to override any open_port settings inside the config.yaml file:
@@ -24,7 +24,7 @@ $ BEYLA_OPEN_PORT=8080 beyla -config /path/to/config.yaml
 ```
 or
 ```
-$ BEYLA_OPEN_PORT=8080 BEYLA_CONFIG=/path/to/config.yaml beyla
+$ BEYLA_OPEN_PORT=8080 BEYLA_CONFIG_PATH=/path/to/config.yaml beyla
 ```
 
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -13,14 +13,20 @@ aliases:
 # Beyla configuration options
 
 Beyla can be configured via environment variables or via
-a YAML configuration file that is passed with the `-config` command-line
-argument. Environment variables have priority over the properties in the
+a YAML configuration file that is passed either with the `-config` command-line
+argument or the `BEYLA_CONFIG` environment variable.
+Environment variables have priority over the properties in the
 configuration file. For example, in the following command line, the BEYLA_OPEN_PORT option,
 is used to override any open_port settings inside the config.yaml file:
 
 ```
 $ BEYLA_OPEN_PORT=8080 beyla -config /path/to/config.yaml
 ```
+or
+```
+$ BEYLA_OPEN_PORT=8080 BEYLA_CONFIG=/path/to/config.yaml beyla
+```
+
 
 At the end of this document, there is an [example of YAML configuration file](#yaml-file-example).
 

--- a/docs/sources/distributed-traces.md
+++ b/docs/sources/distributed-traces.md
@@ -47,7 +47,7 @@ services:
   beyla:
     image: grafana/beyla:latest
     environment:
-      BEYLA_CONFIG: "/configs/beyla-config.yml"
+      BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
     volumes:
       - /sys/kernel/security:/sys/kernel/security
 ```

--- a/docs/sources/distributed-traces.md
+++ b/docs/sources/distributed-traces.md
@@ -46,9 +46,8 @@ services:
   ...
   beyla:
     image: grafana/beyla:latest
-    command:
-      - /beyla
-      - --config=/configs/beyla-config.yml
+    environment:
+      BEYLA_CONFIG: "/configs/beyla-config.yml"
     volumes:
       - /sys/kernel/security:/sys/kernel/security
 ```

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -111,7 +111,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -111,7 +111,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -122,7 +122,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -122,7 +122,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -121,7 +121,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -121,7 +121,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -119,7 +119,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -119,7 +119,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -119,7 +119,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -119,7 +119,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -107,7 +107,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument:
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -107,7 +107,7 @@ routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG` environment variable instead):
+Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -245,7 +245,7 @@ this site).
 
 To provide the configuration as a file, the recommended way is to deploy
 a ConfigMap with the intended configuration, then mount it into the Beyla
-Pod, and refer to it by overriding the Beyla container command.
+Pod, and refer to it with the `BEYLA_CONFIG` environment variable.
 
 Example of ConfigMap with the Beyla YAML documentation:
 
@@ -302,8 +302,11 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: beyla-config
-          # tell beyla where to find the configuration file
-          command: ["/beyla", "--config=/config/beyla-config.yml"]
+          env:
+            # tell beyla where to find the configuration file
+            - name: BEYLA_CONFIG
+              value: "/config/beyla-config.yml"
+
 ```
 
 ## Providing secret configuration

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -245,7 +245,7 @@ this site).
 
 To provide the configuration as a file, the recommended way is to deploy
 a ConfigMap with the intended configuration, then mount it into the Beyla
-Pod, and refer to it with the `BEYLA_CONFIG` environment variable.
+Pod, and refer to it with the `BEYLA_CONFIG_PATH` environment variable.
 
 Example of ConfigMap with the Beyla YAML documentation:
 
@@ -304,7 +304,7 @@ spec:
               name: beyla-config
           env:
             # tell beyla where to find the configuration file
-            - name: BEYLA_CONFIG
+            - name: BEYLA_CONFIG_PATH
               value: "/config/beyla-config.yml"
 
 ```

--- a/docs/sources/tutorial/k8s-walkthrough.md
+++ b/docs/sources/tutorial/k8s-walkthrough.md
@@ -301,13 +301,14 @@ spec:
         - name: beyla
           image: grafana/beyla:main
           imagePullPolicy: IfNotPresent
-          command: ["/beyla", "--config=/config/beyla-config.yml"]
           securityContext:
             privileged: true # mandatory!
           volumeMounts:
             - mountPath: /config
               name: beyla-config
           env:
+            - name: BEYLA_CONFIG
+              value: "/config/beyla-config.yml"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/docs/sources/tutorial/k8s-walkthrough.md
+++ b/docs/sources/tutorial/k8s-walkthrough.md
@@ -307,7 +307,7 @@ spec:
             - mountPath: /config
               name: beyla-config
           env:
-            - name: BEYLA_CONFIG
+            - name: BEYLA_CONFIG_PATH
               value: "/config/beyla-config.yml"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               valueFrom:

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -19,9 +19,6 @@ services:
   # Beyla for NGINX
   nginxbeyla:
     image: grafana/beyla:latest
-    command:
-      - /beyla
-      - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -30,6 +27,7 @@ services:
     network_mode: "service:nginx"
     pid: "service:nginx"
     environment:
+      BEYLA_CONFIG: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "3330"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -51,9 +49,6 @@ services:
   # Beyla for Java Spring Boot 3.0 GraalVM Native Image
   gobeyla:
     image: grafana/beyla:latest
-    command:
-      - /beyla
-      - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -62,6 +57,7 @@ services:
     network_mode: "service:gotestserver"
     pid: "service:gotestserver"
     environment:
+      BEYLA_CONFIG: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8080"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -83,9 +79,6 @@ services:
   # Beyla for Java Spring Boot 3.0 GraalVM Native Image
   javabeyla:
     image: grafana/beyla:latest
-    command:
-      - /beyla
-      - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -94,6 +87,7 @@ services:
     network_mode: "service:javatestserver"
     pid: "service:javatestserver"
     environment:
+      BEYLA_CONFIG: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8085"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -115,9 +109,6 @@ services:
   # Beyla for Rust Actix
   rustbeyla:
     image: grafana/beyla:latest
-    command:
-      - /beyla
-      - --config=/configs/beyla-config.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -126,6 +117,7 @@ services:
     network_mode: "service:rusttestserver"
     pid: "service:rusttestserver"
     environment:
+      BEYLA_CONFIG: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8090"
       BEYLA_SERVICE_NAMESPACE: "demo"

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     network_mode: "service:nginx"
     pid: "service:nginx"
     environment:
-      BEYLA_CONFIG: "/configs/beyla-config.yml"
+      BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "3330"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -57,7 +57,7 @@ services:
     network_mode: "service:gotestserver"
     pid: "service:gotestserver"
     environment:
-      BEYLA_CONFIG: "/configs/beyla-config.yml"
+      BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8080"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -87,7 +87,7 @@ services:
     network_mode: "service:javatestserver"
     pid: "service:javatestserver"
     environment:
-      BEYLA_CONFIG: "/configs/beyla-config.yml"
+      BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8085"
       BEYLA_SERVICE_NAMESPACE: "demo"
@@ -117,7 +117,7 @@ services:
     network_mode: "service:rusttestserver"
     pid: "service:rusttestserver"
     environment:
-      BEYLA_CONFIG: "/configs/beyla-config.yml"
+      BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "8090"
       BEYLA_SERVICE_NAMESPACE: "demo"

--- a/test/integration/docker-compose-1.16.yml
+++ b/test/integration/docker-compose-1.16.yml
@@ -17,9 +17,6 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
-    command:
-      - /beyla
-      - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs
       - ../../testoutput:/coverage
@@ -28,6 +25,7 @@ services:
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     pid: "service:testserver"
     environment:
+      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: 8080

--- a/test/integration/docker-compose-1.16.yml
+++ b/test/integration/docker-compose-1.16.yml
@@ -25,7 +25,7 @@ services:
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     pid: "service:testserver"
     environment:
-      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
+      BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: 8080

--- a/test/integration/docker-compose-java-host.yml
+++ b/test/integration/docker-compose-java-host.yml
@@ -12,9 +12,6 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
-    command:
-      - /beyla
-      - --config=/configs/instrumenter-config-java-host.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -25,6 +22,7 @@ services:
     network_mode: "host"
     pid: "host"
     environment:
+      BEYLA_CONFIG: "/configs/instrumenter-config-java-host.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-java-host.yml
+++ b/test/integration/docker-compose-java-host.yml
@@ -22,7 +22,7 @@ services:
     network_mode: "host"
     pid: "host"
     environment:
-      BEYLA_CONFIG: "/configs/instrumenter-config-java-host.yml"
+      BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java-host.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-java-pid.yml
+++ b/test/integration/docker-compose-java-pid.yml
@@ -22,7 +22,7 @@ services:
     network_mode: "service:testserver"
     pid: "service:testserver"
     environment:
-      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
+      BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-java-pid.yml
+++ b/test/integration/docker-compose-java-pid.yml
@@ -12,9 +12,6 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
-    command:
-      - /beyla
-      - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -25,6 +22,7 @@ services:
     network_mode: "service:testserver"
     pid: "service:testserver"
     environment:
+      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-java-system-wide.yml
+++ b/test/integration/docker-compose-java-system-wide.yml
@@ -25,9 +25,6 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
-    command:
-      - /beyla
-      - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs
       - ../../testoutput:/coverage
@@ -37,6 +34,7 @@ services:
     network_mode: "service:testserver"
     pid: "host"
     environment:
+      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-java-system-wide.yml
+++ b/test/integration/docker-compose-java-system-wide.yml
@@ -34,7 +34,7 @@ services:
     network_mode: "service:testserver"
     pid: "host"
     environment:
-      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
+      BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"

--- a/test/integration/docker-compose-python.yml
+++ b/test/integration/docker-compose-python.yml
@@ -26,7 +26,7 @@ services:
     network_mode: "service:testserver"
     pid: "service:testserver"
     environment:
-      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
+      BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"

--- a/test/integration/docker-compose-python.yml
+++ b/test/integration/docker-compose-python.yml
@@ -16,9 +16,6 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
-    command:
-      - /beyla
-      - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
@@ -29,6 +26,7 @@ services:
     network_mode: "service:testserver"
     pid: "service:testserver"
     environment:
+      BEYLA_CONFIG: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -83,7 +83,7 @@ spec:
             - mountPath: /testoutput
               name: testoutput
           env:
-            - name: BEYLA_CONFIG
+            - name: BEYLA_CONFIG_PATH
               value: "/configs/instrumenter-config.yml"
             - name: GOCOVERDIR
               value: "/testoutput"

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -83,6 +83,8 @@ spec:
             - mountPath: /testoutput
               name: testoutput
           env:
+            - name: BEYLA_CONFIG
+              value: "/configs/instrumenter-config.yml"
             - name: GOCOVERDIR
               value: "/testoutput"
             - name: BEYLA_PRINT_TRACES

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -95,7 +95,7 @@ spec:
             - mountPath: /testoutput
               name: testoutput
           env:
-            - name: BEYLA_CONFIG
+            - name: BEYLA_CONFIG_PATH
               value: "/configs/instrumenter-config-promscrape.yml"
             - name: GOCOVERDIR
               value: "/testoutput"

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -89,13 +89,14 @@ spec:
           imagePullPolicy: Never # loaded into Kind from localhost
           securityContext:
             privileged: true
-          command: ["/beyla", "--config=/configs/instrumenter-config-promscrape.yml"]
           volumeMounts:
             - mountPath: /configs
               name: configs
             - mountPath: /testoutput
               name: testoutput
           env:
+            - name: BEYLA_CONFIG
+              value: "/configs/instrumenter-config-promscrape.yml"
             - name: GOCOVERDIR
               value: "/testoutput"
             - name: BEYLA_DISCOVERY_POLL_INTERVAL


### PR DESCRIPTION
Adding @grafsean as a reviewer, as this PR affects documentation.

As an addition to the `-config` CLI argument, the introduced `BEYLA_CONFIG_PATH` env var would allow cleaner configuration in container-based environments, not forcing the users to override the `/beyla` command invocation (which should be kept as an internal detail).

The good-old `-config` CLI arg will keep working as usual.