### PR TITLE
Link to rendered tutorial docs rather than the source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo -E ./beyla
 
 Now, you should see metrics on [http://localhost:9400/metrics](http://localhost:9400/metrics).
 
-See [Documentation](https://grafana.com/docs/beyla/) and the [tutorials](docs/sources/tutorial/_index.md) for more info.
+See [Documentation](https://grafana.com/docs/beyla/) and the [tutorials](https://grafana.com/docs/beyla/latest/tutorial/) for more info.
 
 ## Requirements
 


### PR DESCRIPTION
Mini docs fix: Link to the rendered tutorial on grafana.com/docs/ rather than the source code for the docs.