### PR TITLE
Add .total suffix to network flow bytes metric in OTEL

### DIFF
--- a/pkg/internal/netolly/export/otel/metrics.go
+++ b/pkg/internal/netolly/export/otel/metrics.go
@@ -84,7 +84,7 @@ func MetricsExporterProvider(cfg *MetricsConfig) (pipe.FinalFunc[[]*ebpf.Record]
 	ebpfEvents := provider.Meter("network_ebpf_events")
 
 	_, err = ebpfEvents.Int64ObservableCounter(
-		"beyla.network.flow.bytes",
+		"beyla.network.flow.bytes.total",
 		metric2.WithDescription("total bytes_sent value of network flows observed by probe since its launch"),
 		metric2.WithUnit("{bytes}"),
 		metric2.WithInt64Callback(expirer.Collect),


### PR DESCRIPTION
When network metrics are sent via Prometheus or via an intermadiate OTEL collector, the metrics are queryable as `beyla_network_flow_metrics_total` in Grafana.

When we use the OTEL endpoint in Grafana Cloud, metrics are visible as `beyla_network_flow_metrics`, without the `_total`.

This PR adds explicitly the `.total` suffix to the OTEL exporter.

Unchanged integration tests verify that, when an OTEL collector is used, it won't duplicate the `_total_total` suffix.