### PR TITLE
Tweak generator image

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -51,16 +51,8 @@ local buildx(stepName, app, auto_tag, tags) = {
   },
 };
 
-local make(target) = {
-  name: 'beyla-make-%s' % target,
-  image: 'ubuntu:latest',
-  commands: [ 'make %s' % target ],
-};
-
 local beyla() = pipeline('beyla') {
   steps+: [
-    make('check-ebpf-integrity'),
-  ] + [
     buildx('dryrun', 'beyla-dryrun', false, 'test') {
       when: onPRs,  // TODO: if container creation fails, make the PR fail
       settings+: {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -2,10 +2,6 @@
 kind: pipeline
 name: beyla
 steps:
-- commands:
-  - make check-ebpf-integrity
-  image: ubuntu:latest
-  name: beyla-make-check-ebpf-integrity
 - image: thegeeklab/drone-docker-buildx:24
   name: beyla-dryrun-docker-buildx
   privileged: true
@@ -108,6 +104,6 @@ kind: secret
 name: docker_password
 ---
 kind: signature
-hmac: dff177ef0acc6bc1fe18399a976da5332de3d7b844e968cdf6b45a5222baff77
+hmac: 80d28c3b23c53bdd6b5c90e2881d39901c0b01d4cdcc435de61d34112a267965
 
 ...

--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -45,4 +45,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.timestamp.outputs.ts }}"
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"

--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -30,10 +30,10 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          tags: |
-            type=schedule,pattern={{date 'YYYYMMDD-hhmm'}}
-            type=ref,event=branch
 
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "::set-output name=ts::$(date +'%Y%m%d%H%M')"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v5.3.0
@@ -41,5 +41,8 @@ jobs:
           context: .
           file: ./generator.Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.timestamp.outputs.ts }}"
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMG = $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/grafana/beyla-generator:latest
+GEN_IMG ?= ghcr.io/grafana/beyla-generator:main
 
 COMPOSE_ARGS ?= -f test/integration/docker-compose.yml
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMG = $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/grafana/beyla-generator:main
+GEN_IMG ?= ghcr.io/grafana/beyla-generator:latest
 
 COMPOSE_ARGS ?= -f test/integration/docker-compose.yml
 


### PR DESCRIPTION
* Reverted drone check because it seems that currently the ebpf check task is not consistent across different hosts, and the image push was being blocked.
* Uploading generator image also for arm64 arch.
* Keeping a timestamped version of the images in case we need to deal with multiple versions in different branches.