### PR TITLE
Catch pids that are off a parent and not quite ready

### DIFF
--- a/pkg/internal/discover/matcher.go
+++ b/pkg/internal/discover/matcher.go
@@ -92,6 +92,17 @@ func (m *matcher) filterCreated(obj processAttrs) (Event[ProcessMatch], bool) {
 			}, true
 		}
 	}
+
+	// We didn't match the process, but let's see if the parent PID is tracked, it might be the child hasn't opened the port yet
+	if _, ok := m.processHistory[PID(proc.PPid)]; ok {
+		m.log.Debug("found process by matching the process parent id", "pid", proc.Pid, "ppid", proc.PPid, "comm", proc.ExePath, "metadata", obj.metadata)
+		m.processHistory[obj.pid] = proc
+		return Event[ProcessMatch]{
+			Type: EventCreated,
+			Obj:  ProcessMatch{Criteria: &m.criteria[0], Process: proc},
+		}, true
+	}
+
 	return Event[ProcessMatch]{}, false
 }
 


### PR DESCRIPTION
When we match processes by open port, it's possible that a child subprocess (Python, C++) is created, but the kernel hasn't associated yet their PID with the inode of the parent open port. There's a small time window when this can happen, us finding the child process but not seeing as matching by open port.

This PR adds an additional check that if we discover a child process and it doesn't match our criteria, but it's parent did, we'll start tracking the child process.

TODO:

- [x] unit tests (integration tests are hard to make)