### PR TITLE
Allow customizing the base path and don't mount the BPF fs if it is already mounted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,11 @@ test:
 	@echo "### Testing code"
 	go test -race -mod vendor -a ./... -coverpkg=./... -coverprofile $(TEST_OUTPUT)/cover.all.txt
 
+.PHONY: test-privileged
+test-privileged:
+	@echo "### Testing code with privileged tests enabled"
+	PRIVILEGED_TESTS=true go test -race -mod vendor -a ./... -coverpkg=./... -coverprofile $(TEST_OUTPUT)/cover.all.txt
+
 .PHONY: cov-exclude-generated
 cov-exclude-generated:
 	grep -vE $(EXCLUDE_COVERAGE_FILES) $(TEST_OUTPUT)/cover.all.txt > $(TEST_OUTPUT)/cover.txt

--- a/NOTICE
+++ b/NOTICE
@@ -16,6 +16,10 @@ inspired by ebpf-go (https://github.com/cilium/ebpf).
 Copyright Authors of Cilium.
 
 The Initial Developer of some parts of the product, which are copied from, derived from, or
+inspired by ebpf-go (https://github.com/cilium/cilium).
+Copyright Authors of Cilium.
+
+The Initial Developer of some parts of the product, which are copied from, derived from, or
 inspired by NetObserv eBPF Agent (https://github.com/netobserv/netobserv-ebpf-agent).
 Copyright Red Hat/IBM.
 
@@ -306,3 +310,208 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+License notice for cilium
+--------------------------
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} Authors of Cilium
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -3,6 +3,7 @@ package beyla
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/caarlos0/env/v9"
@@ -36,6 +37,7 @@ var DefaultConfig = Config{
 		BatchLength:  100,
 		BatchTimeout: time.Second,
 		BpfBaseDir:   "/var/run/beyla",
+		BpfPath:      fmt.Sprintf("beyla-%d", os.Getpid()),
 	},
 	Grafana: otel.GrafanaConfig{
 		OTLP: otel.GrafanaOTLP{

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -93,6 +93,7 @@ network:
 			BatchLength:  100,
 			BatchTimeout: time.Second,
 			BpfBaseDir:   "/var/run/beyla",
+			BpfPath:      DefaultConfig.EBPF.BpfPath,
 		},
 		Grafana: otel.GrafanaConfig{
 			OTLP: otel.GrafanaOTLP{

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -2,9 +2,7 @@ package discover
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os"
 	"path"
 
 	"github.com/cilium/ebpf/link"
@@ -193,7 +191,7 @@ func monitorPIDs(tracer *ebpf.ProcessTracer, ie *Instrumentable) {
 // it will be:
 //   - current beyla PID
 func BuildPinPath(cfg *beyla.Config) string {
-	return path.Join(cfg.EBPF.BpfBaseDir, fmt.Sprintf("beyla-%d", os.Getpid()))
+	return path.Join(cfg.EBPF.BpfBaseDir, cfg.EBPF.BpfPath)
 }
 
 func (ta *TraceAttacher) notifyProcessDeletion(ie *Instrumentable) {

--- a/pkg/internal/discover/attacher_linux_privileged_test.go
+++ b/pkg/internal/discover/attacher_linux_privileged_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package discover
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMountBpfPinPath(t *testing.T) {
+	if os.Getenv(privilegedEnv) == "" {
+		t.Skipf("Set %s to run this test", privilegedEnv)
+	}
+	tmpDir := "path"
+	ta := &TraceAttacher{
+		log:     slog.With("component", "discover.TraceAttacher"),
+		pinPath: tmpDir,
+	}
+
+	// Nothing there to start the test
+	mounted, matched, err := IsMountFS(FilesystemTypeBPFFS, tmpDir)
+	assert.NoError(t, err)
+	assert.False(t, mounted)
+	assert.False(t, matched)
+
+	err = ta.mountBpfPinPath()
+	assert.NoError(t, err)
+
+	// Check that it is mounted
+	mounted, matched, err = IsMountFS(FilesystemTypeBPFFS, tmpDir)
+	assert.NoError(t, err)
+	assert.True(t, mounted)
+	assert.True(t, matched)
+
+	// Ensure mounting the same path twice does not fail
+	err = ta.mountBpfPinPath()
+	assert.NoError(t, err)
+
+	// Check that it is mounted
+	mounted, matched, err = IsMountFS(FilesystemTypeBPFFS, tmpDir)
+	assert.NoError(t, err)
+	assert.True(t, mounted)
+	assert.True(t, matched)
+
+	ta.unmountBpfPinPath()
+
+	// Check that it is cleaned up
+	mounted, matched, err = IsMountFS(FilesystemTypeBPFFS, tmpDir)
+	assert.NoError(t, err)
+	assert.False(t, mounted)
+	assert.False(t, matched)
+}

--- a/pkg/internal/discover/mountinfo_linux.go
+++ b/pkg/internal/discover/mountinfo_linux.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// original source:
+// https://github.com/cilium/cilium/blob/5130d33a835638c78dda2572d7dc92091ffb3dc1/pkg/mountinfo/mountinfo_linux.go#L27
+
+package discover
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// FilesystemType superblock magic numbers for filesystems,
+	// to be used for IsMountFS.
+	FilesystemTypeBPFFS   = unix.BPF_FS_MAGIC
+	FilesystemTypeCgroup2 = unix.CGROUP2_SUPER_MAGIC
+)
+
+// IsMountFS returns two boolean values, checking
+//   - whether the path is a mount point;
+//   - if yes, whether its filesystem type is mntType.
+//
+// Note that this function can not detect bind mounts,
+// and is not working properly when path="/".
+func IsMountFS(mntType int64, path string) (bool, bool, error) {
+	var st, pst unix.Stat_t
+
+	err := unix.Lstat(path, &st)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			// non-existent path can't be a mount point
+			return false, false, nil
+		}
+		return false, false, &os.PathError{Op: "lstat", Path: path, Err: err}
+	}
+
+	parent := filepath.Dir(path)
+	err = unix.Lstat(parent, &pst)
+	if err != nil {
+		return false, false, &os.PathError{Op: "lstat", Path: parent, Err: err}
+	}
+	if st.Dev == pst.Dev {
+		// parent has the same dev -- not a mount point
+		return false, false, nil
+	}
+
+	// Check the fstype
+	fst := unix.Statfs_t{}
+	err = unix.Statfs(path, &fst)
+	if err != nil {
+		return true, false, &os.PathError{Op: "statfs", Path: path, Err: err}
+	}
+
+	return true, int64(fst.Type) == mntType, nil
+
+}

--- a/pkg/internal/discover/mountinfo_linux_privileged_test.go
+++ b/pkg/internal/discover/mountinfo_linux_privileged_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Original source:
+// https://github.com/cilium/cilium/blob/5130d33a835638c78dda2572d7dc92091ffb3dc1/pkg/mountinfo/mountinfo_privileged_test.go
+
+//go:build linux
+
+package discover
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+const privilegedEnv = "PRIVILEGED_TESTS"
+
+// TestIsMountFSbyMount tests the public function IsMountFS by performing
+// an actual mount.
+func TestIsMountFSbyMount(t *testing.T) {
+	if os.Getenv(privilegedEnv) == "" {
+		t.Skipf("Set %s to run this test", privilegedEnv)
+	}
+	tmpDir, err := os.MkdirTemp("", "IsMountFS_")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	mounted, matched, err := IsMountFS(unix.TMPFS_MAGIC, tmpDir)
+	assert.NoError(t, err)
+	assert.False(t, mounted)
+	assert.False(t, matched)
+
+	err = unix.Mount("tmpfs", tmpDir, "tmpfs", 0, "")
+	assert.NoError(t, err)
+	defer unix.Unmount(tmpDir, unix.MNT_DETACH)
+
+	// deliberately check with wrong fstype
+	mounted, matched, err = IsMountFS(unix.PROC_SUPER_MAGIC, tmpDir)
+	assert.NoError(t, err)
+	assert.True(t, mounted)
+	assert.False(t, matched)
+
+	// now check with proper fstype
+	mounted, matched, err = IsMountFS(unix.TMPFS_MAGIC, tmpDir)
+	assert.NoError(t, err)
+	assert.True(t, mounted)
+	assert.True(t, matched)
+}

--- a/pkg/internal/discover/mountinfo_linux_privileged_test.go
+++ b/pkg/internal/discover/mountinfo_linux_privileged_test.go
@@ -35,7 +35,10 @@ func TestIsMountFSbyMount(t *testing.T) {
 
 	err = unix.Mount("tmpfs", tmpDir, "tmpfs", 0, "")
 	assert.NoError(t, err)
-	defer unix.Unmount(tmpDir, unix.MNT_DETACH)
+	defer func() {
+		err := unix.Unmount(tmpDir, unix.MNT_DETACH)
+		assert.NoError(t, err)
+	}()
 
 	// deliberately check with wrong fstype
 	mounted, matched, err = IsMountFS(unix.PROC_SUPER_MAGIC, tmpDir)

--- a/pkg/internal/discover/mountinfo_linux_test.go
+++ b/pkg/internal/discover/mountinfo_linux_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Original source:
+// https://github.com/cilium/cilium/blob/5130d33a835638c78dda2572d7dc92091ffb3dc1/pkg/mountinfo/mountinfo_test.go
+
+//go:build linux
+
+package discover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+// TestIsMountFS tests the public function IsMountFS. We cannot expect every
+// system and machine to have any predictable mounts, but let's try a couple
+// of very well known paths.
+func TestIsMountFS(t *testing.T) {
+	mounted, matched, err := IsMountFS(unix.PROC_SUPER_MAGIC, "/proc")
+	assert.NoError(t, err)
+	assert.True(t, mounted)
+	assert.True(t, matched)
+
+	mounted, matched, err = IsMountFS(FilesystemTypeBPFFS, "/sys/fs/bpf")
+	assert.NoError(t, err)
+	// We can't expect /sys/fs/bpf is mounted, so only check fstype
+	// if it is mounted. IOW, if /sys/fs/bpf is a mount point,
+	// we expect it to be bpffs.
+	if mounted {
+		assert.True(t, matched)
+	}
+}

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -55,6 +55,10 @@ type TracerConfig struct {
 	// By default, it will be /var/run/beyla
 	BpfBaseDir string `yaml:"bpf_fs_base_dir" env:"BEYLA_BPF_FS_BASE_DIR"`
 
+	// BpfPath specifies the path in the base directory where the BPF pinned maps will be mounted.
+	// By default, it will be beyla-<pid>.
+	BpfPath string `yaml:"bpf_fs_path" env:"BEYLA_BPF_FS_PATH"`
+
 	// If enabled, the kprobes based HTTP request tracking will start tracking the request
 	// headers to process any 'Traceparent' fields.
 	TrackRequestHeaders bool `yaml:"track_request_headers" env:"BEYLA_BPF_TRACK_REQUEST_HEADERS"`

--- a/pkg/internal/ebpf/common/common_test.go
+++ b/pkg/internal/ebpf/common/common_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const privilegedEnv = "PRIVILEGED_TESTS"
+
 func setIntegrity(t *testing.T, path, text string) {
 	err := os.WriteFile(path, []byte(text), 0644)
 	assert.NoError(t, err)
@@ -54,6 +56,11 @@ func TestLockdownParsing(t *testing.T) {
 
 	setIntegrity(t, path, "")
 	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
+
+	if os.Getenv(privilegedEnv) != "" {
+		// This test doesn't pass when run as sudo
+		t.Skipf("Skipping this test because %v is set", privilegedEnv)
+	}
 
 	setIntegrity(t, path, "[none] integrity confidentiality\n")
 	setNotReadable(t, path)


### PR DESCRIPTION
Fixes https://github.com/grafana/beyla/issues/732

This enables beyla to be run without the SYS_ADMIN capability.  See https://github.com/dashpole/beyla/pull/1 for more details.

The code to determine if a mount is a bpf mount is based on https://github.com/cilium/cilium/blob/5130d33a835638c78dda2572d7dc92091ffb3dc1/pkg/mountinfo/mountinfo_linux.go#L27.  Importing that would add a dependency on `github.com/cilium/cilium`, which the project doesn't currently have.

I could:

* Add a dependency on cilium, or
* Put the code in its own file with the cilium copyright header, and also copy the unit tests.

Let me know which you would prefer, and if there is anything else needed (docs updates, etc) for the change.