### PR TITLE
Update metric collection names to stable HTTP spec

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -768,8 +768,8 @@ boundaries via a configuration file (see `buckets` YAML section of your metrics 
 
 Sets the bucket boundaries for the metrics related to the request duration. Specifically:
 
-- `http.server.duration` (OTEL) / `http_server_duration_seconds` (Prometheus)
-- `http.client.duration` (OTEL) / `http_client_duration_seconds` (Prometheus)
+- `http.server.request.duration` (OTEL) / `http_server_request_duration_seconds` (Prometheus)
+- `http.client.request.duration` (OTEL) / `http_client_request_duration_seconds` (Prometheus)
 - `rpc.server.duration` (OTEL) / `rpc_server_duration_seconds` (Prometheus)
 - `rpc.client.duration` (OTEL) / `rpc_client_duration_seconds` (Prometheus)
 
@@ -786,8 +786,8 @@ If the value is unset, the default bucket boundaries follow the
 
 Sets the bucket boundaries for the metrics related to request sizes. This is:
 
-- `http.server.request.size` (OTEL) / `http_server_request_size_bytes` (Prometheus)
-- `http.client.request.size` (OTEL) / `http_client_request_size_bytes` (Prometheus)
+- `http.server.request.body.size` (OTEL) / `http_server_request_body_size_bytes` (Prometheus)
+- `http.client.request.body.size` (OTEL) / `http_client_request_body_size_bytes` (Prometheus)
 
 If the value is unset, the default bucket boundaries are:
 

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -15,15 +15,15 @@ aliases:
 
 The following table describes the exported metrics in both OpenTelemetry and Prometheus format.
 
-| Name (OTEL)                | Name (Prometheus)                | Type      | Unit    | Description                                                  |
-| -------------------------- | -------------------------------- | --------- | ------- | ------------------------------------------------------------ |
-| `http.client.duration`     | `http_client_duration_seconds`   | Histogram | seconds | Duration of HTTP service calls from the client side          |
-| `http.client.request.size` | `http_client_request_size_bytes` | Histogram | bytes   | Size of the HTTP request body as sent by the client          |
-| `http.server.duration`     | `http_server_duration_seconds`   | Histogram | seconds | Duration of HTTP service calls from the server side          |
-| `http.server.request.size` | `http_server_request_size_bytes` | Histogram | bytes   | Size of the HTTP request body as received at the server side |
-| `rpc.client.duration`      | `rpc_client_duration_seconds`    | Histogram | seconds | Duration of GRPC service calls from the client side          |
-| `rpc.server.duration`      | `rpc_server_duration_seconds`    | Histogram | seconds | Duration of RPC service calls from the server side           |
-| `sql.client.duration`      | `sql_client_duration_seconds`    | Histogram | seconds | Duration of SQL client operations (Experimental)             |
+| Name (OTEL)                     | Name (Prometheus)                      | Type      | Unit    | Description                                                  |
+| ------------------------------- | -------------------------------------- | --------- | ------- | ------------------------------------------------------------ |
+| `http.client.request.duration`  | `http_client_request_duration_seconds` | Histogram | seconds | Duration of HTTP service calls from the client side          |
+| `http.client.request.body.size` | `http_client_request_body_size_bytes`  | Histogram | bytes   | Size of the HTTP request body as sent by the client          |
+| `http.server.request.duration`  | `http_server_request_duration_seconds` | Histogram | seconds | Duration of HTTP service calls from the server side          |
+| `http.server.request.body.size` | `http_server_request_body_size_bytes`  | Histogram | bytes   | Size of the HTTP request body as received at the server side |
+| `rpc.client.duration`           | `rpc_client_duration_seconds`          | Histogram | seconds | Duration of GRPC service calls from the client side          |
+| `rpc.server.duration`           | `rpc_server_duration_seconds`          | Histogram | seconds | Duration of RPC service calls from the server side           |
+| `sql.client.duration`           | `sql_client_duration_seconds`          | Histogram | seconds | Duration of SQL client operations (Experimental)             |
 
 ## Internal metrics
 

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -132,7 +132,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sort_desc(topk by(http_route, service_name) (5,  max by (http_route, service_name) (histogram_quantile(0.95,  (sum by(http_route, service_name, le) (rate(http_server_duration_bucket{instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))))))",
+          "expr": "sort_desc(topk by(http_route, service_name) (5,  max by (http_route, service_name) (histogram_quantile(0.95,  (sum by(http_route, service_name, le) (rate(http_server_request_duration_bucket{instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))))))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -417,7 +417,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(service_name, le) (rate(http_server_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(service_name, le) (rate(http_server_request_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))",
           "legendFormat": "HTTP p99",
           "range": true,
           "refId": "A"
@@ -428,7 +428,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) by (service_name, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) by (service_name, le))",
           "hide": false,
           "legendFormat": "HTTP p95",
           "range": true,
@@ -440,7 +440,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_server_duration_sum{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) / sum(rate(http_server_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval]))",
+          "expr": "sum(rate(http_server_request_duration_sum{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) / sum(rate(http_server_request_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval]))",
           "hide": false,
           "legendFormat": "HTTP Avg",
           "range": true,
