### PR TITLE
Support DaemonSet and StatefulSet in discovery and decoration

### DIFF
--- a/pkg/internal/discover/services/criteria.go
+++ b/pkg/internal/discover/services/criteria.go
@@ -11,18 +11,26 @@ import (
 )
 
 const (
-	AttrNamespace      = "k8s_namespace"
-	AttrPodName        = "k8s_pod_name"
-	AttrDeploymentName = "k8s_deployment_name"
-	AttrReplicaSetName = "k8s_replicaset_name"
+	AttrNamespace       = "k8s_namespace"
+	AttrPodName         = "k8s_pod_name"
+	AttrDeploymentName  = "k8s_deployment_name"
+	AttrReplicaSetName  = "k8s_replicaset_name"
+	AttrDaemonSetName   = "k8s_daemonset_name"
+	AttrStatefulSetName = "k8s_statefulset_name"
+	// AttrOwnerName would be a generic search criteria that would
+	// match against deployment, replicaset, daemonset and statefulset names
+	AttrOwnerName = "k8s_owner_name"
 )
 
 // any attribute name not in this set will cause an error during the YAML unmarshalling
 var allowedAttributeNames = map[string]struct{}{
-	AttrNamespace:      {},
-	AttrPodName:        {},
-	AttrDeploymentName: {},
-	AttrReplicaSetName: {},
+	AttrNamespace:       {},
+	AttrPodName:         {},
+	AttrDeploymentName:  {},
+	AttrReplicaSetName:  {},
+	AttrDaemonSetName:   {},
+	AttrStatefulSetName: {},
+	AttrOwnerName:       {},
 }
 
 // ProcessInfo stores some relevant information about a running process

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/grafana/beyla/pkg/internal/connector"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
+	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
-	"github.com/grafana/beyla/pkg/internal/transform"
 )
 
 // using labels and names that are equivalent names to the OTEL attributes
@@ -312,12 +312,12 @@ func appendK8sLabelNames(names []string) []string {
 func appendK8sLabelValues(values []string, span *request.Span) []string {
 	// must follow the order in appendK8sLabelNames
 	values = append(values,
-		span.ServiceID.Metadata[transform.NamespaceName],
-		span.ServiceID.Metadata[transform.DeploymentName],
-		span.ServiceID.Metadata[transform.PodName],
-		span.ServiceID.Metadata[transform.NodeName],
-		span.ServiceID.Metadata[transform.PodUID],
-		span.ServiceID.Metadata[transform.PodStartTime],
+		span.ServiceID.Metadata[kube.NamespaceName],
+		span.ServiceID.Metadata[kube.DeploymentName],
+		span.ServiceID.Metadata[kube.PodName],
+		span.ServiceID.Metadata[kube.NodeName],
+		span.ServiceID.Metadata[kube.PodUID],
+		span.ServiceID.Metadata[kube.PodStartTime],
 	)
 	return values
 }

--- a/pkg/internal/kube/owner.go
+++ b/pkg/internal/kube/owner.go
@@ -1,0 +1,89 @@
+package kube
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	NamespaceName   = "k8s.namespace.name"
+	PodName         = "k8s.pod.name"
+	DeploymentName  = "k8s.deployment.name"
+	ReplicaSetName  = "k8s.replicaset.name"
+	DaemonSetName   = "k8s.daemonset.name"
+	StatefulSetName = "k8s.statefulset.name"
+	NodeName        = "k8s.node.name"
+	PodUID          = "k8s.pod.uid"
+	PodStartTime    = "k8s.pod.start_time"
+)
+
+type OwnerType int
+
+const (
+	OwnerUnknown = OwnerType(iota)
+	OwnerReplicaSet
+	OwnerDeployment
+	OwnerStatefulSet
+	OwnerDaemonSet
+)
+
+func (o OwnerType) LabelName() string {
+	switch o {
+	case OwnerReplicaSet:
+		return ReplicaSetName
+	case OwnerDeployment:
+		return DeploymentName
+	case OwnerStatefulSet:
+		return StatefulSetName
+	case OwnerDaemonSet:
+		return DaemonSetName
+	default:
+		return "k8s.unknown.owner"
+	}
+}
+
+type Owner struct {
+	Type OwnerType
+	Name string
+	// Owner of the owner. For example, a ReplicaSet might be owned by a Deployment
+	Owner *Owner
+}
+
+// OwnerFromPodInfo returns the pod Owner reference. It might be
+// null if the Pod does not have any owner
+func OwnerFromPodInfo(pod *v1.Pod) *Owner {
+	for i := range pod.OwnerReferences {
+		or := &pod.OwnerReferences[i]
+		if or.APIVersion != "apps/v1" {
+			continue
+		}
+		switch or.Kind {
+		case "ReplicaSet":
+			return &Owner{Type: OwnerReplicaSet, Name: or.Name}
+		case "Deployment":
+			return &Owner{Type: OwnerDeployment, Name: or.Name}
+		case "StatefulSet":
+			return &Owner{Type: OwnerStatefulSet, Name: or.Name}
+		case "DaemonSet":
+			return &Owner{Type: OwnerDaemonSet, Name: or.Name}
+		}
+	}
+	return nil
+}
+
+func (o *Owner) String() string {
+	sb := strings.Builder{}
+	o.string(&sb)
+	return sb.String()
+}
+
+func (o *Owner) string(sb *strings.Builder) {
+	if o.Owner != nil {
+		o.Owner.string(sb)
+		sb.WriteString("->")
+	}
+	sb.WriteString(o.Type.LabelName())
+	sb.WriteByte(':')
+	sb.WriteString(o.Name)
+}

