### PR TITLE
Remove beyla metrics and traces by default

### DIFF
--- a/pkg/internal/export/otel/instrument.go
+++ b/pkg/internal/export/otel/instrument.go
@@ -5,7 +5,6 @@ import (
 
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 )
@@ -26,19 +25,5 @@ func (ie *instrumentedMetricsExporter) Export(ctx context.Context, md *metricdat
 		totalMetrics += len(scope.Metrics)
 	}
 	ie.internal.OTELMetricExport(totalMetrics)
-	return nil
-}
-
-type instrumentedTracesExporter struct {
-	trace.SpanExporter
-	internal imetrics.Reporter
-}
-
-func (ie *instrumentedTracesExporter) ExportSpans(ctx context.Context, ss []trace.ReadOnlySpan) error {
-	if err := ie.SpanExporter.ExportSpans(ctx, ss); err != nil {
-		ie.internal.OTELTraceExportError(err)
-		return err
-	}
-	ie.internal.OTELTraceExport(len(ss))
 	return nil
 }

--- a/pkg/internal/export/otel/instrument.go
+++ b/pkg/internal/export/otel/instrument.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 )
@@ -25,5 +26,19 @@ func (ie *instrumentedMetricsExporter) Export(ctx context.Context, md *metricdat
 		totalMetrics += len(scope.Metrics)
 	}
 	ie.internal.OTELMetricExport(totalMetrics)
+	return nil
+}
+
+type instrumentedTracesExporter struct {
+	trace.SpanExporter
+	internal imetrics.Reporter
+}
+
+func (ie *instrumentedTracesExporter) ExportSpans(ctx context.Context, ss []trace.ReadOnlySpan) error {
+	if err := ie.SpanExporter.ExportSpans(ctx, ss); err != nil {
+		ie.internal.OTELTraceExportError(err)
+		return err
+	}
+	ie.internal.OTELTraceExport(len(ss))
 	return nil
 }


### PR DESCRIPTION
When we switched to the OpenTelemetry collector SDK for generating traces we ended up accidentally enabling Beyla internal metrics and traces. This PR reverts that setting. If the internal metrics Prometheus port is enabled, the trace exporter metrics get enabled now.