### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 USER 0:0
 
-CMD [ "/beyla" ]
+ENTRYPOINT [ "/beyla" ]

--- a/test/integration/components/beyla/Dockerfile
+++ b/test/integration/components/beyla/Dockerfile
@@ -29,4 +29,4 @@ WORKDIR /
 COPY --from=builder /src/bin/beyla .
 USER 0:0
 
-CMD [ "/beyla" ]
+ENTRYPOINT [ "/beyla" ]

--- a/test/integration/components/beyla/Dockerfile_dbg
+++ b/test/integration/components/beyla/Dockerfile_dbg
@@ -35,4 +35,4 @@ COPY --from=builder /beyla_wrapper.sh /beyla_wrapper.sh
 WORKDIR /
 USER 0:0
 
-CMD [ "/beyla_wrapper.sh" ]
+ENTRYPOINT [ "/beyla_wrapper.sh" ]

--- a/test/integration/docker-compose-1.17.yml
+++ b/test/integration/docker-compose-1.17.yml
@@ -21,7 +21,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config${INSTRUMENTER_CONFIG_SUFFIX}.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-client.yml
+++ b/test/integration/docker-compose-client.yml
@@ -14,7 +14,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config${INSTRUMENTER_CONFIG_SUFFIX}.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-dotnet.yml
+++ b/test/integration/docker-compose-dotnet.yml
@@ -17,8 +17,9 @@ services:
     build:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile${INSTRUMENT_DOCKERFILE_SUFFIX}
-    command:
+    entrypoint:
       - /beyla${INSTRUMENT_COMMAND_SUFFIX}
+    command:
       - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-java.yml
+++ b/test/integration/docker-compose-java.yml
@@ -16,7 +16,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-java.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -85,7 +85,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-multiexec.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-nodeclient.yml
+++ b/test/integration/docker-compose-nodeclient.yml
@@ -20,7 +20,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config${INSTRUMENTER_CONFIG_SUFFIX}.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-nodejs.yml
+++ b/test/integration/docker-compose-nodejs.yml
@@ -21,7 +21,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-node.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-ruby.yml
+++ b/test/integration/docker-compose-ruby.yml
@@ -14,7 +14,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-ruby.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose-rust.yml
+++ b/test/integration/docker-compose-rust.yml
@@ -17,7 +17,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config${INSTRUMENTER_CONFIG_SUFFIX}.yml
     volumes:
       - ./configs/:/configs

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -76,7 +76,7 @@ spec:
           imagePullPolicy: Never # loaded into Kind from localhost
           securityContext:
             privileged: true
-          command: ["--config=/configs/instrumenter-config.yml"]
+          args: ["--config=/configs/instrumenter-config.yml"]
           volumeMounts:
             - mountPath: /configs
               name: configs

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -76,7 +76,7 @@ spec:
           imagePullPolicy: Never # loaded into Kind from localhost
           securityContext:
             privileged: true
-          command: ["/beyla", "--config=/configs/instrumenter-config.yml"]
+          command: ["--config=/configs/instrumenter-config.yml"]
           volumeMounts:
             - mountPath: /configs
               name: configs

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -43,7 +43,7 @@ spec:
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost
-          command: ["/beyla", "--config=/config/beyla-config.yml"]
+          command: ["--config=/config/beyla-config.yml"]
           securityContext:
             privileged: true
             runAsUser: 0

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -43,7 +43,7 @@ spec:
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost
-          command: ["--config=/config/beyla-config.yml"]
+          args: ["--config=/config/beyla-config.yml"]
           securityContext:
             privileged: true
             runAsUser: 0

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -49,7 +49,7 @@ spec:
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost
-          command: ["/beyla", "--config=/config/beyla-config.yml"]
+          command: ["--config=/config/beyla-config.yml"]
           securityContext:
             privileged: true
             runAsUser: 0

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -49,7 +49,7 @@ spec:
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost
-          command: ["--config=/config/beyla-config.yml"]
+          args: ["--config=/config/beyla-config.yml"]
           securityContext:
             privileged: true
             runAsUser: 0

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -75,7 +75,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: [ "/beyla", "--config=/configs/instrumenter-config.yml" ]
+      command: ["--config=/configs/instrumenter-config.yml" ]
       ports:
         - containerPort: 8999
       volumeMounts:

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -75,7 +75,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: ["--config=/configs/instrumenter-config.yml" ]
+      args: ["--config=/configs/instrumenter-config.yml" ]
       ports:
         - containerPort: 8999
       volumeMounts:

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -43,7 +43,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: ["--config=/configs/instrumenter-config.yml" ]
+      args: ["--config=/configs/instrumenter-config.yml" ]
       volumeMounts:
         - mountPath: /configs
           name: configs

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -43,7 +43,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: [ "/beyla", "--config=/configs/instrumenter-config.yml" ]
+      command: ["--config=/configs/instrumenter-config.yml" ]
       volumeMounts:
         - mountPath: /configs
           name: configs

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -87,7 +87,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: ["--config=/configs/instrumenter-config.yml"]
+      args: ["--config=/configs/instrumenter-config.yml"]
       volumeMounts:
         - mountPath: /configs
           name: configs

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -87,7 +87,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      command: ["/beyla", "--config=/configs/instrumenter-config.yml"]
+      command: ["--config=/configs/instrumenter-config.yml"]
       volumeMounts:
         - mountPath: /configs
           name: configs

--- a/test/oats/docker-compose-beyla-build.yml
+++ b/test/oats/docker-compose-beyla-build.yml
@@ -6,7 +6,6 @@ services:
       context: ../../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-traces.yml
     volumes:
       - {{ .ConfigDir }}:/configs

--- a/test/oats/docker-compose-beyla-gosqlclient.yml
+++ b/test/oats/docker-compose-beyla-gosqlclient.yml
@@ -13,7 +13,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-traces.yml
     volumes:
       - {{ .ConfigDir }}:/configs

--- a/test/oats/docker-compose-beyla-gotestserver.yml
+++ b/test/oats/docker-compose-beyla-gotestserver.yml
@@ -18,7 +18,6 @@ services:
       context: ../..
       dockerfile: ./test/integration/components/beyla/Dockerfile
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-traces.yml
     volumes:
       - {{ .ConfigDir }}:/configs

--- a/test/oats/docker-compose-beyla-image.yml
+++ b/test/oats/docker-compose-beyla-image.yml
@@ -4,7 +4,6 @@ services:
   autoinstrumenter:
     image: grafana/beyla:latest
     command:
-      - /beyla
       - --config=/configs/instrumenter-config-traces.yml
     volumes:
       - {{ .ConfigDir }}:/configs


### PR DESCRIPTION
Replaced `CMD` by `ENTRYPOINT` in Beyla. This should be the standard way of specifying a container command.

This will cause that some docker-compose setups will break because this `command` value won't be valid anymore:
```yaml
command:
- /beyla
- config-file.yml
```
The correct and standard way will be:
```
command:
- config-file.yml
```
Kubernetes deployments will still keep working because they accept either `command` for the whole CLI and `args` for the arguments.

I will document this as the very first item in the release notes.