### PR TITLE
Allow neto11y start in print-only mode

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -171,13 +171,14 @@ func (c *Config) Validate() error {
 		return ConfigError("BEYLA_BPF_BATCH_LENGTH must be at least 1")
 	}
 
-	if c.Enabled(FeatureNetO11y) && !c.Grafana.OTLP.MetricsEnabled() && !c.Metrics.Enabled() {
+	if c.Enabled(FeatureNetO11y) && !c.Grafana.OTLP.MetricsEnabled() && !c.Metrics.Enabled() && !c.NetworkFlows.Print {
 		return ConfigError("enabling network observability requires to enable at least the OpenTelemetry" +
 			" metrics exporter: grafana or otel_metrics_export sections in the YAML configuration file; or the" +
-			" OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variables")
+			" OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variables. For debugging" +
+			" purposes, you can also set BEYLA_NETWORK_PRINT_FLOWS=true")
 	}
 
-	if !c.Noop.Enabled() && !c.Printer.Enabled() &&
+	if c.Enabled(FeatureAppO11y) && !c.Noop.Enabled() && !c.Printer.Enabled() &&
 		!c.Grafana.OTLP.MetricsEnabled() && !c.Grafana.OTLP.TracesEnabled() &&
 		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
 		!c.Prometheus.Enabled() {

--- a/pkg/internal/netolly/export/metrics.go
+++ b/pkg/internal/netolly/export/metrics.go
@@ -23,6 +23,10 @@ type MetricsConfig struct {
 	AllowedAttributes []string
 }
 
+func (mc MetricsConfig) Enabled() bool {
+	return mc.Metrics != nil && mc.Metrics.Enabled()
+}
+
 func mlog() *slog.Logger {
 	return slog.With("component", "flows.MetricsReporter")
 }


### PR DESCRIPTION
As for App O11y, this PR allows to start beyla NetO11y in print-only mode for debugging purposes. There is no need now to provide an OTEL exporter if the flow printer is setup.