### PR TITLE
feat helm: optionally create ServiceMonitor resource 

### DIFF
--- a/charts/beyla/templates/servicemonitor.yaml
+++ b/charts/beyla/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.service.enabled .Values.serviceMonitor.enabled .Values.config.data.prometheus_export }}
+{{- $root := . }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "beyla.fullname" . }}
+  namespace: {{ include "beyla.namespace" .}}
+  labels:
+    {{- include "beyla.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $root }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: {{ .Values.service.portName }}
+      path: {{ .Values.config.data.prometheus_export.path }}
+      scheme: http 
+      {{- with .Values.serviceMonitor.endpoint }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | default (include "beyla.fullname" .) }}
+  selector:
+    matchLabels:
+      {{- include "beyla.labels" . | nindent 6 }}
+      {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -203,3 +203,17 @@ envValueFrom: {}
 # -- Preconfigures some default properties for network or application observability.
 # Accepted values are "network" or "application".
 preset: application
+
+# -- Enable creation of ServiceMonitor for scraping of prometheus HTTP endpoint
+serviceMonitor:
+  enabled: false
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scraping endpoint
+  # Target port and path is set based on service and prometheus_export values
+  # For additional values, see the ServiceMonitor spec
+  endpoint:
+    interval: 15s
+  # -- Prometheus job label
+  # If empty, chart release name is used
+  jobLabel: ""


### PR DESCRIPTION
Enables the optional creation of a ServiceMonitor resource to scrape the service resource exposing the Prometheus HTTP endpoint. Follows issue #829 

The ServiceMonitor endpoint spec leverages existing values used in service and config.data.prometheus_endpoint.

The generated manifest, when setting `service.enabled: true` and `serviceMonitor.enabled: true` with dummy values for a release name and namespace: 
```yaml
# Source: beyla/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: beyla-test
  namespace: beyla
  labels:
    helm.sh/chart: beyla-1.0.0
    app.kubernetes.io/name: beyla
    app.kubernetes.io/instance: beyla-test
    app.kubernetes.io/version: "1.5.2"
    app.kubernetes.io/managed-by: Helm
spec:
  endpoints:
    - port: metrics
      path: /metrics
      scheme: http
      interval: 15s
  jobLabel: beyla-test
  selector:
    matchLabels:
      helm.sh/chart: beyla-1.0.0
      app.kubernetes.io/name: beyla
      app.kubernetes.io/instance: beyla-test
      app.kubernetes.io/version: "1.5.2"
      app.kubernetes.io/managed-by: Helm
```