--- a/pkg/internal/kube/owner_test.go
+++ b/pkg/internal/kube/owner_test.go
@@ -1,0 +1,14 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwnerString(t *testing.T) {
+	owner := Owner{Type: OwnerReplicaSet, Name: "rs"}
+	assert.Equal(t, "k8s.replicaset.name:rs", owner.String())
+	owner.Owner = &Owner{Type: OwnerDeployment, Name: "dep"}
+	assert.Equal(t, "k8s.deployment.name:dep->k8s.replicaset.name:rs", owner.String())
+}

--- a/pkg/internal/transform/k8s_test.go
+++ b/pkg/internal/transform/k8s_test.go
@@ -23,18 +23,17 @@ func TestDecoration(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "pod-12", Namespace: "the-ns", UID: "uid-12",
 			},
-			NodeName:       "the-node",
-			StartTimeStr:   "2020-01-02 12:12:56",
-			DeploymentName: "deployment-12",
-			ReplicaSetName: "rs-12",
+			NodeName:     "the-node",
+			StartTimeStr: "2020-01-02 12:12:56",
+			Owner:        &kube.Owner{Type: kube.OwnerDeployment, Name: "deployment-12"},
 		},
 		34: &kube.PodInfo{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "pod-34", Namespace: "the-ns", UID: "uid-34",
 			},
