### PR TITLE
Makefile: automatically update prereq binaries after version changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,20 @@ PROJECT_DIR := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOOLS_DIR ?= $(PROJECT_DIR)/bin
 
+# $(1) command name
+# $(2) repo URL
+# $(3) version
 define go-install-tool
-@[ -f $(1) ] || { \
+@[ -f "$(1)-$(3)" ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(TOOLS_DIR) GOFLAGS="-mod=mod" go install $(2) ;\
+echo "Removing any outdated version of $(1)";\
+rm -f $(1)*;\
+echo "Downloading $(2)@$(3)" ;\
+GOBIN=$(TOOLS_DIR) GOFLAGS="-mod=mod" go install "$(2)@$(3)" ;\
+touch "$(1)-$(3)";\
 rm -rf $$TMP_DIR ;\
 }
 endef
@@ -93,13 +99,13 @@ endef
 prereqs:
 	@echo "### Check if prerequisites are met, and installing missing dependencies"
 	mkdir -p $(TEST_OUTPUT)/run
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2)
-	$(call go-install-tool,$(BPF2GO),github.com/cilium/ebpf/cmd/bpf2go@$(call gomod-version,cilium/ebpf))
-	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker@$(call gomod-version,grafana/go-offsets-tracker))
-	$(call go-install-tool,$(GOIMPORTS_REVISER),github.com/incu6us/goimports-reviser/v3@v3.4.5)
-	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses@v1.6.0)
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.20.0)
-	$(call go-install-tool,$(DASHBOARD_LINTER),github.com/grafana/dashboard-linter@latest)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,v1.57.2)
+	$(call go-install-tool,$(BPF2GO),github.com/cilium/ebpf/cmd/bpf2go,$(call gomod-version,cilium/ebpf))
+	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker,$(call gomod-version,grafana/go-offsets-tracker))
+	$(call go-install-tool,$(GOIMPORTS_REVISER),github.com/incu6us/goimports-reviser/v3,v3.4.5)
+	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses,v1.6.0)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,v0.20.0)
+	$(call go-install-tool,$(DASHBOARD_LINTER),github.com/grafana/dashboard-linter,latest)
 
 .PHONY: fmt
 fmt: prereqs

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ itest-coverage-data:
 	grep -vE $(EXCLUDE_COVERAGE_FILES) $(TEST_OUTPUT)/itest-covdata.all.txt > $(TEST_OUTPUT)/itest-covdata.txt
 
 bin/ginkgo:
-	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@latest)
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,latest)
 
 .PHONY: oats-prereq
 oats-prereq: bin/ginkgo


### PR DESCRIPTION
Detects if a version in the `go-install-tool` has changed and automatically downloads the binary, without having to manually remove it.

It will populate your `bin/` directory with empty files that specify the name of the binary and the current version. For example:

```
bpf2go-v0.12.3
go-licenses-v1.6.0       
go-offsets-tracker-v0.1.7 
goimports-reviser-v3.4.5  
golangci-lint-v1.57.2     
kind-v0.20.0
```