### PR TITLE
Prometheus process metrics exporter

### DIFF
--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -138,7 +138,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 	)
 	if _, err := meter.Float64ObservableGauge(
 		attributes.ProcessCPUUtilization.OTEL,
-		metric2.WithDescription("TODO"),
+		metric2.WithDescription("Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process"),
 		metric2.WithUnit("1"),
 		metric2.WithFloat64Callback(m.cpuTime.Collect),
 	); err != nil {

--- a/pkg/internal/export/prom/expirer.go
+++ b/pkg/internal/export/prom/expirer.go
@@ -1,10 +1,12 @@
-package expire
+package prom
 
 import (
 	"log/slog"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/beyla/pkg/internal/export/expire"
 )
 
 func plog() *slog.Logger {
@@ -13,7 +15,7 @@ func plog() *slog.Logger {
 
 // Expirer drops metrics from labels that haven't been updated during a given timeout
 type Expirer[T prometheus.Metric] struct {
-	entries *ExpiryMap[T]
+	entries *expire.ExpiryMap[T]
 	wrapped *prometheus.MetricVec
 }
 
@@ -22,7 +24,7 @@ type Expirer[T prometheus.Metric] struct {
 func NewExpirer[T prometheus.Metric](wrapped *prometheus.MetricVec, clock func() time.Time, expireTime time.Duration) *Expirer[T] {
 	return &Expirer[T]{
 		wrapped: wrapped,
-		entries: NewExpiryMap[T](clock, expireTime),
+		entries: expire.NewExpiryMap[T](clock, expireTime),
 	}
 }
 

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -136,16 +136,16 @@ func (p PrometheusConfig) Enabled() bool {
 type metricsReporter struct {
 	cfg *PrometheusConfig
 
-	beylaInfo             *expire.Expirer[prometheus.Gauge]
-	httpDuration          *expire.Expirer[prometheus.Histogram]
-	httpClientDuration    *expire.Expirer[prometheus.Histogram]
-	grpcDuration          *expire.Expirer[prometheus.Histogram]
-	grpcClientDuration    *expire.Expirer[prometheus.Histogram]
-	dbClientDuration      *expire.Expirer[prometheus.Histogram]
-	msgPublishDuration    *expire.Expirer[prometheus.Histogram]
-	msgProcessDuration    *expire.Expirer[prometheus.Histogram]
-	httpRequestSize       *expire.Expirer[prometheus.Histogram]
-	httpClientRequestSize *expire.Expirer[prometheus.Histogram]
+	beylaInfo             *Expirer[prometheus.Gauge]
+	httpDuration          *Expirer[prometheus.Histogram]
+	httpClientDuration    *Expirer[prometheus.Histogram]
+	grpcDuration          *Expirer[prometheus.Histogram]
+	grpcClientDuration    *Expirer[prometheus.Histogram]
+	dbClientDuration      *Expirer[prometheus.Histogram]
+	msgPublishDuration    *Expirer[prometheus.Histogram]
+	msgProcessDuration    *Expirer[prometheus.Histogram]
+	httpRequestSize       *Expirer[prometheus.Histogram]
+	httpClientRequestSize *Expirer[prometheus.Histogram]
 
 	// user-selected attributes for the application-level metrics
 	attrHTTPDuration          []attributes.Field[*request.Span, string]
@@ -159,16 +159,16 @@ type metricsReporter struct {
 	attrHTTPClientRequestSize []attributes.Field[*request.Span, string]
 
 	// trace span metrics
-	spanMetricsLatency    *expire.Expirer[prometheus.Histogram]
-	spanMetricsCallsTotal *expire.Expirer[prometheus.Counter]
-	spanMetricsSizeTotal  *expire.Expirer[prometheus.Counter]
-	tracesTargetInfo      *expire.Expirer[prometheus.Gauge]
+	spanMetricsLatency    *Expirer[prometheus.Histogram]
+	spanMetricsCallsTotal *Expirer[prometheus.Counter]
+	spanMetricsSizeTotal  *Expirer[prometheus.Counter]
+	tracesTargetInfo      *Expirer[prometheus.Gauge]
 
 	// trace service graph
-	serviceGraphClient *expire.Expirer[prometheus.Histogram]
-	serviceGraphServer *expire.Expirer[prometheus.Histogram]
-	serviceGraphFailed *expire.Expirer[prometheus.Counter]
-	serviceGraphTotal  *expire.Expirer[prometheus.Counter]
+	serviceGraphClient *Expirer[prometheus.Histogram]
+	serviceGraphServer *Expirer[prometheus.Histogram]
+	serviceGraphFailed *Expirer[prometheus.Counter]
+	serviceGraphTotal  *Expirer[prometheus.Counter]
 
 	promConnect *connector.PrometheusManager
 
@@ -251,7 +251,7 @@ func newReporter(
 		attrMsgProcessDuration:    attrMessagingProcessDuration,
 		attrHTTPRequestSize:       attrHTTPRequestSize,
 		attrHTTPClientRequestSize: attrHTTPClientRequestSize,
-		beylaInfo: expire.NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		beylaInfo: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: BeylaBuildInfo,
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
 				"goversion from which Beyla was built, the goos and goarch for the build, and the" +
@@ -264,7 +264,7 @@ func newReporter(
 				"revision":  buildinfo.Revision,
 			},
 		}, beylaInfoLabelNames).MetricVec, clock.Time, cfg.TTL),
-		httpDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		httpDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.HTTPServerDuration.Prom,
 			Help:                            "duration of HTTP service calls from the server side, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -272,7 +272,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrHTTPDuration)).MetricVec, clock.Time, cfg.TTL),
-		httpClientDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		httpClientDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.HTTPClientDuration.Prom,
 			Help:                            "duration of HTTP service calls from the client side, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -280,7 +280,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrHTTPClientDuration)).MetricVec, clock.Time, cfg.TTL),
-		grpcDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		grpcDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.RPCServerDuration.Prom,
 			Help:                            "duration of RCP service calls from the server side, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -288,7 +288,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrGRPCDuration)).MetricVec, clock.Time, cfg.TTL),
-		grpcClientDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		grpcClientDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.RPCClientDuration.Prom,
 			Help:                            "duration of GRPC service calls from the client side, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -296,7 +296,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrGRPCClientDuration)).MetricVec, clock.Time, cfg.TTL),
-		dbClientDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		dbClientDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.DBClientDuration.Prom,
 			Help:                            "duration of db client operations, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -304,7 +304,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrDBClientDuration)).MetricVec, clock.Time, cfg.TTL),
-		msgPublishDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		msgPublishDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.MessagingPublishDuration.Prom,
 			Help:                            "duration of messaging client publish operations, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -312,7 +312,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrMessagingPublishDuration)).MetricVec, clock.Time, cfg.TTL),
-		msgProcessDuration: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		msgProcessDuration: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.MessagingProcessDuration.Prom,
 			Help:                            "duration of messaging client process operations, in seconds",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -320,7 +320,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrMessagingProcessDuration)).MetricVec, clock.Time, cfg.TTL),
-		httpRequestSize: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		httpRequestSize: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.HTTPServerRequestSize.Prom,
 			Help:                            "size, in bytes, of the HTTP request body as received at the server side",
 			Buckets:                         cfg.Buckets.RequestSizeHistogram,
@@ -328,7 +328,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrHTTPRequestSize)).MetricVec, clock.Time, cfg.TTL),
-		httpClientRequestSize: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		httpClientRequestSize: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            attributes.HTTPClientRequestSize.Prom,
 			Help:                            "size, in bytes, of the HTTP request body as sent from the client side",
 			Buckets:                         cfg.Buckets.RequestSizeHistogram,
