### PR TITLE
Remove check-ebpf-integrity from release_binaries task

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,8 +18,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - name: Check eBPF integrity
-        run: make check-ebpf-integrity
       - name: Build Go release for linux/${{ matrix.arch }}
         run: make artifact
         env:


### PR DESCRIPTION
The github action is disabled but we forgot this on. This is preventing Beyla binaries from being released.