### PR TITLE
Fix K8s tutorial images

### DIFF
--- a/docs/sources/tutorial/k8s-walkthrough.md
+++ b/docs/sources/tutorial/k8s-walkthrough.md
@@ -347,13 +347,13 @@ Now, go to your Grafana Cloud instance and, in the _Explore_ section, search for
 all the traces. In the list, you will see only the traces from the `docs`
 instance (port 8081):
 
-![](/Users/mmacias/Desktop/tut-traces-list.png)
+![](https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/tut-traces-list.png)
 
-If you enter into the trace details, you will also see that the traces are
+If you enter into the trace details, you will also see that the resource attributes of the traces are
 decorated with the metadata of the Kubernetes Pod running the instrumented
 service:
 
-![](/Users/mmacias/Desktop/tut-trace-details.png)
+![](https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/tut-trace-details.png)
 
 ## Links
 


### PR DESCRIPTION
By some reason, my IDE replaced the image links by local paths in the K8s quickstart tutorial; and we didn't notice it