-			NodeName:       "the-node",
-			StartTimeStr:   "2020-01-02 12:34:56",
-			ReplicaSetName: "rs-34",
+			NodeName:     "the-node",
+			StartTimeStr: "2020-01-02 12:34:56",
+			Owner:        &kube.Owner{Type: kube.OwnerReplicaSet, Name: "rs-34"},
 		},
 		56: &kube.PodInfo{
 			ObjectMeta: v1.ObjectMeta{
@@ -74,11 +73,12 @@ func TestDecoration(t *testing.T) {
 		assert.Equal(t, "the-ns", deco[0].ServiceID.Namespace)
 		assert.Equal(t, "rs-34", deco[0].ServiceID.Name)
 		assert.Equal(t, map[string]string{
-			"k8s.node.name":      "the-node",
-			"k8s.namespace.name": "the-ns",
-			"k8s.pod.name":       "pod-34",
-			"k8s.pod.uid":        "uid-34",
-			"k8s.pod.start_time": "2020-01-02 12:34:56",
+			"k8s.node.name":       "the-node",
+			"k8s.namespace.name":  "the-ns",
+			"k8s.replicaset.name": "rs-34",
+			"k8s.pod.name":        "pod-34",
+			"k8s.pod.uid":         "uid-34",
+			"k8s.pod.start_time":  "2020-01-02 12:34:56",
 		}, deco[0].ServiceID.Metadata)
 	})
 	t.Run("pod info with only pod name should set pod name as name", func(t *testing.T) {

--- a/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dsservice
+spec:
+  selector:
+    app: dsservice
+  ports:
+    - port: 8081
+      name: http1
+      targetPort: http1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dsservice
+  labels:
+    app: dsservice
+spec:
+  selector:
+    matchLabels:
+      app: dsservice
+  template:
+    metadata:
+      name: dsservice
+      labels:
+        app: dsservice
+    spec:
+      containers:
+        - name: dsservice
+          image: testserver:dev
+          imagePullPolicy: Never # loaded into Kind from localhost
+          ports:
+            - containerPort: 8081
+              hostPort: 8081
+              name: http1
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"

--- a/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: statefulservice
+spec:
+  selector:
+    app: statefulservice
+  ports:
+    - port: 8080
+      name: http
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulservice
+  labels:
+    app: statefulservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statefulservice
+  template:
+    metadata:
+      name: statefulservice
+      labels:
+        app: statefulservice
+    spec:
+      containers:
+        - name: statefulservice
+          image: testserver:dev
+          imagePullPolicy: Never # loaded into Kind from localhost
+          ports:
+            - containerPort: 8080
+              hostPort: 8080
+              name: http
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"
+  serviceName: statefulservice

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -15,6 +15,9 @@ data:
         # deployment (ignoring the "testserver" in the other pod)
         # name and namespace will be automatically set from the K8s metadata
         - k8s_deployment_name: otherinstance
+        # used in the k8s_owners_*_test.go
+        - k8s_statefulset_name: statefulservice
+        - k8s_daemonset_name: dsservice
     routes:
       patterns:
         - /pingpong

--- a/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
@@ -64,7 +64,7 @@ func TestDaemonSetMetadata(t *testing.T) {
 						{Key: "k8s.node.name", Type: "string", Value: ".+-control-plane$"},
 						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
-						{Key: "k8s.statefulset.name", Type: "string", Value: "^dsservice$"},
+						{Key: "k8s.daemonset.name", Type: "string", Value: "^dsservice$"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd)

--- a/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package owners
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/grafana/beyla/test/integration/components/jaeger"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+)
+
+// For the DaemonSet scenario, we only check that Beyla is able to instrument any
+// process in the system. We just check that traces are properly generated without
+// entering in too many details
+func TestDaemonSetMetadata(t *testing.T) {
+	feat := features.New("Beyla is able to decorate the metadata of a daemonset").
+		Assess("it sends decorated traces for the daemonset",
+			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+				test.Eventually(t, testTimeout, func(t require.TestingT) {
+					// Invoking both service instances, but we will expect that only one
+					// is instrumented, according to the discovery mechanisms
+					resp, err := http.Get("http://localhost:38081/pingpong")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+
+					resp, err = http.Get(jaegerQueryURL + "?service=dsservice")
+					require.NoError(t, err)
+					if resp == nil {
+						return
+					}
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+					var tq jaeger.TracesQuery
+					require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+					traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/pingpong"})
+					require.NotEmpty(t, traces)
+					trace := traces[0]
+					require.NotEmpty(t, trace.Spans)
+
+					// Check that the service.namespace is set from the K8s namespace
+					assert.Len(t, trace.Processes, 1)
+					for _, proc := range trace.Processes {
+						sd := jaeger.DiffAsRegexp([]jaeger.Tag{
+							{Key: "service.namespace", Type: "string", Value: "^default$"},
+						}, proc.Tags)
+						require.Empty(t, sd)
+					}
+
+					// Check the information of the parent span
+					res := trace.FindByOperationName("GET /pingpong")
+					require.Len(t, res, 1)
+					parent := res[0]
+					sd := jaeger.DiffAsRegexp([]jaeger.Tag{
+						{Key: "k8s.pod.name", Type: "string", Value: "^dsservice-.*"},
+						{Key: "k8s.node.name", Type: "string", Value: ".+-control-plane$"},
+						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
+						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
+						{Key: "k8s.statefulset.name", Type: "string", Value: "^dsservice$"},
+						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
+					}, trace.Processes[parent.ProcessID].Tags)
+					require.Empty(t, sd)
+
+					// check that no other labels are added
+					sd = jaeger.DiffAsRegexp([]jaeger.Tag{
+						{Key: "k8s.deployment.name", Type: "string"},
+						{Key: "k8s.statefulset.name", Type: "string"},
+					}, trace.Processes[parent.ProcessID].Tags)
+					require.Equal(t, jaeger.DiffResult{
+						{ErrType: jaeger.ErrTypeMissing, Expected: jaeger.Tag{Key: "k8s.deployment.name", Type: "string"}},
+						{ErrType: jaeger.ErrTypeMissing, Expected: jaeger.Tag{Key: "k8s.statefulset.name", Type: "string"}},
+					}, sd)
+
+				}, test.Interval(100*time.Millisecond))
+				return ctx
+			},
+		).Feature()
+	cluster.TestEnv().Test(t, feat)
+}

--- a/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+// package owners tests the selection and detection of pod ownership metadata, others than deployment:
+// StatefulSet and DaemonSet
+package owners
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/beyla/test/integration/components/docker"
+	"github.com/grafana/beyla/test/integration/components/kube"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/tools"
+)
+
+const (
+	testTimeout = 3 * time.Minute
+
+	jaegerQueryURL = "http://localhost:36686/api/traces"
+)
+
+var cluster *kube.Kind
+
+func TestMain(m *testing.M) {
+	if err := docker.Build(os.Stdout, tools.ProjectDir(),
+		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
+		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
+	); err != nil {
+		slog.Error("can't build docker images", err)
+		os.Exit(-1)
+	}
+
+	cluster = kube.NewKind("test-kind-cluster-daemonset",
+		kube.ExportLogs(k8s.PathKindLogs),
+		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.LocalImage("testserver:dev"),
+		kube.LocalImage("beyla:dev"),
+		kube.LocalImage("grpcpinger:dev"),
+		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
+		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
+		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
+		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
+		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-statefulset.yml"),
+		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-daemonset.yml"),
+		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset.yml"),
+	)
+
+	cluster.Run(m)
+}

--- a/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package owners
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/grafana/beyla/test/integration/components/jaeger"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+)
+
+// For the DaemonSet scenario, we only check that Beyla is able to instrument any
+// process in the system. We just check that traces are properly generated without
+// entering in too many details
+func TestStatefulSetMetadata(t *testing.T) {
+	feat := features.New("Beyla is able to decorate the metadata of a statefulset").
+		Assess("it sends decorated traces for the statefulset",
+			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+				test.Eventually(t, testTimeout, func(t require.TestingT) {
+					// Invoking both service instances, but we will expect that only one
+					// is instrumented, according to the discovery mechanisms
+					resp, err := http.Get("http://localhost:38080/pingpong")
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+
+					resp, err = http.Get(jaegerQueryURL + "?service=statefulservice")
+					require.NoError(t, err)
+					if resp == nil {
+						return
+					}
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+					var tq jaeger.TracesQuery
+					require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+					traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/pingpong"})
+					require.NotEmpty(t, traces)
+					trace := traces[0]
+					require.NotEmpty(t, trace.Spans)
+
+					// Check that the service.namespace is set from the K8s namespace
+					assert.Len(t, trace.Processes, 1)
+					for _, proc := range trace.Processes {
+						sd := jaeger.DiffAsRegexp([]jaeger.Tag{
+							{Key: "service.namespace", Type: "string", Value: "^default$"},
+						}, proc.Tags)
+						require.Empty(t, sd)
+					}
+
+					// Check the information of the parent span
+					res := trace.FindByOperationName("GET /pingpong")
+					require.Len(t, res, 1)
+					parent := res[0]
+					sd := jaeger.DiffAsRegexp([]jaeger.Tag{
+						{Key: "k8s.pod.name", Type: "string", Value: "^statefulservice-.*"},
+						{Key: "k8s.node.name", Type: "string", Value: ".+-control-plane$"},
+						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
+						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
+						{Key: "k8s.statefulset.name", Type: "string", Value: "^statefulservice$"},
+						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
+					}, trace.Processes[parent.ProcessID].Tags)
+					require.Empty(t, sd)
+
+					// check that no other labels are added
+					sd = jaeger.DiffAsRegexp([]jaeger.Tag{
+						{Key: "k8s.deployment.name", Type: "string"},
+						{Key: "k8s.daemonset.name", Type: "string"},
+					}, trace.Processes[parent.ProcessID].Tags)
+					require.Equal(t, jaeger.DiffResult{
+						{ErrType: jaeger.ErrTypeMissing, Expected: jaeger.Tag{Key: "k8s.deployment.name", Type: "string"}},
+						{ErrType: jaeger.ErrTypeMissing, Expected: jaeger.Tag{Key: "k8s.daemonset.name", Type: "string"}},
+					}, sd)
+				}, test.Interval(100*time.Millisecond))
+				return ctx
+			},
+		).Feature()
+	cluster.TestEnv().Test(t, feat)
+}


### PR DESCRIPTION
Missing documentation (in another PR).

Addresses bug https://github.com/grafana/beyla/issues/562

We were assuming that instrumented applications were only deployed as Deployments, while they can be plain replicasets, or daemonsets or statefulsets.

This adds the following metadata fields: `k8s.statefulset.name`, `k8s.daemonset.name` and the following discovery arguments: `k8s_owner_name`, `k8s_statefulset_name`,  `k8s_daemonset_name` (to be documented).