@@ -336,7 +336,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(attrHTTPClientRequestSize)).MetricVec, clock.Time, cfg.TTL),
-		spanMetricsLatency: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		spanMetricsLatency: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            SpanMetricsLatency,
 			Help:                            "duration of service calls (client and server), in seconds, in trace span metrics format",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -344,19 +344,19 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL),
-		spanMetricsCallsTotal: expire.NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+		spanMetricsCallsTotal: NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: SpanMetricsCalls,
 			Help: "number of service calls in trace span metrics format",
 		}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL),
-		spanMetricsSizeTotal: expire.NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+		spanMetricsSizeTotal: NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: SpanMetricsSizes,
 			Help: "size of service calls, in bytes, in trace span metrics format",
 		}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL),
-		tracesTargetInfo: expire.NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		tracesTargetInfo: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: TracesTargetInfo,
 			Help: "target service information in trace span metric format",
 		}, labelNamesTargetInfo(ctxInfo)).MetricVec, clock.Time, cfg.TTL),
-		serviceGraphClient: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		serviceGraphClient: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            ServiceGraphClient,
 			Help:                            "duration of client service calls, in seconds, in trace service graph metrics format",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -364,7 +364,7 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNamesServiceGraph()).MetricVec, clock.Time, cfg.TTL),
