### PR TITLE
Compile as statically linked binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ all: generate build
 .PHONY: compile
 compile:
 	@echo "### Compiling project"
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags="-X 'main.Version=$(RELEASE_VERSION)'" -a -o bin/$(CMD) $(MAIN_GO_FILE)
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags="-X 'main.Version=$(RELEASE_VERSION)'" -a -o bin/$(CMD) $(MAIN_GO_FILE)
 
 .PHONY: dev
 dev: prereqs generate compile-for-coverage
@@ -159,7 +159,7 @@ dev: prereqs generate compile-for-coverage
 .PHONY: compile-for-coverage
 compile-for-coverage:
 	@echo "### Compiling project to generate coverage profiles"
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -cover -a -o bin/$(CMD) $(MAIN_GO_FILE)
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -cover -a -o bin/$(CMD) $(MAIN_GO_FILE)
 
 .PHONY: test
 test:


### PR DESCRIPTION
Hi. Continuing the issue #390 investigation (which started on #600), I've confirmed that Beyla fails to start on Debian 11 (Bullseye) when using a binary compiled on Debian 12 (Bookworm) due to GLIBC version incompatibilities:

```
$ sudo ./bin/beyla
./bin/beyla: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./bin/beyla)
./bin/beyla: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./bin/beyla)
$ ldd --version | head -2
ldd (Debian GLIBC 2.31-13+deb11u7) 2.31
Copyright (C) 2020 Free Software Foundation, Inc.
```

Following the suggestion of [producing statically linked binaries](https://github.com/grafana/beyla/issues/390#issuecomment-1854052996), it appears that simply disabling CGO was enough to make it work:

```
$ sudo ./bin/beyla
time=2024-02-02T14:29:16.109Z level=INFO msg="Grafana Beyla" Version=v1.1.0-81-g74a333c5 "OpenTelemetry SDK Version"=1.18.0
time=2024-02-02T14:29:16.112Z level=ERROR msg="Beyla couldn't start read and forwarding" error="can't instantiate instrumentation pipeline: validating configuration: missing BEYLA_EXECUTABLE_NAME or BEYLA_OPEN_PORT property, or a 'discovery' section in the configuration file. Please check the documentation for more information"
```

Do you think this is a reasonable solution to the problem of running Beyla on systems with older versions of GLIBC?

Closes #390.