### PR TITLE
Add route to client requests for promscrape and tests

### DIFF
--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -250,6 +250,9 @@ func labelNamesHTTPClient(cfg *PrometheusConfig, ctxInfo *global.ContextInfo) []
 	if ctxInfo.K8sEnabled {
 		names = appendK8sLabelNames(names)
 	}
+	if ctxInfo.ReportRoutes {
+		names = append(names, httpRouteKey)
+	}
 	return names
 }
 
@@ -264,6 +267,9 @@ func (r *metricsReporter) labelValuesHTTPClient(span *request.Span) []string {
 	}
 	if r.ctxInfo.K8sEnabled {
 		values = appendK8sLabelValues(values, span)
+	}
+	if r.ctxInfo.ReportRoutes {
+		values = append(values, span.Route) // httpRouteKey
 	}
 	return values
 }

--- a/test/integration/components/pingclient/pingclient.go
+++ b/test/integration/components/pingclient/pingclient.go
@@ -83,8 +83,8 @@ func rtRequest(url string, counter int) {
 func main() {
 	counter := 1
 	for {
-		regularGetRequest("https://grafana.com", counter)
-		rtRequest("https://grafana.com", counter)
+		regularGetRequest("https://grafana.com/oss/", counter)
+		rtRequest("https://grafana.com/oss/", counter)
 		time.Sleep(time.Second)
 		counter++
 	}

--- a/test/integration/red_test_client.go
+++ b/test/integration/red_test_client.go
@@ -27,6 +27,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 		results, err = pq.Query(`http_client_duration_seconds_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
+			`http_route="/oss/",` +
 			`service_namespace="integration-test",` +
 			`service_name="pingclient"}`)
 		require.NoError(t, err)
@@ -40,6 +41,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 		results, err = pq.Query(`http_client_request_size_bytes_count{` +
 			fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
+			`http_route="/oss/",` +
 			`service_namespace="integration-test",` +
 			`service_name="pingclient"}`)
 		require.NoError(t, err)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -68,6 +68,21 @@ func TestSuiteClient(t *testing.T) {
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
 }
 
+func TestSuiteClientPromScrape(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-client.yml", path.Join(pathOutput, "test-suite-client-promscrape.log"))
+	compose.Env = append(compose.Env, `BEYLA_EXECUTABLE_NAME=pingclient`)
+	compose.Env = append(compose.Env,
+		`INSTRUMENTER_CONFIG_SUFFIX=-promscrape`,
+		`PROM_CONFIG_SUFFIX=-promscrape`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibrary)
+	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
+	require.NoError(t, compose.Close())
+	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
+}
+
 // Same as Test suite, but the generated test image does not contain debug information
 func TestSuite_NoDebugInfo(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-nodebug.log"))


### PR DESCRIPTION
The previous PR for adding route to client calls didn't affect promscrape configurations. This PR adds support there too as well as tests for the route in client configurations.