-		serviceGraphServer: expire.NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		serviceGraphServer: NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            ServiceGraphServer,
 			Help:                            "duration of server service calls, in seconds, in trace service graph metrics format",
 			Buckets:                         cfg.Buckets.DurationHistogram,
@@ -372,11 +372,11 @@ func newReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNamesServiceGraph()).MetricVec, clock.Time, cfg.TTL),
-		serviceGraphFailed: expire.NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+		serviceGraphFailed: NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: ServiceGraphFailed,
 			Help: "number of failed service calls in trace service graph metrics format",
 		}, labelNamesServiceGraph()).MetricVec, clock.Time, cfg.TTL),
-		serviceGraphTotal: expire.NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+		serviceGraphTotal: NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: ServiceGraphTotal,
 			Help: "number of service calls in trace service graph metrics format",
 		}, labelNamesServiceGraph()).MetricVec, clock.Time, cfg.TTL),

--- a/pkg/internal/export/prom/prom_proc.go
+++ b/pkg/internal/export/prom/prom_proc.go
@@ -1,0 +1,128 @@
+package prom
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/mariomac/pipes/pipe"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/beyla/pkg/internal/connector"
+	"github.com/grafana/beyla/pkg/internal/export/attributes"
+	"github.com/grafana/beyla/pkg/internal/export/expire"
+	"github.com/grafana/beyla/pkg/internal/export/otel"
+	"github.com/grafana/beyla/pkg/internal/infraolly/process"
+	"github.com/grafana/beyla/pkg/internal/pipe/global"
+)
+
+// injectable function reference for testing
+
+// ProcPrometheusConfig for process metrics just wraps the global prom.ProcPrometheusConfig as provided by the user
+type ProcPrometheusConfig struct {
+	Metrics            *PrometheusConfig
+	AttributeSelectors attributes.Selection
+}
+
+// nolint:gocritic
+func (p ProcPrometheusConfig) Enabled() bool {
+	// TODO:
+	return p.Metrics != nil && p.Metrics.Port != 0 && p.Metrics.OTelMetricsEnabled() &&
+		slices.Contains(p.Metrics.Features, otel.FeatureProcess)
+}
+
+// ProcPrometheusEndpoint provides a pipeline node that export the process information as
+// prometheus metrics
+func ProcPrometheusEndpoint(
+	ctx context.Context, ctxInfo *global.ContextInfo, cfg *ProcPrometheusConfig,
+) pipe.FinalProvider[[]*process.Status] {
+	return func() (pipe.FinalFunc[[]*process.Status], error) {
+		if !cfg.Enabled() {
+			// This node is not going to be instantiated. Let the pipes library just ignore it.
+			return pipe.IgnoreFinal[[]*process.Status](), nil
+		}
+		reporter, err := newProcReporter(ctx, ctxInfo, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return reporter.reportMetrics, nil
+	}
+}
+
+type procMetricsReporter struct {
+	cfg *PrometheusConfig
+
+	promConnect *connector.PrometheusManager
+
+	attrs []attributes.Field[*process.Status, string]
+
+	clock *expire.CachedClock
+	bgCtx context.Context
+
+	// metrics
+	cpuUtilization *Expirer[prometheus.Gauge]
+}
+
+func newProcReporter(
+	ctx context.Context,
+	ctxInfo *global.ContextInfo,
+	cfg *ProcPrometheusConfig,
+) (*procMetricsReporter, error) {
+	group := ctxInfo.MetricAttributeGroups
+	// this property can't be set inside the ConfiguredGroups function, otherwise the
+	// OTEL exporter would report also some prometheus-exclusive attributes
+	group.Add(attributes.GroupPrometheus)
+
+	provider, err := attributes.NewAttrSelector(group, cfg.AttributeSelectors)
+	if err != nil {
+		return nil, fmt.Errorf("network Prometheus exporter attributes enable: %w", err)
+	}
+
+	attrs := attributes.PrometheusGetters(
+		process.PromGetters,
+		provider.For(attributes.ProcessCPUUtilization))
+
+	labelNames := make([]string, 0, len(attrs))
+	for _, label := range attrs {
+		labelNames = append(labelNames, label.ExposedName)
+	}
+
+	clock := expire.NewCachedClock(timeNow)
+	// If service name is not explicitly set, we take the service name as set by the
+	// executable inspector
+	mr := &procMetricsReporter{
+		bgCtx:       ctx,
+		cfg:         cfg.Metrics,
+		promConnect: ctxInfo.Prometheus,
+		attrs:       attrs,
+		clock:       clock,
+		cpuUtilization: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: attributes.ProcessCPUUtilization.Prom,
+			Help: "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process",
+		}, labelNames).MetricVec, clock.Time, cfg.Metrics.TTL),
+	}
+
+	mr.promConnect.Register(cfg.Metrics.Port, cfg.Metrics.Path, mr.cpuUtilization)
+
+	return mr, nil
+}
+
+func (r *procMetricsReporter) reportMetrics(input <-chan []*process.Status) {
+	go r.promConnect.StartHTTP(r.bgCtx)
+	for flows := range input {
+		// clock needs to be updated to let the expirer
+		// remove the old metrics
+		r.clock.Update()
+		for _, flow := range flows {
+			r.observe(flow)
+		}
+	}
+}
+
+func (r *procMetricsReporter) observe(flow *process.Status) {
+	labelValues := make([]string, 0, len(r.attrs))
+	for _, attr := range r.attrs {
+		labelValues = append(labelValues, attr.Get(flow))
+	}
+	r.cpuUtilization.WithLabelValues(labelValues...).Set(flow.CPUPercent / 100)
+}

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -2,6 +2,8 @@ package process
 
 import (
 	"log/slog"
+	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -80,6 +82,30 @@ func OTELGetters(name attr.Name) (attributes.Getter[*Status, attribute.KeyValue]
 		g = func(s *Status) attribute.KeyValue {
 			return attribute.Key(attr.ProcPid).Int(int(s.ProcessID))
 		}
+	}
+	return g, g != nil
+}
+
+// nolint:cyclop
+func PromGetters(name attr.Name) (attributes.Getter[*Status, string], bool) {
+	var g attributes.Getter[*Status, string]
+	switch name {
+	case attr.ProcCommand:
+		g = func(s *Status) string { return s.Command }
+	case attr.ProcCommandLine:
+		g = func(s *Status) string { return s.CommandLine }
+	case attr.ProcExecName:
+		g = func(status *Status) string { return status.ExecName }
+	case attr.ProcExecPath:
+		g = func(status *Status) string { return status.ExecPath }
+	case attr.ProcCommandArgs:
+		g = func(status *Status) string { return strings.Join(status.CommandArgs, ",") }
+	case attr.ProcOwner:
+		g = func(s *Status) string { return s.User }
+	case attr.ProcParentPid:
+		g = func(s *Status) string { return strconv.Itoa(int(s.ParentProcessID)) }
+	case attr.ProcPid:
+		g = func(s *Status) string { return strconv.Itoa(int(s.ProcessID)) }
 	}
 	return g, g != nil
 }

