### PR TITLE
Make sure that all the subcomponents have finished before stopping Beyla

### DIFF
--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -65,8 +65,7 @@ func main() {
 	// child process isn't found.
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
-	components.StartBeyla(ctx, config)
-	<-ctx.Done()
+	components.RunBeyla(ctx, config)
 
 	if gc := os.Getenv("GOCOVERDIR"); gc != "" {
 		slog.Info("Waiting 1s to collect coverage data...")


### PR DESCRIPTION
After CTRL+C was pressed, the Beyla main process could stop after giving time to the internal goroutines to unload all the resources (and could leave some eBPF programs loaded).

The cause was that after `StartBeyla`, we only waited for the parent context to be canceled (this is, CTRL+C was pressed).

Now we wait for all the internal beyla components (app and net o11y) to finish.