### PR TITLE
rename network_flow_bytes metric to beyla_network_flow_bytes

### DIFF
--- a/examples/asserts/rules-entity-relation.yml
+++ b/examples/asserts/rules-entity-relation.yml
@@ -8,7 +8,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_owner_name) (network_flow_bytes_total{k8s_src_owner_type=~"Pod|Deployment|Node|DaemonSet|ReplicaSet|StatefulSet"})
+          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_owner_name) (beyla_network_flow_bytes_total{k8s_src_owner_type=~"Pod|Deployment|Node|DaemonSet|ReplicaSet|StatefulSet"})
   - type: Service
     name: k8s_dst_owner_name
     scope:
@@ -17,7 +17,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_owner_name) (network_flow_bytes_total{k8s_dst_owner_type=~"Pod|Deployment|Node|DaemonSet|ReplicaSet|StatefulSet"})
+          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_owner_name) (beyla_network_flow_bytes_total{k8s_dst_owner_type=~"Pod|Deployment|Node|DaemonSet|ReplicaSet|StatefulSet"})
   - type: Node
     name: k8s_src_host_name
     scope:
@@ -26,7 +26,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_src_host_name) (network_flow_bytes_total{k8s_src_type=~"Pod|Node"})
+          group by (asserts_env, asserts_site, k8s_src_host_name) (beyla_network_flow_bytes_total{k8s_src_type=~"Pod|Node"})
   - type: Node
     name: k8s_dst_host_name
     scope:
@@ -35,7 +35,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_dst_host_name) (network_flow_bytes_total{k8s_dst_type=~"Pod|Node"})
+          group by (asserts_env, asserts_site, k8s_dst_host_name) (beyla_network_flow_bytes_total{k8s_dst_type=~"Pod|Node"})
   - type: Namespace
     name: k8s_src_namespace
     scope:
@@ -44,7 +44,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_src_namespace) (network_flow_bytes_total{k8s_src_type="Pod"})
+          group by (asserts_env, asserts_site, k8s_src_namespace) (beyla_network_flow_bytes_total{k8s_src_type="Pod"})
   - type: Namespace
     name: k8s_dst_namespace
     scope:
@@ -53,7 +53,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_dst_namespace) (network_flow_bytes_total{k8s_dst_type="Pod"})
+          group by (asserts_env, asserts_site, k8s_dst_namespace) (beyla_network_flow_bytes_total{k8s_dst_type="Pod"})
   - type: Pod
     name: k8s_src_name
     scope:
@@ -62,7 +62,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_name) (network_flow_bytes_total{k8s_src_type="Pod"})
+          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_name) (beyla_network_flow_bytes_total{k8s_src_type="Pod"})
   - type: Pod
     name: k8s_dst_name
     scope:
@@ -71,7 +71,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_name) (network_flow_bytes_total{k8s_dst_type="Pod"})
+          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_name) (beyla_network_flow_bytes_total{k8s_dst_type="Pod"})
   - type: Service
     name: k8s_src_name
     scope:
@@ -80,7 +80,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_name) (network_flow_bytes_total{k8s_src_type="Service"})
+          group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_name) (beyla_network_flow_bytes_total{k8s_src_type="Service"})
   - type: Service
     name: k8s_dst_name
     scope:
@@ -89,7 +89,7 @@ entities:
       site: asserts_site
     definedBy:
       - query: |
-          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_name) (network_flow_bytes_total{k8s_dst_ype="Service"})
+          group by (asserts_env, asserts_site, k8s_dst_namespace, k8s_dst_name) (beyla_network_flow_bytes_total{k8s_dst_ype="Service"})
 relations:
   - type: ROUTES
     startEntityType: Pod
@@ -97,7 +97,7 @@ relations:
     definedBy: !<METRICS>
       pattern: |
         group by (asserts_env, asserts_site, k8s_src_namespace, k8s_src_name, k8s_dst_namespace, k8s_dst_name) (
-            rate(network_flow_bytes_total{k8s_src_type="Pod",k8s_dst_type="Pod"}[1m])
+            rate(beyla_network_flow_bytes_total{k8s_src_type="Pod",k8s_dst_type="Pod"}[1m])
         )
       startEntityMatchers:
         name: k8s_src_name
