### PR TITLE
Disable http2 context prop test

### DIFF
--- a/test/integration/http2go_test.go
+++ b/test/integration/http2go_test.go
@@ -93,6 +93,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 }
 
 func testNestedHTTP2Traces(t *testing.T, url string) {
+	t.Skip("seems flaky, we need to look into this")
 	var traceID string
 
 	var trace jaeger.Trace
@@ -170,7 +171,7 @@ func TestHTTP2Go(t *testing.T) {
 	})
 
 	// Seems flaky, we need to look into this.
-	if !lockdown && false {
+	if !lockdown {
 		t.Run("Go RED metrics: http2 context propagation ", func(t *testing.T) {
 			testNestedHTTP2Traces(t, "ping")
 			testNestedHTTP2Traces(t, "pingdo")

--- a/test/integration/http2go_test.go
+++ b/test/integration/http2go_test.go
@@ -169,7 +169,8 @@ func TestHTTP2Go(t *testing.T) {
 		testREDMetricsForHTTP2Library(t, "/pingrt", "http2-go")
 	})
 
-	if !lockdown {
+	// Seems flaky, we need to look into this.
+	if !lockdown && false {
 		t.Run("Go RED metrics: http2 context propagation ", func(t *testing.T) {
 			testNestedHTTP2Traces(t, "ping")
 			testNestedHTTP2Traces(t, "pingdo")


### PR DESCRIPTION
This new test seems flaky, I'm disabling it for now until we can look into it. Based on the logs the context propagation worked for all APIs, but the test can't seem to find certain paths. Based on what I can see the trace_id is the same between all the pairs of the client server calls

```
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (54.401µs[35.225µs]) 200 GET /ping [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-452f1eedac2a82df9f668ce46c4efce5-2eaa0c61ce388b0a-01]
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (757.726µs[757.726µs]) 200 GET /ping []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-452f1eedac2a82df9f668ce46c4efce5-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:12.867Z level=DEBUG msg="creating new Metrics reporter" component=otel.MetricsReporter service="{UID:beyla-22303 Name:server AutoName:false Namespace:http2-go SDKLanguage:go Instance:beyla-22303 Metadata:map[]}"
autoinstrumenter-1  | time=2024-02-01T14:58:12.867Z level=DEBUG msg="creating new Tracers reporter" component=otel.TracesReporter service="{UID:beyla-22303 Name:server AutoName:false Namespace:http2-go SDKLanguage:go Instance:beyla-22303 Metadata:map[]}"
autoinstrumenter-1  | time=2024-02-01T14:58:12.887Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | time=2024-02-01T14:58:12.887Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (35.516µs[25.096µs]) 200 GET /pingrt [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-0b948b184c1c14bba7482b636a9204b8-a8262b891cb50670-01]
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (1.047451ms[1.047451ms]) 200 GET /pingrt []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-0b948b184c1c14bba7482b636a9204b8-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:12.896Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (79.195µs[71.12µs]) 200 GET /pingdo [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-2f64d01f09336598c81ee6cdc27922d2-1a408f7b984cac24-01]
autoinstrumenter-1  | time=2024-02-01T14:58:12.898Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:12.2125812 (920.675µs[920.675µs]) 200 GET /pingdo []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-2f64d01f09336598c81ee6cdc27922d2-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:13.907Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (269.993µs[31.469µs]) 200 GET /ping [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-cf5881d7a1df16506e9f20a7f0c98829-caa04964684bfe6b-01]
autoinstrumenter-1  | time=2024-02-01T14:58:13.908Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (1.326671ms[1.326671ms]) 200 GET /ping []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-cf5881d7a1df16506e9f20a7f0c98829-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:13.927Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | time=2024-02-01T14:58:13.927Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (3.064939ms[3.064939ms]) 200 GET /pingrt []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-0bc66396e857484f00a2ce687a7fc808-0000000000000000-01]
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (52.768µs[25.978µs]) 200 GET /pingrt [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-0bc66396e857484f00a2ce687a7fc808-c448cb67292403b5-01]
autoinstrumenter-1  | time=2024-02-01T14:58:13.937Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (140.221µs[25.467µs]) 200 GET /pingdo [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-571555386f609b0cdd4c4b3544924216-84e551e2bda170d7-01]
autoinstrumenter-1  | time=2024-02-01T14:58:13.938Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:13.2125813 (670.769µs[670.769µs]) 200 GET /pingdo []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-571555386f609b0cdd4c4b3544924216-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.957Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (59.912µs[31.158µs]) 200 GET /ping [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-0eb95bdc20ba6a83a268b907755e6a10-b2593c5d8ea44724-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.957Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (668.945µs[668.945µs]) 200 GET /ping []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-0eb95bdc20ba6a83a268b907755e6a10-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.967Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (46.066µs[27.992µs]) 200 GET /pingrt [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-536b8f0573bc82ff3f18712fd9da7ab0-222345d427919986-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.967Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (699.275µs[699.275µs]) 200 GET /pingrt []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-536b8f0573bc82ff3f18712fd9da7ab0-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.988Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (40.882µs[23.384µs]) 200 GET /pingdo [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-e23da4c079cc25ab7e42463eb5f0a9fe-f2085c07ac229ea4-01]
autoinstrumenter-1  | time=2024-02-01T14:58:14.988Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:14.2125814 (571.244µs[571.244µs]) 200 GET /pingdo []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-e23da4c079cc25ab7e42463eb5f0a9fe-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:15.997Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:15.2125815 (111.556µs[31.359µs]) 200 GET /ping [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-45e474923b2d27edb4ea9822b98ef54b-9d81bc5d00cb0893-01]
autoinstrumenter-1  | time=2024-02-01T14:58:15.997Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:15.2125815 (720.194µs[720.194µs]) 200 GET /ping []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-45e474923b2d27edb4ea9822b98ef54b-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:16.017Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:16.2125816 (105.767µs[91.28µs]) 200 GET /pingrt [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-f421790e8179f09b010f8d96e50e7e6f-0714cbcde703d564-01]
autoinstrumenter-1  | time=2024-02-01T14:58:16.018Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:16.2125816 (559.642µs[559.642µs]) 200 GET /pingrt []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-f421790e8179f09b010f8d96e50e7e6f-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:16.027Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:16.2125816 (2.568792ms[2.568792ms]) 200 GET /pingdo []->[testserver:7373] size:0B svc=[http2-go/client go] traceparent=[00-29be891732b2d73ac43f86dc0b3279c3-0000000000000000-01]
autoinstrumenter-1  | time=2024-02-01T14:58:16.027Z level=DEBUG msg="submitting traces on timeout" component=nethttp.Tracer len=1
autoinstrumenter-1  | 2024-02-01 14:58:16.2125816 (71.405µs[29.986µs]) 200 GET /pingdo [172.18.0.5]->[testserver:7373] size:0B svc=[http2-go/server go] traceparent=[00-29be891732b2d73ac43f86dc0b3279c3-5603ca419fe4fa82-01]
```