### PR TITLE
helm-test.yml: disable super-linter

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,17 +39,6 @@ jobs:
             exit 1
           fi
 
-      - name: Lint Code Base with super-linter
-        uses: docker://github/super-linter:v3.12.0
-        env:
-          FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt).*
-          FILTER_REGEX_INCLUDE: ${{ inputs.filter_regex_include }}
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_KUBERNETES_KUBEVAL: false
-          VALIDATE_YAML: false
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Linting with chart-testing
         uses: helm/chart-testing-action@v2.1.0
 


### PR DESCRIPTION
I copied this script from another repo, thinking that it would lint the helm charts, but super-linter actually lints everything but helm. It makes the task to fail while linting the go files.