### PR TITLE
Network metrics: prometheus expirer

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -63,7 +63,7 @@ var DefaultConfig = Config{
 		Path:       "/metrics",
 		Buckets:    otel.DefaultBuckets,
 		Features:   []string{otel.FeatureNetwork, otel.FeatureApplication},
-		ExpireTime: 3 * time.Minute,
+		ExpireTime: 5 * time.Minute,
 	},
 	Printer: false,
 	Noop:    false,

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -60,9 +60,10 @@ var DefaultConfig = Config{
 		ReportersCacheLen:  ReporterLRUSize,
 	},
 	Prometheus: prom.PrometheusConfig{
-		Path:     "/metrics",
-		Buckets:  otel.DefaultBuckets,
-		Features: []string{otel.FeatureNetwork, otel.FeatureApplication},
+		Path:       "/metrics",
+		Buckets:    otel.DefaultBuckets,
+		Features:   []string{otel.FeatureNetwork, otel.FeatureApplication},
+		ExpireTime: 3 * time.Minute,
 	},
 	Printer: false,
 	Noop:    false,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -32,6 +32,7 @@ otel_metrics_export:
     duration_histogram: [0, 1, 2]
   histogram_aggregation: base2_exponential_bucket_histogram
 prometheus_export:
+  expire_time: 1s
   buckets:
     request_size_histogram: [0, 10, 20, 22]
 attributes:
