### PR TITLE
Increase Refresh Interval in Sample Dashboard

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1135,7 +1135,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 38,
   "tags": [
     "ebpf",


### PR DESCRIPTION
Increase Refresh Interval in Sample Dashboard, as current setting of `5s` is very low, and in most cases data is only being sent every `15s` or `60s` and the refresh interval can cause a lot of expensive queries to be run (especially if a large number of jobs) more often than there will be new data.