### PR TITLE
Improve process discovery performance

### DIFF
--- a/pkg/internal/exec/proclang_darwin.go
+++ b/pkg/internal/exec/proclang_darwin.go
@@ -10,6 +10,6 @@ func FindProcLanguage(_ int32, _ *elf.File) svc.InstrumentableType {
 	return svc.InstrumentableGeneric
 }
 
-func FindExeSymbols(_ *elf.File) (map[string]Sym, error) {
+func FindExeSymbols(_ *elf.File, _ map[string]struct{}) (map[string]Sym, error) {
 	return nil, nil
 }

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -38,7 +38,7 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 	// no go symbols in the executable, maybe it's statically linked
 	// find regular elf symbols
 	if gosyms == nil {
-		allSyms, err = exec.FindExeSymbols(elfF)
+		allSyms, err = exec.FindExeSymbols(elfF, functions)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
While running the OpenTelemetry DEMO with Beyla I noticed excessive CPU utilization, more than I expected for the workload that the DEMO has. 

I was seeing around 175% CPU utilization on Beyla, while the node.js service for the front-end was around 30%. This is unusually high, Beyla should be low tens of CPU on something like the DEMO. I did a `perf` profile and I noticed a large percentage of time was spent in Beyla detecting and parsing new processes:

![image](https://github.com/grafana/beyla/assets/6207777/aa22fa6a-cd61-45d9-bbfe-ed78a3ffe631)

After some digging around, this is actually caused by the OTel DEMO load generator, which launches constantly new Chromium instances to simulate web browsers visiting the DEMO website. While this is technically a non-standard scenario, when customers instrument all of their pods/executables, we might find many other cases of executables that keep on launching.

I made two fixes:
1. I improved the performance of scanning for language type by separating that code into its own function. We didn't need any of the symbol addresses for this operation and we were unnecessarily creating bunch of memory.
2. I made a cache of executable types. Namely, if the same executable keeps on launching for a short lived process, we remember the expensive ELF parsing information now, like the Go offsets and the executable type (if we hand to look into the executable symbols for the type).

After making these 2 changes, Beyla takes around 25% CPU and here's the profile, all related to ring buffer processing (which is what it should be doing):

![image](https://github.com/grafana/beyla/assets/6207777/c3b52b7e-81dd-4e6a-a5d3-55c9f3cb3de0)
