### PR TITLE
Split integration tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,8 @@ jobs:
         run: make verify cov-exclude-generated
       - name: Report coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/cover.txt
           flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -36,7 +36,8 @@ jobs:
             testoutput/kind
       - name: Report coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/itest-covdata.txt
           flags: integration-test
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -1,0 +1,42 @@
+name: Pull request K8s integration tests
+
+on:
+  push:
+    branches: [ 'main', 'release-*' ]
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.22' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Clean up disk space
+        run: |
+          docker system prune -af
+          docker volume prune -f
+      - name: Run integration tests
+        run: make integration-test-k8s
+        timeout-minutes: 60
+      - name: Upload integration test logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test Logs
+          path: |
+            testoutput/*.log
+            testoutput/kind
+      - name: Report coverage
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./testoutput/itest-covdata.txt
+          flags: k8s-integration-test
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: Test Logs
+          name: K8s test Logs
           path: |
             testoutput/*.log
             testoutput/kind

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -36,7 +36,8 @@ jobs:
             testoutput/kind
       - name: Report coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/itest-covdata.txt
           flags: k8s-integration-test
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -33,7 +33,8 @@ jobs:
           path: test/oats/*/build/*
       - name: Report coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/itest-covdata.txt
           flags: oats-test
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ integration-test: prereqs prepare-integration-test
 	$(MAKE) cleanup-integration-test
 
 .PHONY: integration-test-k8s
-integration-test: prereqs prepare-integration-test
+integration-test-k8s: prereqs prepare-integration-test
 	$(MAKE) run-integration-test-k8s || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
 	$(MAKE) itest-coverage-data
 	$(MAKE) cleanup-integration-test

--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,21 @@ run-integration-test:
 	go clean -testcache
 	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration
 
+.PHONY: run-integration-test-k8s
+run-integration-test-k8s:
+	@echo "### Running integration tests"
+	go clean -testcache
+	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration_k8s
+
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test
 	$(MAKE) run-integration-test || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
+	$(MAKE) itest-coverage-data
+	$(MAKE) cleanup-integration-test
+
+.PHONY: integration-test-k8s
+integration-test: prereqs prepare-integration-test
+	$(MAKE) run-integration-test-k8s || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
 	$(MAKE) itest-coverage-data
 	$(MAKE) cleanup-integration-test
 

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package k8s
 

--- a/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package promtest
 

--- a/test/integration/k8s/netolly_sk_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_sk_promexport/k8s_netolly_prom_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package promtestsk
 

--- a/test/integration/k8s/otel/k8s_main_test.go
+++ b/test/integration/k8s/otel/k8s_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/otel/k8s_otel_metrics_test.go
+++ b/test/integration/k8s/otel/k8s_otel_metrics_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/otel/k8s_otel_traces_test.go
+++ b/test/integration/k8s/otel/k8s_otel_traces_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package otel
 

--- a/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package owners
 

--- a/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 // package owners tests the selection and detection of pod ownership metadata, others than deployment:
 // StatefulSet and DaemonSet

--- a/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package owners
 

--- a/test/integration/k8s/prom/k8s_prom_main_test.go
+++ b/test/integration/k8s/prom/k8s_prom_main_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package prom
 

--- a/test/integration/k8s/prom/k8s_prom_test.go
+++ b/test/integration/k8s/prom/k8s_prom_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration_k8s
 
 package prom
 


### PR DESCRIPTION
In order to shorten PR integration testing in GitHub. Splits Docker and K8s integration tests in different GitHub actions.