### PR TITLE
Remove gin specific instrumentation

### DIFF
--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -77,7 +77,6 @@ func newGoTracersGroup(cfg *beyla.Config, metrics imetrics.Reporter) []ebpf.Trac
 	// Each program is an eBPF source: net/http, grpc...
 	return []ebpf.Tracer{
 		nethttp.New(cfg, metrics),
-		&nethttp.GinTracer{Tracer: *nethttp.New(cfg, metrics)},
 		grpc.New(cfg, metrics),
 		goruntime.New(cfg, metrics),
 	}


### PR DESCRIPTION
The gin specific instrumentation shouldn't be needed anymore. We set our probes on `net/http.serverHandler.ServeHTTP` and it's what calls the Gin method we were instrumenting.

Here's the output from Delve, stopped at our Gin instrumentation point:

```sh
569:	// ServeHTTP conforms to the http.Handler interface.
=> 570:	func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
   571:		c := engine.pool.Get().(*Context)
   572:		c.writermem.reset(w)
   573:		c.Request = req
   574:		c.reset()
   575:	
(dlv) bt
0  0x0000000000931f4e in github.com/gin-gonic/gin.(*Engine).ServeHTTP
   at ./vendor/github.com/gin-gonic/gin/gin.go:570
1  0x000000000071844e in net/http.serverHandler.ServeHTTP < ** we instrument this already **
   at /home/nino/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.1.linux-amd64/src/net/http/server.go:3137
2  0x0000000000713728 in net/http.(*conn).serve
   at /home/nino/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.1.linux-amd64/src/net/http/server.go:2039
3  0x0000000000718c68 in net/http.(*Server).Serve.gowrap3
   at /home/nino/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.1.linux-amd64/src/net/http/server.go:3285
4  0x0000000000472bc1 in runtime.goexit
   at /home/nino/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.1.linux-amd64/src/runtime/asm_amd64.s:1695
```