### PR TITLE
Remove deadcode and varcheck deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
     - integration
 linters:
   enable:
-    - deadcode
     - errcheck
     - errorlint
     - cyclop
@@ -23,7 +22,6 @@ linters:
     - stylecheck
     - typecheck
     - unused
-    - varcheck
   disable:
     - exhaustive
 linters-settings:


### PR DESCRIPTION
This removes the following warnigs:

```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
```
unused is activated, therefore is safe to remove these linters.