@@ -121,8 +122,9 @@ network:
 			ReportersCacheLen:  ReporterLRUSize,
 		},
 		Prometheus: prom.PrometheusConfig{
-			Path:     "/metrics",
-			Features: []string{otel.FeatureNetwork, otel.FeatureApplication},
+			Path:       "/metrics",
+			Features:   []string{otel.FeatureNetwork, otel.FeatureApplication},
+			ExpireTime: time.Second,
 			Buckets: otel.Buckets{
 				DurationHistogram:    otel.DefaultBuckets.DurationHistogram,
 				RequestSizeHistogram: []float64{0, 10, 20, 22},

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -90,6 +90,12 @@ type PrometheusConfig struct {
 
 	Buckets otel.Buckets `yaml:"buckets"`
 
+	// ExpireTime is the time since a metric was updated for the last time until it is
+	// removed from the metrics set.
+	ExpireTime time.Duration `yaml:"expire_time" env:"BEYLA_PROMETHEUS_EXPIRE_TIME"`
+
+	// Registry is only used for embedding Beyla within the Grafana Agent.
+	// It must be nil when Beyla runs as standalone
 	Registry *prometheus.Registry `yaml:"-"`
 }
 

--- a/pkg/internal/netolly/export/prom/expirer.go
+++ b/pkg/internal/netolly/export/prom/expirer.go
@@ -1,0 +1,90 @@
+package prom
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const DefaultExpireTime = 3 * time.Minute
+
+var timeNow = time.Now
+
+// TODO: generify and move to a common section for using it also in AppO11y
+type Expirer struct {
+	mt         sync.RWMutex
+	expireTime time.Duration
+	timeNow    time.Time
+	wrapped    *prometheus.CounterVec
+	entries    map[string]*entry
+}
+
+type entry struct {
+	lastAccess  time.Time
+	labelValues []string
+	count       prometheus.Counter
+}
+
+func NewExpirer(wrapped *prometheus.CounterVec, expireTime time.Duration) *Expirer {
+	return &Expirer{
+		wrapped:    wrapped,
+		expireTime: expireTime,
+		entries:    map[string]*entry{},
+	}
+}
+
+func (ex *Expirer) UpdateTime() {
+	ex.timeNow = timeNow()
+}
+
+func (ex *Expirer) WithLabelValues(lbls ...string) prometheus.Counter {
+	h := labelsKey(lbls)
+	ex.mt.RLock()
+	e, ok := ex.entries[h]
+	if ok {
+		e.lastAccess = ex.timeNow
+		ex.mt.RUnlock()
+		return e.count
+	}
+	ex.mt.RUnlock()
+
+	c := ex.wrapped.WithLabelValues(lbls...)
+	ex.mt.Lock()
+	ex.entries[h] = &entry{
+		labelValues: lbls,
+		lastAccess:  ex.timeNow,
+		count:       c,
+	}
+	ex.mt.Unlock()
+	return c
+}
+
+func labelsKey(lbls []string) string {
+	return strings.Join(lbls, ":")
+}
+
+func (ex *Expirer) Describe(descs chan<- *prometheus.Desc) {
+	ex.wrapped.Describe(descs)
+}
+
+func (ex *Expirer) Collect(metrics chan<- prometheus.Metric) {
+	now := timeNow()
+	var delKeys []string
+	var delLabels [][]string
+	for k, e := range ex.entries {
+		if now.Sub(e.lastAccess) > ex.expireTime {
+			delKeys = append(delKeys, k)
+			delLabels = append(delLabels, e.labelValues)
+		} else {
+			metrics <- e.count
+		}
+	}
+	for _, k := range delKeys {
+		delete(ex.entries, k)
+	}
+	for _, k := range delLabels {
+		ex.wrapped.DeleteLabelValues(k...)
+	}
+}

--- a/pkg/internal/netolly/export/prom/expirer.go
+++ b/pkg/internal/netolly/export/prom/expirer.go
@@ -15,6 +15,7 @@ func plog() *slog.Logger {
 	return slog.With("component", "prom.Expirer")
 }
 
+// Expirer drops metrics from labels that haven't been updated during a given timeout
 // TODO: generify and move to a common section for using it also in AppO11y
 type Expirer struct {
 	mt         sync.RWMutex
@@ -30,6 +31,8 @@ type entry struct {
 	count       prometheus.Counter
 }
 
+// NewExpirer creates a metric that wraps a given CounterVec. Its labeled instances are dropped
+// if they haven't been updated during the last timeout period
 func NewExpirer(wrapped *prometheus.CounterVec, expireTime time.Duration) *Expirer {
 	return &Expirer{
 		wrapped:    wrapped,
@@ -38,20 +41,28 @@ func NewExpirer(wrapped *prometheus.CounterVec, expireTime time.Duration) *Expir
 	}
 }
 
+// UpdateTime updates the last access time to be annotated to any new or existing metric.
+// It is a required operation before processing a given
+// batch of metrics (invoking the WithLabelValues).
 func (ex *Expirer) UpdateTime() {
 	ex.timeNow = timeNow()
 }
 
+// WithLabelValues returns the Counter for the given slice of label
+// values (same order as the variable labels in Desc). If that combination of
+// label values is accessed for the first time, a new Counter is created.
+// If not, a cached copy is returned and the "last access" cache time is updated.
 func (ex *Expirer) WithLabelValues(lbls ...string) prometheus.Counter {
 	h := labelsKey(lbls)
 	ex.mt.RLock()
 	e, ok := ex.entries[h]
+	ex.mt.RUnlock()
 	if ok {
+		ex.mt.Lock()
 		e.lastAccess = ex.timeNow
-		ex.mt.RUnlock()
+		ex.mt.Unlock()
 		return e.count
 	}
-	ex.mt.RUnlock()
 
 	plog().With("labelValues", lbls).Debug("storing new metric label set")
 	c := ex.wrapped.WithLabelValues(lbls...)
@@ -69,16 +80,19 @@ func labelsKey(lbls []string) string {
 	return strings.Join(lbls, ":")
 }
 
+// Describe wraps prometheus.Collector Describe method
 func (ex *Expirer) Describe(descs chan<- *prometheus.Desc) {
 	ex.wrapped.Describe(descs)
 }
 
+// Collect wraps prometheus.Collector Wrap method
 func (ex *Expirer) Collect(metrics chan<- prometheus.Metric) {
 	log := plog()
 	log.Debug("invoking metrics collection")
 	now := timeNow()
 	var delKeys []string
 	var delLabels [][]string
+	ex.mt.RLock()
 	for k, e := range ex.entries {
 		if now.Sub(e.lastAccess) > ex.expireTime {
 			delKeys = append(delKeys, k)
@@ -87,9 +101,12 @@ func (ex *Expirer) Collect(metrics chan<- prometheus.Metric) {
 			metrics <- e.count
 		}
 	}
+	ex.mt.RUnlock()
+	ex.mt.Lock()
 	for _, k := range delKeys {
 		delete(ex.entries, k)
 	}
+	ex.mt.Unlock()
 	for _, k := range delLabels {
 		ex.wrapped.DeleteLabelValues(k...)
 		log.With("labelValues", k).Debug("deleting old Prometheus metric")

--- a/pkg/internal/netolly/export/prom/expirer_test.go
+++ b/pkg/internal/netolly/export/prom/expirer_test.go
@@ -1,0 +1,39 @@
+package prom
+
+import (
+	"hash/fnv"
+	"hash/maphash"
+	"strings"
+	"testing"
+)
+
+var lbls = []string{"asdfkjhdsfakl", "ksadlfjlk", "ksdlaf", "k3klj", "kdk", "kdsfjdlkjfd"}
+
+func BenchmarkMapHash(b *testing.B) {
+	m := map[uint64][]string{}
+	for i := 0; i < b.N; i++ {
+		h := maphash.Hash{}
+		for _, l := range lbls {
+			h.WriteString(l)
+		}
+		m[h.Sum64()] = lbls
+	}
+}
+
+func BenchmarkFNV(b *testing.B) {
+	m := map[uint64][]string{}
+	for i := 0; i < b.N; i++ {
+		h := fnv.New64()
+		for _, l := range lbls {
+			h.Write([]byte(l))
+		}
+		m[h.Sum64()] = lbls
+	}
+}
+
+func BenchmarkJoin(b *testing.B) {
+	m := map[string][]string{}
+	for i := 0; i < b.N; i++ {
+		m[strings.Join(lbls, ":")] = lbls
+	}
+}

--- a/pkg/internal/netolly/export/prom/expirer_test.go
+++ b/pkg/internal/netolly/export/prom/expirer_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/beyla/pkg/internal/connector"
@@ -17,12 +18,11 @@ import (
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 )
 
+const timeout = 3 * time.Second
+
 func TestMetricsExpiration(t *testing.T) {
-	slog.SetLogLoggerLevel(slog.LevelDebug)
-	now := time.Now()
-	timeNow = func() time.Time {
-		return now
-	}
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
@@ -31,6 +31,7 @@ func TestMetricsExpiration(t *testing.T) {
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
 	require.NoError(t, err)
 
+	// GIVEN a Prometheus Metrics Exporter with a metrics expire time of 3 minutes
 	exporter, err := PrometheusEndpoint(
 		ctx,
 		&PrometheusConfig{Config: &prom.PrometheusConfig{
@@ -45,6 +46,7 @@ func TestMetricsExpiration(t *testing.T) {
 	metrics := make(chan []*ebpf.Record, 20)
 	go exporter(metrics)
 
+	// WHEN it receives metrics
 	metrics <- []*ebpf.Record{
 		{Attrs: ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
 			NetFlowRecordT: ebpf.NetFlowRecordT{Metrics: ebpf.NetFlowMetrics{Bytes: 123}}},
@@ -52,21 +54,68 @@ func TestMetricsExpiration(t *testing.T) {
 			NetFlowRecordT: ebpf.NetFlowRecordT{Metrics: ebpf.NetFlowMetrics{Bytes: 456}}},
 	}
 
-	time.Sleep(2 * time.Second)
+	// THEN the metrics are exported
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		exported := getMetrics(t, promURL)
+		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"} 123`)
+		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
+	})
 
-	AQUI PARSEAR SIMPLEMENTE QUE EL RESPONSE CONTAINS
-	beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"} 123
-	beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"} 456
-	reported := getMetrics(t, promURL)
-	fmt.Println("reported", reported)
+	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
+	now.Advance(2 * time.Minute)
+	metrics <- []*ebpf.Record{
+		{Attrs: ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{Metrics: ebpf.NetFlowMetrics{Bytes: 123}}},
+	}
+	now.Advance(2 * time.Minute)
 
+	// THEN THE metrics that have been received during the timeout period are still visible
+	var exported string
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		exported = getMetrics(t, promURL)
+		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"} 246`)
+	})
+	// BUT not the metrics that haven't been received during that time
+	assert.NotContains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"}`)
+	now.Advance(2 * time.Minute)
+
+	// AND WHEN the metrics labels that disappeared are received again
+	metrics <- []*ebpf.Record{
+		{Attrs: ebpf.RecordAttrs{SrcName: "baz", DstName: "bae"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{Metrics: ebpf.NetFlowMetrics{Bytes: 456}}},
+	}
+	now.Advance(2 * time.Minute)
+
+	// THEN they are reported again, starting from zero in the case of counters
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		exported = getMetrics(t, promURL)
+		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
+	})
+	assert.NotContains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"}`)
 }
 
-func getMetrics(t *testing.T, promURL string) string {
+func getMetrics(t require.TestingT, promURL string) string {
 	resp, err := http.Get(promURL)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return string(body)
+}
+
+type syncedClock struct {
+	mt  sync.Mutex
+	now time.Time
+}
+
+func (c *syncedClock) Now() time.Time {
+	c.mt.Lock()
+	defer c.mt.Unlock()
+	return c.now
+}
+
+func (c *syncedClock) Advance(t time.Duration) {
+	c.mt.Lock()
+	defer c.mt.Unlock()
+	c.now = c.now.Add(t)
 }


### PR DESCRIPTION
The Prometheus exporter now removes the metrics that haven't been updated during a given period (defaults to 3 minutes).