### PR TITLE
helm-release.yml: disable chart changes verification

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -26,44 +26,9 @@ jobs:
       - name: Install chart-testing
         uses: helm/chart-testing-action@v2
 
-      - name: List changed charts
-        id: list-changed
-        run: |
-          cd source
-          
-          latest_tag=$( if ! git describe --tags --abbrev=0 --match='helm-chart/*' 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD; fi )
-          
-          echo "Running: ct list-changed --config ${CT_CONFIGFILE} --since ${latest_tag} --target-branch ${{ github.ref_name }}"
-          changed=$(ct list-changed --config "${CT_CONFIGFILE}" --since "${latest_tag}" --target-branch "${{ github.ref_name }}")
-          echo "${changed}"
-          
-          num_changed=$(wc -l <<< ${changed})
-          if [[ "${num_changed}" -gt "1" ]] ; then
-            echo "More than one chart changed, exiting"
-            exit 1
-          fi
-          if [[ -n "${changed}" ]]; then
-            name=$(yq ".name" < ${changed}/Chart.yaml)
-            version=$(yq ".version" < ${changed}/Chart.yaml)
-            tagname="v${version}"
-          
-            if [ $(git tag -l "${tagname}") ]; then
-              echo "Tag ${tagname} already exists, skipping release"
-              echo "changed=false" >> $GITHUB_OUTPUT
-            else
-              echo "Releasing ${changed}"
-              echo "changed=true" >> $GITHUB_OUTPUT
-              echo "chartpath=${changed}" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No charts have changed, skipping release"
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
   release:
     needs: [setup]
     runs-on: ubuntu-latest
-    if: needs.setup.outputs.changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The current scripts rely on Git tags, and it was taken from a repository that was dedicated exclusively to a helm chart. This won't work on this directory because it checks that tag v1.0.0 does not exist before releasing.

Since this is a manual action, I'm just disabling this check and let automatize/improve it for the future.