### PR TITLE
Exposing beyla_build_info metric in Prometheus exporter

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -40,6 +40,7 @@ local buildx(stepName, app, auto_tag, tags) = {
   privileged: true,
   settings: {
     auto_tag: auto_tag,
+    build_args_from_env: ['DRONE_TAG'],
     tags: tags,
     repo: 'grafana/%s' % app,
     dockerfile: 'Dockerfile',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -7,6 +7,8 @@ steps:
   privileged: true
   settings:
     auto_tag: false
+    build_args_from_env:
+    - DRONE_TAG
     dockerfile: Dockerfile
     dry_run: true
     password:
@@ -26,6 +28,8 @@ steps:
   privileged: true
   settings:
     auto_tag: true
+    build_args_from_env:
+    - DRONE_TAG
     dockerfile: Dockerfile
     dry_run: false
     password:
@@ -45,6 +49,8 @@ steps:
   privileged: true
   settings:
     auto_tag: false
+    build_args_from_env:
+    - DRONE_TAG
     dockerfile: Dockerfile
     dry_run: false
     password:
@@ -64,6 +70,8 @@ steps:
   privileged: true
   settings:
     auto_tag: false
+    build_args_from_env:
+    - DRONE_TAG
     dockerfile: Dockerfile
     dry_run: false
     password:
@@ -96,6 +104,6 @@ kind: secret
 name: docker_password
 ---
 kind: signature
-hmac: b2d0a0ed30050f8632ab6331f58a4d147c8e155e5f28a51de72a1d3b3a46759e
+hmac: 80d28c3b23c53bdd6b5c90e2881d39901c0b01d4cdcc435de61d34112a267965
 
 ...

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -16,10 +16,9 @@ import (
 	otelsdk "go.opentelemetry.io/otel/sdk"
 
 	"github.com/grafana/beyla/pkg/beyla"
+	"github.com/grafana/beyla/pkg/buildinfo"
 	"github.com/grafana/beyla/pkg/components"
 )
-
-var Version = "main"
 
 func main() {
 	lvl := slog.LevelVar{}
@@ -28,7 +27,7 @@ func main() {
 		Level: &lvl,
 	})))
 
-	slog.Info("Grafana Beyla", "Version", Version, "OpenTelemetry SDK Version", otelsdk.Version())
+	slog.Info("Grafana Beyla", "Version", buildinfo.Version, "Revision", buildinfo.Revision, "OpenTelemetry SDK Version", otelsdk.Version())
 
 	configPath := flag.String("config", "", "path to the configuration file")
 	flag.Parse()

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,5 @@
+package buildinfo
+
+// Version and Revision variables are overriden at build time with Git repository information
+var Version = "unset"
+var Revision = "unset"

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -594,3 +594,14 @@ func testREDMetricsForGoBasicOnly(t *testing.T, url string, comm string) {
 		}
 	})
 }
+
+func testPrometheusBeylaBuildInfo(t *testing.T) {
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`beyla_build_info{target_lang="go"}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+	})
+}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -78,6 +78,8 @@ func TestSuiteClientPromScrape(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibraryNoTraces)
+	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
+
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
 	require.NoError(t, compose.Close())
 	t.Run("BPF pinning folder unmounted", testBPFPinningUnmounted)
@@ -199,6 +201,7 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
 
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
 	require.NoError(t, compose.Close())


### PR DESCRIPTION
In the Prometheus exporter, it exposes metrics like:
```
beyla_build_info{goarch="arm64",goos="linux",goversion="go1.21.7",revision="0fed3f3",target_lang="go",version:"1.3.0"}}
```
It also should (Nth attempt) fix the internal version generation in Drone scripts.