### PR TITLE
Fix check for context propagation support

### DIFF
--- a/docs/sources/distributed-traces.md
+++ b/docs/sources/distributed-traces.md
@@ -25,7 +25,7 @@ Beyla will read any incoming trace context header values, track the Go program e
 
 ### Kernel integrity mode limitations
 
-In order to write the `traceparent` value in outgoing HTTP/gRPC request headers, Beyla needs to write to the process memory using the [bpf_probe_write_user](https://www.man7.org/linux/man-pages/man7/bpf-helpers.7.html) eBPF helper. Since kernel 5.15 this helper is protected (and unavailable to BPF programs) if the Linux Kernel is running in `integrity` lockdown mode. Kernel integrity mode is typically enabled by default if the Kernel has [Secure Boot](https://wiki.debian.org/SecureBoot) enabled, but it can also be enabled manually.
+In order to write the `traceparent` value in outgoing HTTP/gRPC request headers, Beyla needs to write to the process memory using the [bpf_probe_write_user](https://www.man7.org/linux/man-pages/man7/bpf-helpers.7.html) eBPF helper. Since kernel 5.14 (with fixes backported to the 5.10 series) this helper is protected (and unavailable to BPF programs) if the Linux Kernel is running in `integrity` lockdown mode. Kernel integrity mode is typically enabled by default if the Kernel has [Secure Boot](https://wiki.debian.org/SecureBoot) enabled, but it can also be enabled manually.
 
 Beyla will automatically check if it can use the `bpf_probe_write_user` helper, and enable context propagation only if it's allowed by the kernel configuration. Verify the Linux Kernel lockdown mode by running the following command:
 

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -121,8 +121,8 @@ func SupportsContextPropagation(log *slog.Logger) bool {
 	kernelMajor, kernelMinor := KernelVersion()
 	log.Debug("Linux kernel version", "major", kernelMajor, "minor", kernelMinor)
 
-	if kernelMajor < 5 || (kernelMajor == 5 && kernelMinor < 14) {
-		log.Debug("Found Linux kernel earlier than 5.14, trace context propagation is supported", "major", kernelMajor, "minor", kernelMinor)
+	if kernelMajor < 5 || (kernelMajor == 5 && kernelMinor < 10) {
+		log.Debug("Found Linux kernel earlier than 5.10, trace context propagation is supported", "major", kernelMajor, "minor", kernelMinor)
 		return true
 	}
 


### PR DESCRIPTION
Hi. I was investigating the issue #390, based on [the report that it doesn't work on Debian 11 (Bullseye)](https://github.com/grafana/beyla/issues/390#issuecomment-1853219667), which should have a supported kernel:

```
$ cat /etc/os-release | head -5
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
$ uname -a
Linux bullseye 5.10.0-27-amd64 #1 SMP Debian 5.10.205-2 (2023-12-31) x86_64 GNU/Linux
$ grep CONFIG_DEBUG_INFO_BTF /boot/config-5.10.0-27-amd64
CONFIG_DEBUG_INFO_BTF=y
```

I managed to start Beyla after recompiling it and was able to trace C programs, like the Apache HTTP Server. The problem is that Go binaries like the [testserver](https://github.com/grafana/beyla/tree/447c8b9c21eb662697414fb5dd26c548dbde863a/test/integration/components/testserver) weren't working:

```
time=2024-02-02T01:49:22.338Z level=ERROR msg="couldn't trace process.
Stopping process tracer" component=ebpf.ProcessTracer
path=/home/myhro/github.com/grafana/beyla/test/integration/components/testserver/testserver
pid=563 error="loading and assigning BPF objects: field
UprobeHttp2FramerWriteHeadersReturns: program
uprobe_http2FramerWriteHeaders_returns: load program: invalid argument: 73:
(57) r7 &= 15: ; (truncated, 987 line(s) omitted)"
```

After debugging for a while, trying to understand what `uprobe_http2FramerWriteHeaders_returns` had different than other BPF programs, I realized that the VM was running with Secure Boot enabled (which is the default on LXD/Incus). This, in turn, enables the kernel integrity mode:

```
$ cat /sys/kernel/security/lockdown
none [integrity] confidentiality
```

As documented, in cases like that [the context propagation might not work](https://github.com/grafana/beyla/blob/447c8b9c21eb662697414fb5dd26c548dbde863a/docs/sources/distributed-traces.md#kernel-integrity-mode-limitations). What made it a bit more interesting is the fact that while yes, the lockdown check for the `bpf_probe_write_user()` helper was indeed [introduced on kernel 5.14](https://github.com/torvalds/linux/commit/51e1bb9), it was also [backported to the 5.10 tree](https://elixir.bootlin.com/linux/v5.10.59/A/ident/LOCKDOWN_BPF_WRITE_USER) as well.

Based on these findings, I'm proposing a fix for the context propagation support check.

P.s.: I also checked 5.4 (the previous LTS) and 5.9 versions and didn't find the patch in their trees.