### PR TITLE
OTEL exporter: separate metrics by features

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -773,6 +773,23 @@ Specifies whether the exporter must submit the caller peer address as a metric a
 
 It is disabled by default to avoid cardinality explosion.
 
+| YAML       | Environment variable         | Type            | Default                      |
+|------------|------------------------------|-----------------|------------------------------|
+| `families` | `BEYLA_OTEL_METRIC_FAMILIES` | list of strings | `["application", "network"]` |
+
+A list of metric families that are allowed to be exported.
+
+- If the list contains `application`, the Beyla OpenTelemetry exporter will export application-level metrics;
+  but only if there is defined an OpenTelemetry endpoint, and Beyla was able to discover any
+  process matching the entries in the `discovery` section.
+- If the list contains `network`, the Beyla OpenTelemetry exporter will export network-level
+  metrics; but only if there is defined an OpenTelemetry endpoint and the
+  [network metrics are enabled]({{< relref "../network" >}}).
+
+Usually you do not need to change this configuration option, unless, for example, a Beyla instance
+instruments both network and applications, and you want to disable application-level metrics because
+you only care about application traces, but still want Beyla to send network metrics.
+
 | YAML      | Environment variable | Type   |
 | --------- | ------- | ------ |
 | `buckets` | (n/a)   | Object |

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -779,10 +779,10 @@ It is disabled by default to avoid cardinality explosion.
 
 A list of metric families that are allowed to be exported.
 
-- If the list contains `application`, the Beyla OpenTelemetry exporter will export application-level metrics;
+- If the list contains `application`, the Beyla OpenTelemetry exporter exports application-level metrics;
   but only if there is defined an OpenTelemetry endpoint, and Beyla was able to discover any
   process matching the entries in the `discovery` section.
-- If the list contains `network`, the Beyla OpenTelemetry exporter will export network-level
+- If the list contains `network`, the Beyla OpenTelemetry exporter exports network-level
   metrics; but only if there is defined an OpenTelemetry endpoint and the
   [network metrics are enabled]({{< relref "../network" >}}).
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -778,7 +778,7 @@ It is disabled by default to avoid cardinality explosion.
 | `features` | `BEYLA_OTEL_METRIC_FEATURES` | list of strings | `["application", "network"]` |
 
 A list of metric groups that are allowed to be exported. Each group belongs to a different feature
-of beyla: application-level metrics or network metrics.
+of Beyla: application-level metrics or network metrics.
 
 - If the list contains `application`, the Beyla OpenTelemetry exporter exports application-level metrics;
   but only if there is defined an OpenTelemetry endpoint, and Beyla was able to discover any

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -775,9 +775,10 @@ It is disabled by default to avoid cardinality explosion.
 
 | YAML       | Environment variable         | Type            | Default                      |
 |------------|------------------------------|-----------------|------------------------------|
-| `families` | `BEYLA_OTEL_METRIC_FAMILIES` | list of strings | `["application", "network"]` |
+| `features` | `BEYLA_OTEL_METRIC_FEATURES` | list of strings | `["application", "network"]` |
 
-A list of metric families that are allowed to be exported.
+A list of metric groups that are allowed to be exported. Each group belongs to a different feature
+of beyla: application-level metrics or network metrics.
 
 - If the list contains `application`, the Beyla OpenTelemetry exporter exports application-level metrics;
   but only if there is defined an OpenTelemetry endpoint, and Beyla was able to discover any

--- a/docs/sources/network/config.md
+++ b/docs/sources/network/config.md
@@ -33,7 +33,12 @@ network:
     - 10.10.0.0/24
     - 10.0.0.0/8
     - 10.30.0.0/16
