### PR TITLE
Fix indent for imagePullSecrets

### DIFF
--- a/charts/beyla/templates/daemon-set.yml
+++ b/charts/beyla/templates/daemon-set.yml
@@ -71,9 +71,9 @@ spec:
       {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.global.image.pullSecrets }}
-        {{- toYaml .Values.global.image.pullSecrets | nindent 4 }}
+        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
         {{- else }}
-        {{- toYaml .Values.image.pullSecrets | nindent 4 }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Getting the following error when `image.pullSecrets` is set:
```
Error: YAML parse error on beyla/templates/daemon-set.yml: error converting YAML to JSON: yaml: line 45: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 45: did not find expected key
YAML parse error on beyla/templates/daemon-set.yml
```
This change fixes the indent for `imagePullSecrets` in daemon-set.yaml.
