### PR TITLE
Fix generator-build-image makefile task

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -31,6 +31,8 @@ ENV TOOLS_DIR $GOBIN
 WORKDIR /tmp
 # Copies some pre-required Go dependencies to avoid downloading them on each build
 COPY Makefile Makefile
+COPY go.mod go.mod
+
 RUN make prereqs
 
 WORKDIR /src


### PR DESCRIPTION
It failed after looking for some version numbers in an nonexistent go.mod file.