--- a/pkg/internal/netolly/agent/pipeline.go
+++ b/pkg/internal/netolly/agent/pipeline.go
@@ -6,10 +6,10 @@ import (
 	"github.com/mariomac/pipes/pipe"
 
 	"github.com/grafana/beyla/pkg/internal/export/otel"
+	"github.com/grafana/beyla/pkg/internal/export/prom"
 	"github.com/grafana/beyla/pkg/internal/filter"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/export"
-	"github.com/grafana/beyla/pkg/internal/netolly/export/prom"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow"
 	"github.com/grafana/beyla/pkg/internal/netolly/transform/cidr"
 	"github.com/grafana/beyla/pkg/internal/netolly/transform/k8s"
@@ -139,7 +139,7 @@ func (f *Flows) pipelineBuilder(ctx context.Context) (*pipe.Builder[*FlowsPipeli
 		})
 	})
 	pipe.AddFinalProvider(pb, promExport, func() (pipe.FinalFunc[[]*ebpf.Record], error) {
-		return prom.PrometheusEndpoint(ctx, f.ctxInfo, &prom.PrometheusConfig{
+		return prom.NetPrometheusEndpoint(ctx, f.ctxInfo, &prom.NetPrometheusConfig{
 			Config:             &f.cfg.Prometheus,
 			AttributeSelectors: f.cfg.Attributes.Select,
 		})

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -4,3 +4,10 @@ routes:
   unmatched: path
 prometheus_export:
   port: 8999
+  features:
+    - application
+    - application_process
+attributes:
+  select:
+    process_cpu_utilization:
+      include: ["*"]

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       GOCOVERDIR: "/coverage"
       BEYLA_PRINT_TRACES: "true"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
-      BEYLA_OTEL_METRICS_FEATURES: "application,application_span"
-      BEYLA_PROMETHEUS_FEATURES: "application,application_span"
+      BEYLA_OTEL_METRICS_FEATURES: "application,application_span,application_process"
+      BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"
       BEYLA_SKIP_GO_SPECIFIC_TRACERS: "${BEYLA_SKIP_GO_SPECIFIC_TRACERS}"

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -79,6 +79,12 @@ func TestSuiteClientPromScrape(t *testing.T) {
 	require.NoError(t, compose.Up())
 	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibraryNoTraces)
 	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
+	t.Run("Testing process-level metrics", testProcesses(map[string]string{
+		"process_executable_name": "pingclient",
+		"process_executable_path": "/pingclient",
+		"process_command":         "pingclient",
+		"process_command_line":    "/pingclient",
+	}))
 
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
 	require.NoError(t, compose.Close())
@@ -220,6 +226,12 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
 	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
+	t.Run("Testing process-level metrics", testProcesses(map[string]string{
+		"process_executable_name": "testserver",
+		"process_executable_path": "/testserver",
+		"process_command":         "testserver",
+		"process_command_line":    "/testserver",
+	}))
 
 	t.Run("BPF pinning folder mounted", testBPFPinningMounted)
 	require.NoError(t, compose.Close())


### PR DESCRIPTION
This PR also reorganizes a bit the code, moving the prometheus expirer and prometheus network metrics to the `internal/export/prom` package.