### PR TITLE
Fix format check of old_grpc component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ DASHBOARD_LINTER = $(TOOLS_DIR)/dashboard-linter
 GINKGO = $(TOOLS_DIR)/ginkgo
 
 define check_format
-	$(shell $(foreach FILE, $(shell find . -name "*.go" -not -path "./vendor/*"), \
+	$(shell $(foreach FILE, $(shell find . -name "*.go" -not -path "**/vendor/*"), \
 		$(GOIMPORTS_REVISER) -company-prefixes github.com/grafana -list-diff -output stdout $(FILE);))
 endef
 
@@ -102,7 +102,7 @@ prereqs:
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,v1.57.2)
 	$(call go-install-tool,$(BPF2GO),github.com/cilium/ebpf/cmd/bpf2go,$(call gomod-version,cilium/ebpf))
 	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker,$(call gomod-version,grafana/go-offsets-tracker))
-	$(call go-install-tool,$(GOIMPORTS_REVISER),github.com/incu6us/goimports-reviser/v3,v3.4.5)
+	$(call go-install-tool,$(GOIMPORTS_REVISER),github.com/incu6us/goimports-reviser/v3,v3.6.4)
 	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses,v1.6.0)
 	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,v0.20.0)
 	$(call go-install-tool,$(DASHBOARD_LINTER),github.com/grafana/dashboard-linter,latest)
@@ -110,7 +110,7 @@ prereqs:
 .PHONY: fmt
 fmt: prereqs
 	@echo "### Formatting code and fixing imports"
-	@$(foreach FILE, $(shell find . -name "*.go" -not -path "./vendor/*"), \
+	@$(foreach FILE, $(shell find . -name "*.go" -not -path "**/vendor/*"), \
 		$(GOIMPORTS_REVISER) -company-prefixes github.com/grafana $(FILE);)
 
 .PHONY: checkfmt

--- a/test/integration/components/old_grpc/backend/cmd/backend/main.go
+++ b/test/integration/components/old_grpc/backend/cmd/backend/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v7"
+
 	"github.com/mariomac/distributed-service-example/backend/pkg/rest"
 )
 

--- a/test/integration/components/old_grpc/backend/pkg/rest/rest.go
+++ b/test/integration/components/old_grpc/backend/pkg/rest/rest.go
@@ -8,10 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/mariomac/distributed-service-example/worker/pkg/gprc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (

--- a/test/integration/components/old_grpc/worker/cmd/worker/main.go
+++ b/test/integration/components/old_grpc/worker/cmd/worker/main.go
@@ -5,9 +5,10 @@ import (
 	"net"
 
 	"github.com/caarlos0/env/v7"
+	"google.golang.org/grpc"
+
 	"github.com/mariomac/distributed-service-example/worker/pkg/gprc"
 	"github.com/mariomac/distributed-service-example/worker/pkg/server"
-	"google.golang.org/grpc"
 )
 
 type Config struct {


### PR DESCRIPTION
* Updated goimports-reviser
* Excluded vendored dependencies of inner components
* Reformatted code