+otel_metrics_export:
+  endpoint: http://localhost:4318
 ```
+
+In addition to the `network` YAML section, Beyla configuration requires an endpoint to export the
+network metrics (in the previous example, `otel_metrics_export`).
 
 ## Network metrics configuration properties
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 		Buckets:              otel.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,
-		Families:             []string{otel.FamilyNetwork, otel.FamilyApplication},
+		Features:             []string{otel.FeatureNetwork, otel.FeatureApplication},
 	},
 	Traces: otel.TracesConfig{
 		Protocol:           otel.ProtocolUnset,

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -50,6 +50,7 @@ var DefaultConfig = Config{
 		Buckets:              otel.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,
+		Families:             []string{otel.FamilyNetwork, otel.FamilyApplication},
 	},
 	Traces: otel.TracesConfig{
 		Protocol:           otel.ProtocolUnset,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -109,6 +109,7 @@ network:
 				DurationHistogram:    []float64{0, 1, 2},
 				RequestSizeHistogram: otel.DefaultBuckets.RequestSizeHistogram,
 			},
+			Features:             []string{"network", "application"},
 			HistogramAggregation: "base2_exponential_bucket_histogram",
 		},
 		Traces: otel.TracesConfig{

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -42,6 +43,9 @@ const (
 
 	AggregationExplicit    = "explicit_bucket_histogram"
 	AggregationExponential = "base2_exponential_bucket_histogram"
+
+	FamilyNetwork     = "network"
+	FamilyApplication = "application"
 )
 
 type MetricsConfig struct {
@@ -70,6 +74,9 @@ type MetricsConfig struct {
 	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
 	// and the Info messages leak internal details that are not usually valuable for the final user.
 	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"BEYLA_OTEL_SDK_LOG_LEVEL"`
+
+	// Families of metrics that are can be exported. Accepted values are "application" and "network".
+	Families []string `yaml:"families" env:"BEYLA_OTEL_METRIC_FAMILIES" envSeparator:","`
 
 	// Grafana configuration needs to be explicitly set up before building the graph
 	Grafana *GrafanaOTLP `yaml:"-"`
@@ -101,14 +108,18 @@ func (m *MetricsConfig) GuessProtocol() Protocol {
 	return ProtocolHTTPProtobuf
 }
 
-// Enabled specifies that the OTEL metrics node is enabled if and only if
+// EndpointEnabled specifies that the OTEL metrics node is enabled if and only if
 // either the OTEL endpoint and OTEL metrics endpoint is defined.
 // If not enabled, this node won't be instantiated
 // Reason to disable linting: it requires to be a value despite it is considered a "heavy struct".
 // This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
 // nolint:gocritic
