### PR TITLE
Refactor metric attribute getters

### DIFF
--- a/pkg/internal/export/attr/attr.go
+++ b/pkg/internal/export/attr/attr.go
@@ -65,9 +65,11 @@ func normalizeToUnderscore(name string) string {
 // or underscore notation from the user
 func normalizeToDot(name string) string {
 	name = strings.ReplaceAll(name, "_", ".")
+	// TODO: add future edge cases here
+	// nolint:gocritic
 	switch name {
 	case "http.response.status.code":
-		name = "http_response_status_code"
+		name = "http.response.status_code"
 	}
 	return name
 }

--- a/pkg/internal/export/attr/attr.go
+++ b/pkg/internal/export/attr/attr.go
@@ -1,0 +1,73 @@
+package attr
+
+import (
+	"strings"
+)
+
+// GetFunc is a function that explains how to get a given metric attribute from a data record
+// of the generic type T (e.g. *ebpf.Record or *request.Span)
+type GetFunc[T any] func(T) string
+
+// Getter stores how to expose a metric attribute: its exposed name and how to
+// get its value from the data record of type T
+type Getter[T any] struct {
+	// ExposedName of a metric will vary between OTEL and Prometheus: dot.notation or underscore_notation.
+	ExposedName string
+	Get         GetFunc[T]
+}
+
+// NamedGetters returns the GetFunc for an attribute, given its internal name in dot.notation.
+type NamedGetters[T any] func(internalName string) GetFunc[T]
+
+// PrometheusGetters builds a list of GetFunc getters for the names provided by the
+// user configuration, ready to be passed to a Prometheus exporter.
+// It differentiates two name formats: the exposed name for the attribute (uses _ for word separation, as
+// required by Prometheus); and the internal name of the attribute (uses . for word separation, as internally Beyla
+// stores the metadata).
+// Whatever is the format provided by the user (dot-based or underscore-based), it converts dots to underscores
+// and vice-versa to make sure that the correct format is used either internally or externally.
+func PrometheusGetters[T any](getter NamedGetters[T], names []string) []Getter[T] {
+	attrs := make([]Getter[T], 0, len(names))
+	for _, name := range names {
+		exposedName := normalizeToUnderscore(name)
+		internalName := strings.ReplaceAll(name, "_", ".")
+		attrs = append(attrs, Getter[T]{
+			ExposedName: exposedName,
+			Get:         getter(internalName),
+		})
+	}
+	return attrs
+}
+
+// OpenTelemetryGetters builds a list of GetFunc getters for the names provided by the
+// user configuration, ready to be passed to an OpenTelemetry exporter.
+// Whatever is the format of the user-provided attribute names (dot-based or underscore-based),
+// it converts underscores to dots to make sure that the correct attribute name is exposed.
+func OpenTelemetryGetters[T any](getter NamedGetters[T], names []string) []Getter[T] {
+	attrs := make([]Getter[T], 0, len(names))
+	for _, name := range names {
+		dotName := normalizeToDot(name)
+		attrs = append(attrs, Getter[T]{
+			ExposedName: dotName,
+			Get:         getter(dotName),
+		})
+	}
+	return attrs
+}
+
+func normalizeToUnderscore(name string) string {
+	return strings.ReplaceAll(name, ".", "_")
+}
+
+// normalizeToDot will have into account that some dot metrics still have underscores,
+// such as: http.response.status_code
+// The name is provided by the user, so this function will handle mistakes in the dot
+// or underscore notation from the user
+func normalizeToDot(name string) string {
+	name = strings.ReplaceAll(name, "_", ".")
+	switch name {
+	case "http.response.status.code":
+		name = "http_response_status_code"
+	}
+	return name
+}

--- a/pkg/internal/netolly/export/attributes.go
+++ b/pkg/internal/netolly/export/attributes.go
@@ -2,51 +2,14 @@ package export
 
 import (
 	"strconv"
-	"strings"
 
+	"github.com/grafana/beyla/pkg/internal/export/attr"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow/transport"
 )
 
-// Attribute stores how to expose a metric attribute: its exposed name and how to
-// get its value from the ebpf.Record.
-type Attribute struct {
-	Name string
-	Get  func(r *ebpf.Record) string
-}
-
-// BuildPromAttributeGetters builds a list of Attribute getters for the names provided by the
-// user configuration, ready to be passed to a Prometheus exporter.
-// It differentiates two name formats: the exposed name for the attribute (uses _ for word separation, as
-// required by Prometheus); and the internal name of the attribute (uses . for word separation, as internally Beyla
-// stores the metadata).
-// Whatever is the format provided by the user (dot-based or underscore-based), it converts dots to underscores
-// and vice-versa to make sure that the correct format is used either internally or externally.
-func BuildPromAttributeGetters(names []string) []Attribute {
-	attrs := make([]Attribute, 0, len(names))
-	for _, name := range names {
-		exposedName := strings.ReplaceAll(name, ".", "_")
-		internalName := strings.ReplaceAll(name, "_", ".")
-		attrs = append(attrs, attributeFor(exposedName, internalName))
-	}
-	return attrs
-}
-
-// BuildOTELAttributeGetters builds a list of Attribute getters for the names provided by the
-// user configuration, ready to be passed to an OpenTelemetry exporter.
-// Whatever is the format of the user-provided attribute names (dot-based or underscore-based),
-// it converts underscores to dots to make sure that the correct attribute name is exposed.
-func BuildOTELAttributeGetters(names []string) []Attribute {
-	attrs := make([]Attribute, 0, len(names))
-	for _, name := range names {
-		dotName := strings.ReplaceAll(name, "_", ".")
-		attrs = append(attrs, attributeFor(dotName, dotName))
-	}
-	return attrs
-}
-
-func attributeFor(exposedName, internalName string) Attribute {
-	var getter func(r *ebpf.Record) string
+func NamedGetters(internalName string) attr.GetFunc[*ebpf.Record] {
+	var getter attr.GetFunc[*ebpf.Record]
 	switch internalName {
 	case "beyla.ip":
 		getter = func(r *ebpf.Record) string { return r.Attrs.BeylaIP }
@@ -71,7 +34,7 @@ func attributeFor(exposedName, internalName string) Attribute {
 	default:
 		getter = func(r *ebpf.Record) string { return r.Attrs.Metadata[internalName] }
 	}
-	return Attribute{Name: exposedName, Get: getter}
+	return getter
 }
 
 func directionStr(direction uint8) string {

--- a/pkg/internal/netolly/export/otel/expirer.go
+++ b/pkg/internal/netolly/export/otel/expirer.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/grafana/beyla/pkg/internal/export/attr"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/export"
 )
@@ -22,7 +23,7 @@ func plog() *slog.Logger {
 // Expirer drops metrics from labels that haven't been updated during a given timeout
 // TODO: generify and move to a common section for using it also in AppO11y, supporting more OTEL metrics
 type Expirer struct {
-	attrs   []export.Attribute
+	attrs   []attr.Getter[*ebpf.Record]
 	entries *export.ExpiryMap[*Counter]
 }
 
@@ -33,7 +34,7 @@ type Counter struct {
 
 // NewExpirer creates a metric that wraps a Counter. Its labeled instances are dropped
 // if they haven't been updated during the last timeout period
-func NewExpirer(attrs []export.Attribute, expireTime time.Duration) *Expirer {
+func NewExpirer(attrs []attr.Getter[*ebpf.Record], expireTime time.Duration) *Expirer {
 	return &Expirer{
 		attrs:   attrs,
 		entries: export.NewExpiryMap[*Counter](expireTime, export.WithClock[*Counter](timeNow)),
@@ -79,7 +80,7 @@ func (ex *Expirer) recordAttributes(m *ebpf.Record) (attribute.Set, []string) {
 
 	for _, attr := range ex.attrs {
 		val := attr.Get(m)
-		keyVals = append(keyVals, attribute.String(attr.Name, val))
+		keyVals = append(keyVals, attribute.String(attr.ExposedName, val))
 		vals = append(vals, val)
 	}
 

--- a/pkg/internal/netolly/export/otel/metrics.go
+++ b/pkg/internal/netolly/export/otel/metrics.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
+	"github.com/grafana/beyla/pkg/internal/export/attr"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/export"
@@ -80,7 +81,7 @@ func MetricsExporterProvider(cfg *MetricsConfig) (pipe.FinalFunc[[]*ebpf.Record]
 		return nil, err
 	}
 
-	expirer := NewExpirer(export.BuildOTELAttributeGetters(cfg.AllowedAttributes), cfg.Metrics.TTL)
+	expirer := NewExpirer(attr.OpenTelemetryGetters(export.NamedGetters, cfg.AllowedAttributes), cfg.Metrics.TTL)
 	ebpfEvents := provider.Meter("network_ebpf_events")
 
 	_, err = ebpfEvents.Int64ObservableCounter(

--- a/pkg/internal/netolly/export/otel/metrics_test.go
+++ b/pkg/internal/netolly/export/otel/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/grafana/beyla/pkg/internal/export/attr"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/export"
@@ -34,10 +35,11 @@ func TestMetricAttributes(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me := &metricsExporter{metrics: &Expirer{attrs: export.BuildOTELAttributeGetters([]string{
-		"src.address", "dst.address", "src.port", "dst.port", "src.name", "dst_name",
-		"k8s.src.name", "k8s.src_namespace", "k8s.dst.name", "k8s.dst.namespace",
-	})}}
+	me := &metricsExporter{metrics: &Expirer{attrs: attr.OpenTelemetryGetters(
+		export.NamedGetters, []string{
+			"src.address", "dst.address", "src.port", "dst.port", "src.name", "dst_name",
+			"k8s.src.name", "k8s.src_namespace", "k8s.dst.name", "k8s.dst.namespace",
+		})}}
 	reportedAttributes, _ := me.metrics.recordAttributes(in)
 	for _, mustContain := range []attribute.KeyValue{
 		attribute.String("src.address", "12.34.56.78"),
@@ -82,7 +84,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me := &Expirer{attrs: export.BuildOTELAttributeGetters([]string{
+	me := &Expirer{attrs: attr.OpenTelemetryGetters(export.NamedGetters, []string{
 		"src.address",
 		"k8s.src.name",
 		"k8s.dst.name",

--- a/pkg/internal/netolly/export/prom/prom.go
+++ b/pkg/internal/netolly/export/prom/prom.go
@@ -95,4 +95,3 @@ func (r *metricsReporter) observe(flow *ebpf.Record) {
 	}
 	r.flowBytes.WithLabelValues(labelValues...).Add(float64(flow.Metrics.Bytes))
 }
-

--- a/pkg/internal/netolly/export/prom/prom.go
+++ b/pkg/internal/netolly/export/prom/prom.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/beyla/pkg/internal/connector"
+	"github.com/grafana/beyla/pkg/internal/export/attr"
 	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/export/prom"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
@@ -38,7 +39,7 @@ type metricsReporter struct {
 
 	promConnect *connector.PrometheusManager
 
-	attrs []export.Attribute
+	attrs []attr.Getter[*ebpf.Record]
 
 	bgCtx context.Context
 }
@@ -53,10 +54,10 @@ func PrometheusEndpoint(ctx context.Context, cfg *PrometheusConfig, promMgr *con
 }
 
 func newReporter(ctx context.Context, cfg *PrometheusConfig, promMgr *connector.PrometheusManager) *metricsReporter {
-	attrs := export.BuildPromAttributeGetters(cfg.AllowedAttributes)
+	attrs := attr.PrometheusGetters(export.NamedGetters, cfg.AllowedAttributes)
 	labelNames := make([]string, 0, len(attrs))
 	for _, label := range attrs {
-		labelNames = append(labelNames, label.Name)
+		labelNames = append(labelNames, label.ExposedName)
 	}
 
 	// If service name is not explicitly set, we take the service name as set by the
@@ -94,3 +95,4 @@ func (r *metricsReporter) observe(flow *ebpf.Record) {
 	}
 	r.flowBytes.WithLabelValues(labelValues...).Add(float64(flow.Metrics.Bytes))
 }
+


### PR DESCRIPTION
In preparation for porting the attribute grouping and metric expiration feature to App O11y, I have refactored some Network-metrics code to generify it and allow its later invocation from network metrics.