### PR TITLE
NetO11y: refactor attributes filter to be prometheus-ready

### DIFF
--- a/pkg/internal/netolly/agent/pipeline.go
+++ b/pkg/internal/netolly/agent/pipeline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/export"
+	"github.com/grafana/beyla/pkg/internal/netolly/export/otel"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow"
 	"github.com/grafana/beyla/pkg/internal/netolly/transform/cidr"
 	"github.com/grafana/beyla/pkg/internal/netolly/transform/k8s"
@@ -26,7 +27,7 @@ type FlowsPipeline struct {
 	CIDRs      cidr.Definitions      `forwardTo:"Decorator"`
 	Decorator  `sendTo:"Exporter,Printer"`
 
-	Exporter export.MetricsConfig
+	Exporter otel.MetricsConfig
 	Printer  export.FlowPrinterEnabled
 }
 
@@ -75,7 +76,7 @@ func (f *Flows) buildAndStartPipeline(ctx context.Context) (graph.Graph, error) 
 	graph.RegisterMiddle(gb, flow.ReverseDNSProvider)
 
 	// Terminal nodes export the flow record information out of the pipeline: OTEL and printer
-	graph.RegisterTerminal(gb, export.MetricsExporterProvider)
+	graph.RegisterTerminal(gb, otel.MetricsExporterProvider)
 	graph.RegisterTerminal(gb, export.FlowPrinterProvider)
 
 	var deduperExpireTime = f.cfg.NetworkFlows.DeduperFCExpiry
@@ -91,7 +92,7 @@ func (f *Flows) buildAndStartPipeline(ctx context.Context) (graph.Graph, error) 
 		// TODO: allow prometheus exporting
 		ReverseDNS: f.cfg.NetworkFlows.ReverseDNS,
 		CIDRs:      f.cfg.NetworkFlows.CIDRs,
-		Exporter: export.MetricsConfig{
+		Exporter: otel.MetricsConfig{
 			Metrics:           &f.cfg.Metrics,
 			AllowedAttributes: f.cfg.NetworkFlows.AllowedAttributes,
 		},

--- a/pkg/internal/netolly/export/otel/metrics_test.go
+++ b/pkg/internal/netolly/export/otel/metrics_test.go
@@ -1,4 +1,4 @@
-package export
+package otel
 
 import (
 	"testing"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
+	"github.com/grafana/beyla/pkg/internal/netolly/export"
 )
 
 func TestMetricAttributes(t *testing.T) {
@@ -32,9 +33,9 @@ func TestMetricAttributes(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me := &metricsExporter{attrs: NewAttributesFilter([]string{
-		"src.address", "dst.address", "src.name", "dst.name",
-		"k8s.src.name", "k8s.src.namespace", "k8s.dst.name", "k8s.dst.namespace",
+	me := &metricsExporter{attrs: export.BuildOTELAttributeGetters([]string{
+		"src.address", "dst.address", "src.name", "dst_name",
+		"k8s.src.name", "k8s.src_namespace", "k8s.dst.name", "k8s.dst.namespace",
 	})}
 	reportedAttributes := me.attributes(in)
 	for _, mustContain := range []attribute.KeyValue{
@@ -75,7 +76,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me := &metricsExporter{attrs: NewAttributesFilter([]string{
+	me := &metricsExporter{attrs: export.BuildOTELAttributeGetters([]string{
 		"src.address",
 		"k8s.src.name",
 		"k8s.dst.name",


### PR DESCRIPTION
We are preparing a prometheus exporter for network metrics. Before it, this PR does a small refactor that optimizes the way that attributes are filtered, especially for Prometheus.

With the new way, we can know beforehand the names of all the attributes that are used (as required by the Prometheus metric definition), and can retrieve later its values in the same order they were defined.

This refactor also slightly simplifies and optimizes the OTEL attributes definition, that's why I publish the refactor before providing the Prometheus exporter.