@@ -571,7 +571,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_server_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) by (http_status_code)",
+          "expr": "sum(rate(http_server_request_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) by (http_status_code)",
           "hide": false,
           "legendFormat": "HTTP server - {{http_status_code}}",
           "range": true,
@@ -704,7 +704,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (http_status_code) (rate(http_server_duration_count{service_name=\"${Service}\",http_status_code=~\"(4|5).*\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_server_duration_count{service_name=\"${Service}\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval]))",
+          "expr": "sum by (http_status_code) (rate(http_server_request_duration_count{service_name=\"${Service}\",http_status_code=~\"(4|5).*\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_server_request_duration_count{service_name=\"${Service}\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "HTTP server - {{http_status_code}}",
           "range": true,
@@ -826,7 +826,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(service_name, le) (rate(http_client_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(service_name, le) (rate(http_client_request_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])))",
           "legendFormat": "HTTP p99",
           "range": true,
           "refId": "A"
@@ -837,7 +837,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_client_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) by (service_name, le)) ",
+          "expr": "histogram_quantile(0.95, sum(rate(http_client_request_duration_bucket{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) by (service_name, le)) ",
           "hide": false,
           "legendFormat": "HTTP p95",
           "range": true,
@@ -849,7 +849,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_client_duration_sum{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) / sum(rate(http_client_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval]))",
+          "expr": "sum(rate(http_client_request_duration_sum{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) / sum(rate(http_client_request_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval]))",
           "hide": false,
           "legendFormat": "HTTP Avg",
           "range": true,
@@ -980,7 +980,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_client_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) by (service_name, http_status_code)",
+          "expr": "sum(rate(http_client_request_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"} [$__rate_interval])) by (service_name, http_status_code)",
           "legendFormat": "HTTP client - {{http_status_code}}",
           "range": true,
           "refId": "A"
