### PR TITLE
Fixing network metrics' bytes and adding some useful fields

### DIFF
--- a/pkg/beyla/network_cfg.go
+++ b/pkg/beyla/network_cfg.go
@@ -20,6 +20,8 @@ package beyla
 
 import (
 	"time"
+
+	"github.com/grafana/beyla/pkg/internal/netolly/flow"
 )
 
 type NetworkConfig struct {
@@ -60,6 +62,7 @@ type NetworkConfig struct {
 	// When enabled, it will detect duplicate flows (flows that have been detected e.g. through
 	// both the physical and a virtual interface).
 	// "firstCome" will forward only flows from the first interface the flows are received from.
+	// Default value: firstCome
 	Deduper string `yaml:"deduper" env:"BEYLA_NETWORK_DEDUPER"`
 	// DeduperFCExpiry specifies the expiry duration of the flows "firstCome" deduplicator. After
 	// a flow hasn't been received for that expiry time, the deduplicator forgets it. That means
@@ -92,7 +95,7 @@ var defaultNetworkConfig = NetworkConfig{
 	ExcludeInterfaces:  []string{"lo"},
 	CacheMaxFlows:      5000,
 	CacheActiveTimeout: 5 * time.Second,
-	Deduper:            "none",
+	Deduper:            flow.DeduperFirstCome,
 	DeduperJustMark:    false,
 	Direction:          "both",
 	ListenInterfaces:   "watch",

--- a/pkg/internal/netolly/ebpf/tracer.go
+++ b/pkg/internal/netolly/ebpf/tracer.go
@@ -338,9 +338,9 @@ func (m *FlowFetcher) LookupAndDeleteMap() map[NetFlowId][]NetFlowMetrics {
 	// Changing Iterate+Delete by LookupAndDelete would prevent some possible race conditions
 	// TODO: detect whether LookupAndDelete is supported (Kernel>=4.20) and use it selectively
 	for iterator.Next(&id, &metrics) {
-		//if err := flowMap.Delete(id); err != nil {
-		//	tlog().Warn("couldn't delete flow entry", "flowId", id)
-		//}
+		if err := flowMap.Delete(id); err != nil {
+			tlog().Warn("couldn't delete flow entry", "flowId", id)
+		}
 		// We observed that eBFP PerCPU map might insert multiple times the same key in the map
 		// (probably due to race conditions) so we need to re-join metrics again at userspace
 		// TODO: instrument how many times the keys are is repeated in the same eviction


### PR DESCRIPTION
The fields were previously removed but now I realize that they are really needed to differentiate between duplicate 
metrics.