### PR TITLE
Fix `publish-technical-documentation-release` workflow for tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -55,7 +55,10 @@ jobs:
         # Tags aren't necessarily made to the HEAD of the version branch.
         # The documentation to be published is always on the HEAD of the version branch.
         if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
-        run: git switch --detach origin/${{ steps.target.output.target }}.x
+        # Strip the 'v' prefix from docs-target output.
+        run: git switch --detach origin/release-${TARGET#v}
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
 
       - name: Publish to website repository (release)
         if: steps.has-matching-release-tag.outputs.bool == 'true'


### PR DESCRIPTION
Fix typo in variable from `docs-target` output and checkout correct branch.

The release branches are named `release-X.Y`.
The `docs-target` action outputs `vX.Y`.

The step now uses the output (fixing the typo in the GitHub variable name) as an environment variable so Bash can strip the `v` prefix.