@@ -115,7 +115,7 @@ relations:
     definedBy: !<METRICS>
       pattern: |
         group by (asserts_env, asserts_site, k8s_src_namespace, k8s_dst_namespace) (
-            rate(network_flow_bytes_total{k8s_src_type="Pod",k8s_dst_type="Service"}[1m])
+            rate(beyla_network_flow_bytes_total{k8s_src_type="Pod",k8s_dst_type="Service"}[1m])
         )
       startEntityMatchers:
         name: k8s_src_namespace
@@ -133,7 +133,7 @@ relations:
     definedBy: !<METRICS>
       pattern: |
         group by (asserts_env, asserts_site, k8s_src_host_name, k8s_dst_host_name) (
-            rate(network_flow_bytes_total{k8s_src_type=~"Pod|Node",k8s_dst_type=~"Pod|Node"}[1m])
+            rate(beyla_network_flow_bytes_total{k8s_src_type=~"Pod|Node",k8s_dst_type=~"Pod|Node"}[1m])
         )
       startEntityMatchers:
         name: k8s_src_host_name
@@ -151,7 +151,7 @@ relations:
     definedBy: !<METRICS>
       pattern: |
         group by (asserts_env, asserts_site, k8s_src_namespace, k8s_dst_namespace, k8s_src_owner_name, k8s_dst_owner_name) (
-            rate(network_flow_bytes_total{k8s_src_owner_type=~"Pod|Deployment|DaemonSet|ReplicaSet|StatefulSet|Service",k8s_dst_owner_type=~"Pod|Deployment|DaemonSet|ReplicaSet|StatefulSet|Service"}[1m])
+            rate(beyla_network_flow_bytes_total{k8s_src_owner_type=~"Pod|Deployment|DaemonSet|ReplicaSet|StatefulSet|Service",k8s_dst_owner_type=~"Pod|Deployment|DaemonSet|ReplicaSet|StatefulSet|Service"}[1m])
         )
       startEntityMatchers:
         name: k8s_src_owner_name

--- a/pkg/internal/netolly/export/metrics.go
+++ b/pkg/internal/netolly/export/metrics.go
@@ -113,7 +113,7 @@ func MetricsExporterProvider(cfg MetricsConfig) (node.TerminalFunc[[]*ebpf.Recor
 	ebpfEvents := otel2.Meter("network_ebpf_events")
 
 	flowBytes, err := ebpfEvents.Int64Counter(
-		"network.flow.bytes",
+		"beyla.network.flow.bytes",
 		metric2.WithDescription("total bytes_sent value of network flows observed by probe since its launch"),
 		metric2.WithUnit("{bytes}"),
 	)

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics_test.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics_test.go
@@ -40,7 +40,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 
 	// testing request flows (to testserver as Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`network_flow_bytes_total{src_name="internal-pinger",dst_name="testserver"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name="testserver"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -68,7 +68,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 	})
 	// testing request flows (to testserver as Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`network_flow_bytes_total{src_name="internal-pinger",dst_name=~"testserver-.*"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name=~"testserver-.*"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -99,7 +99,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 
 	// testing response flows (from testserver Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -127,7 +127,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 
 	// testing response flows (from testserver Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -153,7 +153,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 	})
 
 	// check that there aren't captured flows if there is no communication
-	results, err := pq.Query(`network_flow_bytes_total{src_name="internal-pinger",dst_name="otherinstance"}`)
+	results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name="otherinstance"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 

--- a/test/integration/suites_network_test.go
+++ b/test/integration/suites_network_test.go
@@ -62,7 +62,7 @@ func getNetFlows(t *testing.T) []prom.Result {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 
 		// now, verify that the network metric has been reported.
-		results, err = pq.Query(`network_flow_bytes_total`)
+		results, err = pq.Query(`beyla_network_flow_bytes_total`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))


### PR DESCRIPTION
As discussed internally, non-standard OTEL metrics need to prepend the `beyla_` prefix.