-func (m MetricsConfig) Enabled() bool {
+func (m MetricsConfig) EndpointEnabled() bool {
 	return m.CommonEndpoint != "" || m.MetricsEndpoint != "" || m.Grafana.MetricsEnabled()
+}
+
+func (m MetricsConfig) Enabled() bool {
+	return m.EndpointEnabled() && slices.Contains(m.Families, FamilyApplication)
 }
 
 // MetricsReporter implements the graph node that receives request.Span

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -44,8 +44,8 @@ const (
 	AggregationExplicit    = "explicit_bucket_histogram"
 	AggregationExponential = "base2_exponential_bucket_histogram"
 
-	FamilyNetwork     = "network"
-	FamilyApplication = "application"
+	FeatureNetwork     = "network"
+	FeatureApplication = "application"
 )
 
 type MetricsConfig struct {
@@ -75,8 +75,8 @@ type MetricsConfig struct {
 	// and the Info messages leak internal details that are not usually valuable for the final user.
 	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"BEYLA_OTEL_SDK_LOG_LEVEL"`
 
-	// Families of metrics that are can be exported. Accepted values are "application" and "network".
-	Families []string `yaml:"families" env:"BEYLA_OTEL_METRIC_FAMILIES" envSeparator:","`
+	// Features of metrics that are can be exported. Accepted values are "application" and "network".
+	Features []string `yaml:"features" env:"BEYLA_OTEL_METRIC_FEATURES" envSeparator:","`
 
 	// Grafana configuration needs to be explicitly set up before building the graph
 	Grafana *GrafanaOTLP `yaml:"-"`
@@ -119,7 +119,7 @@ func (m MetricsConfig) EndpointEnabled() bool {
 }
 
 func (m MetricsConfig) Enabled() bool {
-	return m.EndpointEnabled() && slices.Contains(m.Families, FamilyApplication)
+	return m.EndpointEnabled() && slices.Contains(m.Features, FeatureApplication)
 }
 
 // MetricsReporter implements the graph node that receives request.Span

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -323,15 +323,19 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 }
 
 func TestMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, MetricsConfig{CommonEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{MetricsEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
+	assert.True(t, MetricsConfig{Families: []string{FamilyApplication, FamilyNetwork}, CommonEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{Families: []string{FamilyApplication}, MetricsEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{Families: []string{FamilyNetwork, FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
-	assert.False(t, MetricsConfig{}.Enabled())
-	assert.False(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}.Enabled())
-	assert.False(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"metrics"}}}.Enabled())
+	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}}.Enabled())
+	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}.Enabled())
+	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"metrics"}}}.Enabled())
+	// application family is not enabled
+	assert.False(t, MetricsConfig{CommonEndpoint: "foo"}.Enabled())
+	assert.False(t, MetricsConfig{MetricsEndpoint: "foo", Families: []string{FamilyNetwork}}.Enabled())
+	assert.False(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
 }
 
 func (f *fakeInternalMetrics) OTELMetricExport(len int) {

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -323,18 +323,18 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 }
 
 func TestMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, MetricsConfig{Families: []string{FamilyApplication, FamilyNetwork}, CommonEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{Families: []string{FamilyApplication}, MetricsEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{Families: []string{FamilyNetwork, FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
+	assert.True(t, MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}.Enabled())
+	assert.True(t, MetricsConfig{Features: []string{FeatureNetwork, FeatureApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
-	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}}.Enabled())
-	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}.Enabled())
-	assert.False(t, MetricsConfig{Families: []string{FamilyApplication}, Grafana: &GrafanaOTLP{Submit: []string{"metrics"}}}.Enabled())
-	// application family is not enabled
+	assert.False(t, MetricsConfig{Features: []string{FeatureApplication}}.Enabled())
+	assert.False(t, MetricsConfig{Features: []string{FeatureApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}.Enabled())
+	assert.False(t, MetricsConfig{Features: []string{FeatureApplication}, Grafana: &GrafanaOTLP{Submit: []string{"metrics"}}}.Enabled())
+	// application feature is not enabled
 	assert.False(t, MetricsConfig{CommonEndpoint: "foo"}.Enabled())
-	assert.False(t, MetricsConfig{MetricsEndpoint: "foo", Families: []string{FamilyNetwork}}.Enabled())
+	assert.False(t, MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}.Enabled())
 	assert.False(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
 }
 

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -384,8 +384,8 @@ func TestTraces_InternalInstrumentationSampling(t *testing.T) {
 
 func TestTracesConfig_Enabled(t *testing.T) {
 	assert.True(t, TracesConfig{CommonEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{MetricsEndpoint: "foo"}.Enabled())
-	assert.True(t, MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
+	assert.True(t, TracesConfig{TracesEndpoint: "foo"}.Enabled())
+	assert.True(t, TracesConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}.Enabled())
 }
 
 func TestTracesConfig_Disabled(t *testing.T) {

--- a/pkg/internal/netolly/export/metrics.go
+++ b/pkg/internal/netolly/export/metrics.go
@@ -24,7 +24,7 @@ type MetricsConfig struct {
 }
 
 func (mc MetricsConfig) Enabled() bool {
-	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() && slices.Contains(mc.Metrics.Families, otel.FamilyNetwork)
+	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() && slices.Contains(mc.Metrics.Features, otel.FeatureNetwork)
 }
 
 func mlog() *slog.Logger {

--- a/pkg/internal/netolly/export/metrics.go
+++ b/pkg/internal/netolly/export/metrics.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,7 +24,7 @@ type MetricsConfig struct {
 }
 
 func (mc MetricsConfig) Enabled() bool {
-	return mc.Metrics != nil && mc.Metrics.Enabled()
+	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() && slices.Contains(mc.Metrics.Families, otel.FamilyNetwork)
 }
 
 func mlog() *slog.Logger {

--- a/pkg/internal/netolly/export/metrics_test.go
+++ b/pkg/internal/netolly/export/metrics_test.go
@@ -105,21 +105,21 @@ func TestMetricAttributes_Filter(t *testing.T) {
 
 func TestMetricsConfig_Enabled(t *testing.T) {
 	assert.True(t, MetricsConfig{Metrics: &otel.MetricsConfig{
-		Families: []string{otel.FamilyApplication, otel.FamilyNetwork}, CommonEndpoint: "foo"}}.Enabled())
+		Features: []string{otel.FeatureApplication, otel.FeatureNetwork}, CommonEndpoint: "foo"}}.Enabled())
 	assert.True(t, MetricsConfig{Metrics: &otel.MetricsConfig{
-		Families: []string{otel.FamilyNetwork, otel.FamilyApplication}, MetricsEndpoint: "foo"}}.Enabled())
+		Features: []string{otel.FeatureNetwork, otel.FeatureApplication}, MetricsEndpoint: "foo"}}.Enabled())
 	assert.True(t, MetricsConfig{Metrics: &otel.MetricsConfig{
-		Families: []string{otel.FamilyNetwork}, Grafana: &otel.GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}}.Enabled())
+		Features: []string{otel.FeatureNetwork}, Grafana: &otel.GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}}.Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
-	var fa = []string{otel.FamilyApplication}
-	var fn = []string{otel.FamilyNetwork}
-	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Families: fn}}.Enabled())
-	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Families: fn, Grafana: &otel.GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}}.Enabled())
-	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Families: fn, Grafana: &otel.GrafanaOTLP{Submit: []string{"metrics"}}}}.Enabled())
-	// network family is not enabled
+	var fa = []string{otel.FeatureApplication}
+	var fn = []string{otel.FeatureNetwork}
+	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Features: fn}}.Enabled())
+	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Features: fn, Grafana: &otel.GrafanaOTLP{Submit: []string{"traces"}, InstanceID: "33221"}}}.Enabled())
+	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Features: fn, Grafana: &otel.GrafanaOTLP{Submit: []string{"metrics"}}}}.Enabled())
+	// network feature is not enabled
 	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{CommonEndpoint: "foo"}}.Enabled())
-	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{MetricsEndpoint: "foo", Families: fa}}.Enabled())
+	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{MetricsEndpoint: "foo", Features: fa}}.Enabled())
 	assert.False(t, MetricsConfig{Metrics: &otel.MetricsConfig{Grafana: &otel.GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}}.Enabled())
 }

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -45,6 +45,7 @@ func TestBasicPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &beyla.Config{
 		Metrics: otel.MetricsConfig{
+			Features:        []string{otel.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true,
 			ReportPeerInfo: true, Interval: 10 * time.Millisecond,
 			ReportersCacheLen: 16,
@@ -192,6 +193,7 @@ func TestRouteConsolidation(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &beyla.Config{
 		Metrics: otel.MetricsConfig{
+			Features:        []string{otel.FeatureApplication},
 			ReportPeerInfo:  false, // no peer info
 			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 			ReportersCacheLen: 16,
@@ -267,6 +269,7 @@ func TestGRPCPipeline(t *testing.T) {
 
 	gb := newGraphBuilder(ctx, &beyla.Config{
 		Metrics: otel.MetricsConfig{
+			Features:        []string{otel.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true, Interval: time.Millisecond,
 			ReportersCacheLen: 16,
 		},
@@ -345,6 +348,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 	tracesInput := make(chan []request.Span, 10)
 	gb := newGraphBuilder(ctx, &beyla.Config{
 		Metrics: otel.MetricsConfig{
+			Features:        []string{otel.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, ReportTarget: true, ReportPeerInfo: true,
 			Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
 		},


### PR DESCRIPTION
Use case: someone willing to report network metrics and application traces, but not application metrics.

This PR lets selectively choosing which metric families can be reported by the OTLP exporter.