@@ -1112,7 +1112,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (http_status_code) (rate(http_client_duration_count{service_name=\"$Service\",http_status_code=~\"5.*\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_client_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval]))",
+          "expr": "sum by (http_status_code) (rate(http_client_request_duration_count{service_name=\"$Service\",http_status_code=~\"5.*\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval])) / ignoring(http_status_code) group_left sum(rate(http_client_request_duration_count{service_name=\"$Service\",instance=~\"$instance\",job=~\"$job\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "HTTP client - {{http_status_code}}",
           "range": true,

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -29,13 +29,13 @@ func mlog() *slog.Logger {
 }
 
 const (
-	HTTPServerDuration    = "http.server.duration"
-	HTTPClientDuration    = "http.client.duration"
+	HTTPServerDuration    = "http.server.request.duration"
+	HTTPClientDuration    = "http.client.request.duration"
 	RPCServerDuration     = "rpc.server.duration"
 	RPCClientDuration     = "rpc.client.duration"
 	SQLClientDuration     = "sql.client.duration"
-	HTTPServerRequestSize = "http.server.request.size"
-	HTTPClientRequestSize = "http.client.request.size"
+	HTTPServerRequestSize = "http.server.request.body.size"
+	HTTPClientRequestSize = "http.client.request.body.size"
 
 	UsualPortGRPC = "4317"
 	UsualPortHTTP = "4318"

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -17,13 +17,13 @@ import (
 // using labels and names that are equivalent names to the OTEL attributes
 // but following the different naming conventions
 const (
-	HTTPServerDuration    = "http_server_duration_seconds"
-	HTTPClientDuration    = "http_client_duration_seconds"
+	HTTPServerDuration    = "http_server_request_duration_seconds"
+	HTTPClientDuration    = "http_client_request_duration_seconds"
 	RPCServerDuration     = "rpc_server_duration_seconds"
 	RPCClientDuration     = "rpc_client_duration_seconds"
 	SQLClientDuration     = "sql_client_duration_seconds"
-	HTTPServerRequestSize = "http_server_request_size_bytes"
-	HTTPClientRequestSize = "http_client_request_size_bytes"
+	HTTPServerRequestSize = "http_server_request_body_size_bytes"
+	HTTPClientRequestSize = "http_client_request_body_size_bytes"
 
 	// target will expose the process hostname-pid (or K8s Pod).
 	// It is advised for users that to use relabeling rules to

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -65,7 +65,7 @@ func TestBasicPipeline(t *testing.T) {
 
 	event := testutil.ReadChannel(t, tc.Records, testTimeout)
 	assert.Equal(t, collector.MetricRecord{
-		Name: "http.server.duration",
+		Name: "http.server.request.duration",
 		Unit: "s",
 		Attributes: map[string]string{
 			string(otel.HTTPRequestMethodKey):      "GET",
@@ -186,7 +186,7 @@ func TestRouteConsolidation(t *testing.T) {
 	}
 
 	assert.Equal(t, collector.MetricRecord{
-		Name: "http.server.duration",
+		Name: "http.server.request.duration",
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.ServiceNameKey):         "svc-1",
@@ -198,7 +198,7 @@ func TestRouteConsolidation(t *testing.T) {
 	}, events["/user/{id}"])
 
 	assert.Equal(t, collector.MetricRecord{
-		Name: "http.server.duration",
+		Name: "http.server.request.duration",
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.ServiceNameKey):         "svc-1",
@@ -210,7 +210,7 @@ func TestRouteConsolidation(t *testing.T) {
 	}, events["/products/{id}/push"])
 
 	assert.Equal(t, collector.MetricRecord{
-		Name: "http.server.duration",
+		Name: "http.server.request.duration",
 		Unit: "s",
 		Attributes: map[string]string{
 			string(semconv.ServiceNameKey):         "svc-1",
@@ -483,7 +483,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 
 	event := testutil.ReadChannel(t, tc.Records, testTimeout)
 	assert.Equal(t, collector.MetricRecord{
-		Name: "http.server.duration",
+		Name: "http.server.request.duration",
 		Unit: "s",
 		Attributes: map[string]string{
 			string(otel.HTTPRequestMethodKey):      "PATCH",

--- a/test/integration/http2go_test.go
+++ b/test/integration/http2go_test.go
@@ -25,7 +25,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 	var results []prom.Result
 	test.Eventually(t, time.Duration(1)*time.Minute, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + svcNs + `",` +
@@ -46,7 +46,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_request_size_bytes_count{` +
+		results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + svcNs + `",` +
@@ -67,7 +67,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_duration_seconds_count{` +
+		results, err = pq.Query(`http_client_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + svcNs + `",` +
@@ -80,7 +80,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_request_size_bytes_count{` +
+		results, err = pq.Query(`http_client_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + svcNs + `",` +

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -30,20 +30,20 @@ const (
 
 var (
 	httpServerMetrics = []string{
-		"http_server_duration_seconds_count",
-		"http_server_duration_seconds_sum",
-		"http_server_duration_seconds_bucket",
-		"http_server_request_size_bytes_count",
-		"http_server_request_size_bytes_sum",
-		"http_server_request_size_bytes_bucket",
+		"http_server_request_duration_seconds_count",
+		"http_server_request_duration_seconds_sum",
+		"http_server_request_duration_seconds_bucket",
+		"http_server_request_body_size_bytes_count",
+		"http_server_request_body_size_bytes_sum",
+		"http_server_request_body_size_bytes_bucket",
 	}
 	httpClientMetrics = []string{
-		"http_client_duration_seconds_count",
-		"http_client_duration_seconds_sum",
-		"http_client_duration_seconds_bucket",
-		"http_client_request_size_bytes_count",
-		"http_client_request_size_bytes_sum",
-		"http_client_request_size_bytes_bucket",
+		"http_client_request_duration_seconds_count",
+		"http_client_request_duration_seconds_sum",
+		"http_client_request_duration_seconds_bucket",
+		"http_client_request_body_size_bytes_count",
+		"http_client_request_body_size_bytes_sum",
+		"http_client_request_body_size_bytes_bucket",
 	}
 	grpcServerMetrics = []string{
 		"rpc_server_duration_seconds_count",
@@ -73,7 +73,7 @@ func DoWaitForComponentsAvailable(t *testing.T) {
 		// now, verify that the metric has been reported.
 		// we don't really care that this metric could be from a previous
 		// test. Once one it is visible, it means that Otel and Prometheus are healthy
-		results, err = pq.Query(`http_server_duration_seconds_count{url_path="` + subpath + `",k8s_pod_name=~"testserver-.*"}`)
+		results, err = pq.Query(`http_server_request_duration_seconds_count{url_path="` + subpath + `",k8s_pod_name=~"testserver-.*"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -81,7 +81,7 @@ func TestMultiProcess(t *testing.T) {
 	t.Run("Non-selected processes must not be instrumented"+
 		" even if they share the executable of another instrumented process", func(t *testing.T) {
 		pq := prom.Client{HostPort: prometheusHostPort}
-		results, err := pq.Query(`http_server_duration_seconds_count{url_path="/dont-instrument"}`)
+		results, err := pq.Query(`http_server_request_duration_seconds_count{url_path="/dont-instrument"}`)
 		require.NoError(t, err)
 		assert.Empty(t, results)
 	})
@@ -118,7 +118,7 @@ func checkReportedOnlyOnce(t *testing.T, baseURL, serviceName string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_name="` + serviceName + `",` +

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -100,7 +100,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="404",` +
 			`service_namespace="` + svcNs + `",` +
@@ -121,7 +121,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_request_size_bytes_count{` +
+		results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="404",` +
 			`service_namespace="` + svcNs + `",` +
@@ -144,7 +144,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 		// Make sure we see /echo
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_server_duration_seconds_count{` +
+			results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -159,7 +159,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_server_request_size_bytes_count{` +
+			results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -175,7 +175,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 		// Make sure we see /echoBack server
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_server_duration_seconds_count{` +
+			results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -190,7 +190,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_server_request_size_bytes_count{` +
+			results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -206,7 +206,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 		// make sure we see /echo client
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_client_duration_seconds_count{` +
+			results, err = pq.Query(`http_client_request_duration_seconds_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -220,7 +220,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			var err error
-			results, err = pq.Query(`http_client_request_size_bytes_count{` +
+			results, err = pq.Query(`http_client_request_body_size_bytes_count{` +
 				`http_request_method="GET",` +
 				`http_response_status_code="203",` +
 				`service_namespace="` + svcNs + `",` +
@@ -249,7 +249,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 
 	// check duration_sum is at least 90ms (3 * 30ms)
 	var err error
-	results, err = pq.Query(`http_server_duration_seconds_sum{` +
+	results, err = pq.Query(`http_server_request_duration_seconds_sum{` +
 		`http_request_method="GET",` +
 		`http_response_status_code="404",` +
 		`service_name="` + svcName + `",` +
@@ -268,7 +268,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.NotNil(t, addr)
 
 	// check request_size_sum is at least 114B (3 * 38B)
-	results, err = pq.Query(`http_server_request_size_bytes_sum{` +
+	results, err = pq.Query(`http_server_request_body_size_bytes_sum{` +
 		`http_request_method="GET",` +
 		`http_response_status_code="404",` +
 		`service_name="` + svcName + `",` +
@@ -286,7 +286,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.NotNil(t, addr)
 
 	// Check that we never recorded metrics for /metrics, in the basic test only traces are ignored
-	results, err = pq.Query(`http_server_duration_seconds_count{http_route="/metrics"}`)
+	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
 	require.NoError(t, err)
 	enoughPromResults(t, results)
 }
@@ -342,7 +342,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="404",` +
 			`service_namespace="integration-test",` +
@@ -363,7 +363,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_request_size_bytes_count{` +
+		results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="404",` +
 			`service_namespace="integration-test",` +
@@ -385,7 +385,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// Make sure we see /echo
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -400,7 +400,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_request_size_bytes_count{` +
+		results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -416,7 +416,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// Make sure we see /echoBack server
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -431,7 +431,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_request_size_bytes_count{` +
+		results, err = pq.Query(`http_server_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -447,7 +447,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// make sure we see /echo client
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_duration_seconds_count{` +
+		results, err = pq.Query(`http_client_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -461,7 +461,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_request_size_bytes_count{` +
+		results, err = pq.Query(`http_client_request_body_size_bytes_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="203",` +
 			`service_namespace="integration-test",` +
@@ -489,7 +489,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 
 	// check duration_sum is at least 90ms (3 * 30ms)
 	var err error
-	results, err = pq.Query(`http_server_duration_seconds_sum{` +
+	results, err = pq.Query(`http_server_request_duration_seconds_sum{` +
 		`http_request_method="GET",` +
 		`http_response_status_code="404",` +
 		`service_name="` + svcName + `",` +
@@ -508,7 +508,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	assert.NotNil(t, addr)
 
 	// check request_size_sum is at least 114B (3 * 38B)
-	results, err = pq.Query(`http_server_request_size_bytes_sum{` +
+	results, err = pq.Query(`http_server_request_body_size_bytes_sum{` +
 		`http_request_method="GET",` +
 		`http_response_status_code="404",` +
 		`service_name="` + svcName + `",` +
@@ -526,7 +526,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	assert.NotNil(t, addr)
 
 	// Check that we never recorded any /metrics calls
-	results, err = pq.Query(`http_server_duration_seconds_count{http_route="/metrics"}`)
+	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
 	require.NoError(t, err)
 	require.Equal(t, len(results), 0)
 }
@@ -575,7 +575,7 @@ func testREDMetricsForGoBasicOnly(t *testing.T, url string, comm string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			namespaceMatch +

--- a/test/integration/red_test_client.go
+++ b/test/integration/red_test_client.go
@@ -24,7 +24,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_duration_seconds_count{` +
+		results, err = pq.Query(`http_client_request_duration_seconds_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
 			`service_namespace="integration-test",` +
@@ -37,7 +37,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_request_size_bytes_count{` +
+		results, err = pq.Query(`http_client_request_body_size_bytes_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
 			`service_namespace="integration-test",` +

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -28,7 +28,7 @@ func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="integration-test",` +
@@ -74,7 +74,7 @@ func testREDMetricsForNetHTTPSLibrary(t *testing.T, url string, comm string) {
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="integration-test",` +

--- a/test/integration/red_test_java.go
+++ b/test/integration/red_test_java.go
@@ -43,7 +43,7 @@ func testREDMetricsForJavaHTTPLibrary(t *testing.T, urls []string, comm string) 
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="204",` +
 			namespaceMatch +

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -24,7 +24,7 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_duration_seconds_count{` +
+		results, err = pq.Query(`http_client_request_duration_seconds_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
 			`service_namespace="integration-test",` +
@@ -37,7 +37,7 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_client_request_size_bytes_count{` +
+		results, err = pq.Query(`http_client_request_body_size_bytes_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
 			`service_namespace="integration-test",` +

--- a/test/integration/red_test_nodejs.go
+++ b/test/integration/red_test_nodejs.go
@@ -32,7 +32,7 @@ func testREDMetricsForNodeHTTPLibrary(t *testing.T, url, urlPath, comm, namespac
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="POST",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +
@@ -78,7 +78,7 @@ func checkReportedNodeJSEvents(t *testing.T, urlPath, comm, namespace string, nu
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="POST",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +

--- a/test/integration/red_test_python.go
+++ b/test/integration/red_test_python.go
@@ -28,7 +28,7 @@ func testREDMetricsForPythonHTTPLibrary(t *testing.T, url, comm, namespace strin
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +
@@ -76,7 +76,7 @@ func checkReportedPythonEvents(t *testing.T, comm, namespace string, numEvents i
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +

--- a/test/integration/red_test_ruby.go
+++ b/test/integration/red_test_ruby.go
@@ -32,7 +32,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 	// Eventually, Prometheus would make this query visible
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="POST",` +
 			`http_response_status_code="201",` +
 			`service_namespace="integration-test",` +
@@ -59,7 +59,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 	// Eventually, Prometheus would make this query visible
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="GET",` +
 			`http_response_status_code="200",` +
 			`service_namespace="integration-test",` +

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -38,7 +38,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="POST",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +
@@ -154,7 +154,7 @@ func checkReportedRustEvents(t *testing.T, comm, namespace string, numEvents int
 	var results []prom.Result
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`http_server_duration_seconds_count{` +
+		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
 			`http_request_method="POST",` +
 			`http_response_status_code="200",` +
 			`service_namespace="` + namespace + `",` +

--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -103,7 +103,7 @@ func waitForTestComponentsSubWithTime(t *testing.T, url, subpath string, minutes
 		// now, verify that the metric has been reported.
 		// we don't really care that this metric could be from a previous
 		// test. Once one it is visible, it means that Otel and Prometheus are healthy
-		results, err := pq.Query(`http_server_duration_seconds_count{url_path="` + subpath + `"}`)
+		results, err := pq.Query(`http_server_request_duration_seconds_count{url_path="` + subpath + `"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))


### PR DESCRIPTION
This PR updates Beyla to use the stable HTTP metrics spec collection names. We had standardized the attribute names to the stable spec before release 1.0, but the collection names were never updated.

Spec: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md

Since this is a breaking change, we'll need the next release cut to me a major number.