### PR TITLE
Add extra k8s docs explanations

### DIFF
--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -183,7 +183,7 @@ spec:
               value: "true"
 ```
 
-For more information about the different configuration options, please check the
+For more information about the different configuration options, check the
 [Configuration]({{< relref "../configure/options.md" >}}) section of this documentation site.
 
 ### Deploy Beyla as a Daemonset
@@ -192,7 +192,7 @@ You can also deploy Beyla as a Daemonset. This is the preferred way if:
 
 - You want to instrument a Daemonset
 - You want to instrument multiple processes from a single Beyla instance, or even
-  all the instrumentable processes in your cluster.
+  all of the processes in your cluster.
 
 Using the previous example (the `goblog` pod), we cannot select the process
 to instrument by using its open port, because the port is internal to the Pod.

--- a/examples/k8s/unprivileged.yaml
+++ b/examples/k8s/unprivileged.yaml
@@ -159,6 +159,8 @@ spec:
               - CHECKPOINT_RESTORE  # <-- Important. Allows Beyla to open ELF files.
               - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
               - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
+              #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
+              #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
             drop:
               - ALL
         volumeMounts:


### PR DESCRIPTION
I discovered that Debian based systems can have higher than 2 setting for `kernel.perf_event_paranoid`, which disallows us to use CAP_PERFMON and require that CAP_SYS_ADMIN is set on the Beyla container instance. This PR documents this potential issue.