### PR TITLE
Prometheus exporter: add k8s_replicaset_name, k8s_daemonset_name and k8s_statefulset_name attributes

### DIFF
--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -45,12 +45,15 @@ const (
 	rpcSystemGRPC        = "rpc_system"
 	DBOperationKey       = "db_operation"
 
-	k8sNamespaceName  = "k8s_namespace_name"
-	k8sPodName        = "k8s_pod_name"
-	k8sDeploymentName = "k8s_deployment_name"
-	k8sNodeName       = "k8s_node_name"
-	k8sPodUID         = "k8s_pod_uid"
-	k8sPodStartTime   = "k8s_pod_start_time"
+	k8sNamespaceName   = "k8s_namespace_name"
+	k8sPodName         = "k8s_pod_name"
+	k8sDeploymentName  = "k8s_deployment_name"
+	k8sStatefulSetName = "k8s_statefulset_name"
+	k8sReplicaSetName  = "k8s_replicaset_name"
+	k8sDaemonSetName   = "k8s_daemonset_name"
+	k8sNodeName        = "k8s_node_name"
+	k8sPodUID          = "k8s_pod_uid"
+	k8sPodStartTime    = "k8s_pod_start_time"
 )
 
 // TODO: TLS
@@ -305,7 +308,8 @@ func (r *metricsReporter) labelValuesHTTP(span *request.Span) []string {
 }
 
 func appendK8sLabelNames(names []string) []string {
-	names = append(names, k8sNamespaceName, k8sDeploymentName, k8sPodName, k8sNodeName, k8sPodUID, k8sPodStartTime)
+	names = append(names, k8sNamespaceName, k8sPodName, k8sNodeName, k8sPodUID, k8sPodStartTime,
+		k8sDeploymentName, k8sReplicaSetName, k8sStatefulSetName, k8sDaemonSetName)
 	return names
 }
 
@@ -313,11 +317,14 @@ func appendK8sLabelValues(values []string, span *request.Span) []string {
 	// must follow the order in appendK8sLabelNames
 	values = append(values,
 		span.ServiceID.Metadata[kube.NamespaceName],
-		span.ServiceID.Metadata[kube.DeploymentName],
 		span.ServiceID.Metadata[kube.PodName],
 		span.ServiceID.Metadata[kube.NodeName],
 		span.ServiceID.Metadata[kube.PodUID],
 		span.ServiceID.Metadata[kube.PodStartTime],
+		span.ServiceID.Metadata[kube.DeploymentName],
+		span.ServiceID.Metadata[kube.ReplicaSetName],
+		span.ServiceID.Metadata[kube.StatefulSetName],
+		span.ServiceID.Metadata[kube.DaemonSetName],
 	)
 	return values
 }

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -105,6 +105,7 @@ func FeatureHTTPMetricsDecoration() features.Feature {
 				"k8s_pod_uid":         UUIDRegex,
 				"k8s_pod_start_time":  TimeRegex,
 				"k8s_deployment_name": "^testserver$",
+				"k8s_replicaset_name": "^testserver-",
 			}),
 		).Feature()
 }
@@ -134,6 +135,7 @@ func FeatureGRPCMetricsDecoration() features.Feature {
 				"k8s_pod_uid":         UUIDRegex,
 				"k8s_pod_start_time":  TimeRegex,
 				"k8s_deployment_name": "^testserver$",
+				"k8s_replicaset_name": "^testserver-",
 			}),
 		).Feature()
 }
@@ -156,10 +158,10 @@ func testMetricsDecoration(
 
 				for _, r := range results {
 					for ek, ev := range expectedLabels {
-						assert.Regexpf(t, ev, r.Metric[ek], "expected %q:%q entry in map %v", ek, ev, r.Metric)
+						assert.Regexpf(t, ev, r.Metric[ek], "%s: expected %q:%q entry in map %v", metric, ek, ev, r.Metric)
 					}
 					for _, ek := range expectedMissingLabels {
-						assert.NotContainsf(t, r.Metric, ek, "not expected %q entry in map %v", ek, r.Metric)
+						assert.NotContainsf(t, r.Metric, ek, "%s: not expected %q entry in map %v", metric, ek, r.Metric)
 					}
 				}
 			})


### PR DESCRIPTION
The [previous PR](https://github.com/grafana/beyla/pull/571) did not update the prometheus exporter.

Now, many labels might be empty. We will let the intermediate prometheus scraper (e.g. the Grafana Agent) to filter these properties.