### PR TITLE
Remove stray debug code

### DIFF
--- a/pkg/internal/ebpf/common/http2grpc_transform.go
+++ b/pkg/internal/ebpf/common/http2grpc_transform.go
@@ -3,7 +3,6 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -179,8 +178,6 @@ func http2InfoToSpan(info *BPFHTTP2Info, method, path, peer, host string, status
 // or :status. Then we know what the protocol actually is.
 func (event *BPFHTTP2Info) eventType(protocol Protocol) request.EventType {
 	eventType := request.EventType(event.Type)
-
-	fmt.Printf("event type %d, protocol %d\n", eventType, protocol)
 
 	switch protocol {
 	case HTTP2:


### PR DESCRIPTION
I found a stray fmt.printf that I had forgot to remove when I implemented the GRPC/HTTP2 support for kprobes.