### PR TITLE
Fix internal metrics documentation section

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -1043,9 +1043,9 @@ The `buckets` object allows overriding the bucket boundaries of diverse histogra
 
 YAML section `internal_metrics`.
 
-This component will report certain internal metrics about the behavior
+This component reports certain internal metrics about the behavior
 of the auto-instrumentation tool. Currently, only [Prometheus](https://prometheus.io/) export
-is supported. It will be enabled if the `internal_metrics` section
+is supported. It is enabled if the `internal_metrics` section
 contains a `prometheus` subsection with the `port` property set.
 
 Example:
@@ -1062,10 +1062,10 @@ internal_metrics:
 | `port` | `BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT` | int  | (unset) |
 
 Specifies the HTTP port for the Prometheus scrape endpoint. If unset or 0,
-no Prometheus endpoint will be open and no metrics will be accounted.
+no Prometheus endpoint is open and no metrics are accounted.
 
 Its value can be the same as [`prometheus_export.port`](#prometheus-http-endpoint) (both metric families
-will share the same HTTP server, though they can be accessed in different paths),
+share the same HTTP server, though they can be accessed in different paths),
 or a different value (two different HTTP servers for the different metric families).
 
 | YAML   | Env var                                  | Type   | Default             |
@@ -1076,7 +1076,7 @@ Specifies the HTTP query path to fetch the list of Prometheus metrics.
 If [`prometheus_export.port`](#prometheus-http-endpoint) and `internal_metrics.prometheus.port` have the
 same values, this `internal_metrics.prometheus.path` value can be
 different from `prometheus_export.path`, to keep both metric families separated,
-or the same (both metric families will be listed in the same scrape endpoint).
+or the same (both metric families are listed in the same scrape endpoint).
 
 ## YAML file example
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -1044,8 +1044,18 @@ The `buckets` object allows overriding the bucket boundaries of diverse histogra
 YAML section `internal_metrics`.
 
 This component will report certain internal metrics about the behavior
-of the auto-instrumentation tool, and expose them as a [Prometheus](https://prometheus.io/)
-scraper. It will be enabled if the `port` property is set.
+of the auto-instrumentation tool. Currently, only [Prometheus](https://prometheus.io/) export
+is supported. It will be enabled if the `internal_metrics` section
+contains a `prometheus` subsection with the `port` property set.
+
+Example:
+
+```yaml
+internal_metrics:
+  prometheus:
+    port: 6060
+    path: /internal/metrics
+```
 
 | YAML   | Env var                                  | Type | Default |
 | ------ | ---------------------------------------- | ---- | ------- |
@@ -1063,8 +1073,8 @@ or a different value (two different HTTP servers for the different metric famili
 | `path` | `BEYLA_INTERNAL_METRICS_PROMETHEUS_PATH` | string | `/internal/metrics` |
 
 Specifies the HTTP query path to fetch the list of Prometheus metrics.
-If [`prometheus_export.port`](#prometheus-http-endpoint) and `internal_metrics.port` have the
-same values, this `internal_metrics.path` value can be
+If [`prometheus_export.port`](#prometheus-http-endpoint) and `internal_metrics.prometheus.port` have the
+same values, this `internal_metrics.prometheus.path` value can be
 different from `prometheus_export.path`, to keep both metric families separated,
 or the same (both metric families will be listed in the same scrape endpoint).
 


### PR DESCRIPTION
We were missing to specify the `prometheus` subsection.