### PR TITLE
Add backport workflow to cherry-pick PR merge commits to other long-lived branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,26 @@
+name: Backport PR creator
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  main:
+    if: github.repository == 'grafana/beyla'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/grafana-github-actions
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          token: ${{ secret.GITHUB_TOKEN }}
+          labelsToAdd: backport
+          title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
Taking a look at the [backport Action](https://github.com/grafana/grafana-github-actions/blob/main/backport/action.yml#L5).

> GitHub token with issue, comment, and label read/write permissions

It looks to be covered by the default permissions for [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

I'm guessing that the Action does require extra permissions since all other instances of the workflow are using PATs or apps but we can test this by merging this PR and trying a backport.

Use of the workflow is documented in [Backport changes](https://grafana.com/docs/writers-toolkit/review/backporting/) although the documentation is pretty specific to Grafana, the workflow will behave similarly here.