### PR TITLE
Standardize how we set peer/host names

### DIFF
--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -544,9 +544,9 @@ func (mr *MetricsReporter) grpcAttributes(span *request.Span) []attribute.KeyVal
 	}
 	if mr.cfg.ReportPeerInfo {
 		if span.Type == request.EventTypeGRPC {
-			attrs = append(attrs, ClientAddr(span.Peer))
+			attrs = append(attrs, ClientAddr(SpanPeer(span)))
 		} else {
-			attrs = append(attrs, ServerAddr(span.Peer))
+			attrs = append(attrs, ServerAddr(SpanPeer(span)))
 		}
 	}
 
@@ -562,7 +562,7 @@ func (mr *MetricsReporter) httpServerAttributes(span *request.Span) []attribute.
 		attrs = append(attrs, HTTPUrlPath(span.Path))
 	}
 	if mr.cfg.ReportPeerInfo {
-		attrs = append(attrs, ClientAddr(span.Peer))
+		attrs = append(attrs, ClientAddr(SpanPeer(span)))
 	}
 	if span.Route != "" {
 		attrs = append(attrs, semconv.HTTPRoute(span.Route))
@@ -577,7 +577,7 @@ func (mr *MetricsReporter) httpClientAttributes(span *request.Span) []attribute.
 		HTTPResponseStatusCode(span.Status),
 	}
 	if mr.cfg.ReportPeerInfo {
-		attrs = append(attrs, ServerAddr(span.Host))
+		attrs = append(attrs, ServerAddr(SpanHost(span)))
 		attrs = append(attrs, ServerPort(span.HostPort))
 	}
 	if span.Route != "" {
@@ -644,18 +644,18 @@ func (mr *MetricsReporter) serviceGraphAttributes(span *request.Span) attribute.
 	var attrs []attribute.KeyValue
 	if span.IsClientSpan() {
 		attrs = []attribute.KeyValue{
-			ClientMetric(span.PeerName),
+			ClientMetric(SpanPeer(span)),
 			ClientNamespaceMetric(span.ServiceID.Namespace),
-			ServerMetric(span.HostName),
+			ServerMetric(SpanHost(span)),
 			ServerNamespaceMetric(span.OtherNamespace),
 			ConnectionTypeMetric("virtual_node"),
 			SourceMetric("beyla"),
 		}
 	} else {
 		attrs = []attribute.KeyValue{
-			ClientMetric(span.PeerName),
+			ClientMetric(SpanPeer(span)),
 			ClientNamespaceMetric(span.OtherNamespace),
-			ServerMetric(span.HostName),
+			ServerMetric(SpanHost(span)),
 			ServerNamespaceMetric(span.ServiceID.Namespace),
 			ConnectionTypeMetric("virtual_node"),
 			SourceMetric("beyla"),

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -296,7 +296,7 @@ func SpanKindString(span *request.Span) string {
 	return "SPAN_KIND_INTERNAL"
 }
 
-func spanHost(span *request.Span) string {
+func SpanHost(span *request.Span) string {
 	if span.HostName != "" {
 		return span.HostName
 	}
@@ -304,7 +304,7 @@ func spanHost(span *request.Span) string {
 	return span.Host
 }
 
-func spanPeer(span *request.Span) string {
+func SpanPeer(span *request.Span) string {
 	if span.PeerName != "" {
 		return span.PeerName
 	}
@@ -321,8 +321,8 @@ func TraceAttributes(span *request.Span) []attribute.KeyValue {
 			HTTPRequestMethod(span.Method),
 			HTTPResponseStatusCode(span.Status),
 			HTTPUrlPath(span.Path),
-			ClientAddr(spanPeer(span)),
-			ServerAddr(spanHost(span)),
+			ClientAddr(SpanPeer(span)),
+			ServerAddr(SpanHost(span)),
 			ServerPort(span.HostPort),
 			HTTPRequestBodySize(int(span.ContentLength)),
 		}
@@ -334,8 +334,8 @@ func TraceAttributes(span *request.Span) []attribute.KeyValue {
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemGRPC,
 			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
-			ClientAddr(spanPeer(span)),
-			ServerAddr(spanHost(span)),
+			ClientAddr(SpanPeer(span)),
+			ServerAddr(SpanHost(span)),
 			ServerPort(span.HostPort),
 		}
 	case request.EventTypeHTTPClient:
@@ -343,7 +343,7 @@ func TraceAttributes(span *request.Span) []attribute.KeyValue {
 			HTTPRequestMethod(span.Method),
 			HTTPResponseStatusCode(span.Status),
 			HTTPUrlFull(span.Path),
-			ServerAddr(spanHost(span)),
+			ServerAddr(SpanHost(span)),
 			ServerPort(span.HostPort),
 			HTTPRequestBodySize(int(span.ContentLength)),
 		}
@@ -352,7 +352,7 @@ func TraceAttributes(span *request.Span) []attribute.KeyValue {
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemGRPC,
 			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
-			ServerAddr(spanHost(span)),
+			ServerAddr(SpanHost(span)),
 			ServerPort(span.HostPort),
 		}
 	case request.EventTypeSQLClient:

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -488,21 +488,21 @@ func TestSpanHostPeer(t *testing.T) {
 		Peer:     "127.0.0.2",
 	}
 
-	assert.Equal(t, "localhost", spanHost(&sp))
-	assert.Equal(t, "peerhost", spanPeer(&sp))
+	assert.Equal(t, "localhost", SpanHost(&sp))
+	assert.Equal(t, "peerhost", SpanPeer(&sp))
 
 	sp = request.Span{
 		Host: "127.0.0.1",
 		Peer: "127.0.0.2",
 	}
 
-	assert.Equal(t, "127.0.0.1", spanHost(&sp))
-	assert.Equal(t, "127.0.0.2", spanPeer(&sp))
+	assert.Equal(t, "127.0.0.1", SpanHost(&sp))
+	assert.Equal(t, "127.0.0.2", SpanPeer(&sp))
 
 	sp = request.Span{}
 
-	assert.Equal(t, "", spanHost(&sp))
-	assert.Equal(t, "", spanPeer(&sp))
+	assert.Equal(t, "", SpanHost(&sp))
+	assert.Equal(t, "", SpanPeer(&sp))
 }
 
 type fakeInternalTraces struct {

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -481,7 +481,7 @@ func (r *metricsReporter) labelValuesGRPC(span *request.Span) []string {
 	// serviceNameKey, rpcMethodKey, rpcSystemGRPC, rpcGRPCStatusCodeKey
 	values := []string{span.ServiceID.Instance, span.ServiceID.Name, span.ServiceID.Namespace, span.Path, "grpc", strconv.Itoa(span.Status)}
 	if r.cfg.ReportPeerInfo {
-		values = append(values, span.Peer) // netSockPeerAddrKey
+		values = append(values, otel.SpanPeer(span)) // netSockPeerAddrKey
 	}
 	if r.ctxInfo.K8sEnabled {
 		values = appendK8sLabelValues(values, span)
@@ -512,7 +512,7 @@ func (r *metricsReporter) labelValuesHTTPClient(span *request.Span) []string {
 	values := []string{span.ServiceID.Instance, span.ServiceID.Name, span.ServiceID.Namespace, span.Method, strconv.Itoa(span.Status)}
 	if r.cfg.ReportPeerInfo {
 		// netSockPeerAddrKey, netSockPeerPortKey
-		values = append(values, span.Host, strconv.Itoa(span.HostPort))
+		values = append(values, otel.SpanHost(span), strconv.Itoa(span.HostPort))
 	}
 	if r.ctxInfo.K8sEnabled {
 		values = appendK8sLabelValues(values, span)
@@ -551,7 +551,7 @@ func (r *metricsReporter) labelValuesHTTP(span *request.Span) []string {
 		values = append(values, span.Path) // httpTargetKey
 	}
 	if r.cfg.ReportPeerInfo {
-		values = append(values, span.Peer) // netSockPeerAddrKey
+		values = append(values, otel.SpanPeer(span)) // netSockPeerAddrKey
 	}
 	if r.ctxInfo.AppO11y.ReportRoutes {
 		values = append(values, span.Route) // httpRouteKey
@@ -648,18 +648,18 @@ func labelNamesServiceGraph() []string {
 func (r *metricsReporter) labelValuesServiceGraph(span *request.Span) []string {
 	if span.IsClientSpan() {
 		return []string{
-			span.PeerName,
+			otel.SpanPeer(span),
 			span.ServiceID.Namespace,
-			span.HostName,
+			otel.SpanHost(span),
 			span.OtherNamespace,
 			"virtual_node",
 			"beyla",
 		}
 	}
 	return []string{
-		span.PeerName,
+		otel.SpanPeer(span),
 		span.OtherNamespace,
-		span.HostName,
+		otel.SpanHost(span),
 		span.ServiceID.Namespace,
 		"virtual_node",
 		"beyla",

--- a/test/integration/http2go_test.go
+++ b/test/integration/http2go_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"path"
 	"testing"
@@ -39,7 +38,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 		assert.LessOrEqual(t, 1, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -60,7 +59,7 @@ func testREDMetricsForHTTP2Library(t *testing.T, route, svcNs string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"strconv"
 	"testing"
 	"time"
@@ -173,7 +172,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -194,7 +193,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -323,7 +322,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	require.NoError(t, err)
 	assert.Less(t, sum, 1.0)
 	assert.Greater(t, sum, (90 * time.Millisecond).Seconds())
-	addr := net.ParseIP(res.Metric["client_address"])
+	addr := res.Metric["client_address"]
 	assert.NotNil(t, addr)
 
 	// check request_size_sum is at least 114B (3 * 38B)
@@ -341,7 +340,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	sum, err = strconv.ParseFloat(fmt.Sprint(res.Value[1]), 64)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, sum, 114.0)
-	addr = net.ParseIP(res.Metric["client_address"])
+	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
 
 	// Check that we never recorded metrics for /metrics, in the basic test only traces are ignored
@@ -377,7 +376,7 @@ func testREDMetricsGRPC(t *testing.T) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -415,7 +414,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -436,7 +435,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -563,7 +562,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	require.NoError(t, err)
 	assert.Less(t, sum, 1.0)
 	assert.Greater(t, sum, (90 * time.Millisecond).Seconds())
-	addr := net.ParseIP(res.Metric["client_address"])
+	addr := res.Metric["client_address"]
 	assert.NotNil(t, addr)
 
 	// check request_size_sum is at least 114B (3 * 38B)
@@ -581,7 +580,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	sum, err = strconv.ParseFloat(fmt.Sprint(res.Value[1]), 64)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, sum, 114.0)
-	addr = net.ParseIP(res.Metric["client_address"])
+	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
 
 	// Check that we never recorded any /metrics calls
@@ -648,7 +647,7 @@ func testREDMetricsForGoBasicOnly(t *testing.T, url string, comm string) {
 			assert.LessOrEqual(t, 3, val)
 
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"net"
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -40,7 +39,7 @@ func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_java.go
+++ b/test/integration/red_test_java.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"net"
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -57,7 +56,7 @@ func testREDMetricsForJavaHTTPLibrary(t *testing.T, urls []string, comm string) 
 			assert.LessOrEqual(t, 3, val)
 
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -58,7 +58,19 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		var tq jaeger.TracesQuery
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
-		traces := tq.FindBySpan(jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(statusCode)})
+		tracesAll := tq.FindBySpan(jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(statusCode)})
+
+		var traces []jaeger.Trace
+
+		// Sometimes we can instrument between the connect and the data being sent
+		// In that case we won't have enough info and we won't look in the parsed
+		// traceID. We filter for that.
+		for _, t := range tracesAll {
+			if strings.HasPrefix(t.TraceID, "0000") {
+				traces = append(traces, t)
+			}
+		}
+
 		require.GreaterOrEqual(t, len(traces), 1)
 		trace = traces[0]
 	}, test.Interval(100*time.Millisecond))

--- a/test/integration/red_test_nodejs.go
+++ b/test/integration/red_test_nodejs.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"net"
 	"os"
 	"path"
 	"testing"
@@ -44,7 +43,7 @@ func testREDMetricsForNodeHTTPLibrary(t *testing.T, url, urlPath, comm, namespac
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -90,7 +89,7 @@ func checkReportedNodeJSEvents(t *testing.T, urlPath, comm, namespace string, nu
 		assert.LessOrEqual(t, val, numEvents)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_python.go
+++ b/test/integration/red_test_python.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"net"
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -40,7 +39,7 @@ func testREDMetricsForPythonHTTPLibrary(t *testing.T, url, comm, namespace strin
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -88,7 +87,7 @@ func checkReportedPythonEvents(t *testing.T, comm, namespace string, numEvents i
 		assert.LessOrEqual(t, val, numEvents)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_ruby.go
+++ b/test/integration/red_test_ruby.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"net"
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -44,7 +43,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 		assert.LessOrEqual(t, 1, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -72,7 +71,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"os"
 	"path"
@@ -50,7 +49,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -137,7 +136,7 @@ func validateLargeDownloadURLSeen(t *testing.T, comm, namespace, urlPath string)
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 			assert.GreaterOrEqual(t, len(res.Value), 1)
 			elapsed := res.Value[0]
@@ -211,7 +210,7 @@ func checkReportedRustEvents(t *testing.T, comm, namespace string, numEvents int
 		assert.LessOrEqual(t, val, numEvents)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})
@@ -248,7 +247,7 @@ func testREDMetricsForRustHTTP2Library(t *testing.T, url, comm, namespace string
 		assert.LessOrEqual(t, 3, val)
 		if len(results) > 0 {
 			res := results[0]
-			addr := net.ParseIP(res.Metric["client_address"])
+			addr := res.Metric["client_address"]
 			assert.NotNil(t, addr)
 		}
 	})


### PR DESCRIPTION
I changed traces to prefer the hostname over the ip address, but we have configuration options to include the peer in metrics too. I made everything consistent with this change.