### PR TITLE
Process network metrics

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -159,6 +159,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			attr.ProcParentPid:   true,
 			attr.ProcPid:         true,
 			attr.ProcDiskIODir:   true,
+			attr.ProcNetIODir:    true,
 			attr.ProcCommandLine: false,
 			attr.ProcCommandArgs: false,
 			attr.ProcExecName:    false,
@@ -245,6 +246,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		ProcessMemoryUsage.Section:    {SubGroups: []*AttrReportGroup{&processAttributes}},
 		ProcessMemoryVirtual.Section:  {SubGroups: []*AttrReportGroup{&processAttributes}},
 		ProcessDiskIO.Section:         {SubGroups: []*AttrReportGroup{&processAttributes}},
+		ProcessNetIO.Section:          {SubGroups: []*AttrReportGroup{&processAttributes}},
 	}
 }
 

--- a/pkg/internal/export/attributes/metric.go
+++ b/pkg/internal/export/attributes/metric.go
@@ -86,6 +86,11 @@ var (
 		Prom:    "process_disk_io_bytes_total",
 		OTEL:    "process.disk.io",
 	}
+	ProcessNetIO = Name{
+		Section: "process.network.io",
+		Prom:    "process_network_io_bytes_total",
+		OTEL:    "process.network.io",
+	}
 	MessagingPublishDuration = Name{
 		Section: "messaging.publish.duration",
 		Prom:    "messaging_publish_duration_seconds",

--- a/pkg/internal/export/attributes/names/attrs.go
+++ b/pkg/internal/export/attributes/names/attrs.go
@@ -107,6 +107,7 @@ const (
 	ProcCommandLine = Name(semconv.ProcessCommandLineKey)
 	ProcCPUState    = Name("process.cpu.state")
 	ProcDiskIODir   = Name(semconv2.DiskIoDirectionKey)
+	ProcNetIODir    = Name(semconv2.NetworkIoDirectionKey)
 	ProcOwner       = Name(semconv.ProcessOwnerKey)
 	ProcParentPid   = Name(semconv.ProcessParentPIDKey)
 	ProcPid         = Name(semconv.ProcessPIDKey)

--- a/pkg/internal/export/otel/expirer_test.go
+++ b/pkg/internal/export/otel/expirer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/beyla/test/collector"
 )
 
-const timeout = 10 * time.Second
+const timeout = 20 * time.Second
 
 func TestMetricsExpiration(t *testing.T) {
 	defer restoreEnvAfterExecution()()

--- a/pkg/internal/export/otel/traces_test.go
+++ b/pkg/internal/export/otel/traces_test.go
@@ -681,7 +681,6 @@ func TestTraces_InternalInstrumentation(t *testing.T) {
 		return &impl.exporter
 	}, TracesReceiver(context.Background(),
 		TracesConfig{
-			SDKLogLevel:       "debug",
 			CommonEndpoint:    coll.URL,
 			BatchTimeout:      10 * time.Millisecond,
 			ExportTimeout:     10 * time.Millisecond,

--- a/pkg/internal/infraolly/process/snapshot_test.go
+++ b/pkg/internal/infraolly/process/snapshot_test.go
@@ -218,3 +218,17 @@ func Test_usernameFromGetent(t *testing.T) { //nolint:paralleltest
 		})
 	}
 }
+
+func TestNetworkBytes(t *testing.T) {
+	netDev := []byte(`Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:   41292     444    0    0    0     0          0         0    33111     444    0    0    0     0       0          0
+  eth0:  233606    1024    0    0    0     0          0         0   44123     775    0    0    0     0       0          0
+br-26b494c37194:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+docker0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+br-a3d66a1fd7b9:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+`)
+	rx, tx := parseProcNetDev(netDev)
+	assert.EqualValues(t, 41292+233606, rx)
+	assert.EqualValues(t, 33111+44123, tx)
+}

--- a/pkg/internal/infraolly/process/snapshot_test.go
+++ b/pkg/internal/infraolly/process/snapshot_test.go
@@ -232,3 +232,41 @@ br-a3d66a1fd7b9:       0       0    0    0    0     0          0         0      
 	assert.EqualValues(t, 41292+233606, rx)
 	assert.EqualValues(t, 33111+44123, tx)
 }
+
+func TestNetworkBytes_Corrupt(t *testing.T) {
+	t.Run("nil net/dev", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			parseProcNetDev(nil)
+		})
+	})
+	t.Run("empty net/dev", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			parseProcNetDev([]byte{})
+		})
+	})
+	t.Run("arbitrary/random net/dev", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			parseProcNetDev([]byte{1, 2, 3, 4, 5, '\n', 3, 34, 56, 12, 67})
+		})
+	})
+	t.Run("net/dev without proper header", func(t *testing.T) {
+		netDev := []byte(`lo:   41292     444    0    0    0     0          0         0    33111     444    0    0    0     0       0          0
+  eth0:  233606    1024    0    0    0     0          0         0   44123     775    0    0    0     0       0          0
+br-26b494c37194:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+docker0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+br-a3d66a1fd7b9:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+`)
+		rx, tx := parseProcNetDev(netDev)
+		assert.EqualValues(t, 233606, rx)
+		assert.EqualValues(t, 44123, tx)
+	})
+	t.Run("incomplete net/dev", func(t *testing.T) {
+		netDev := []byte(`Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:   41292     444    0    0    0     0          0         0    33111     444    0    0    0     0       0          0
+  eth0:  233606    1024    0    0    0     0      `)
+		rx, tx := parseProcNetDev(netDev)
+		assert.EqualValues(t, 41292, rx)
+		assert.EqualValues(t, 33111, tx)
+	})
+}

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -49,6 +49,9 @@ type Status struct {
 	IOReadBytesDelta  uint64
 	IOWriteBytesDelta uint64
 
+	NetTxBytesDelta  int64
+	NetRcvBytesDelta int64
+
 	Service *svc.ID
 }
 
@@ -91,7 +94,7 @@ func OTELGetters(name attr.Name) (attributes.Getter[*Status, attribute.KeyValue]
 		g = func(s *Status) attribute.KeyValue {
 			return attribute.Key(attr.ProcPid).Int(int(s.ProcessID))
 		}
-	case attr.ProcCPUState, attr.ProcDiskIODir:
+	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the OTEL exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
 	default:
@@ -120,7 +123,7 @@ func PromGetters(name attr.Name) (attributes.Getter[*Status, string], bool) {
 		g = func(s *Status) string { return strconv.Itoa(int(s.ParentProcessID)) }
 	case attr.ProcPid:
 		g = func(s *Status) string { return strconv.Itoa(int(s.ProcessID)) }
-	case attr.ProcCPUState, attr.ProcDiskIODir:
+	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the prometheus exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
 	default:

--- a/test/integration/configs/instrumenter-config-java.yml
+++ b/test/integration/configs/instrumenter-config-java.yml
@@ -18,3 +18,5 @@ attributes:
       include: ["*"]
     process_disk_io:
       include: ["*"]
+    process_network_io:
+      include: ["*"]

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -21,3 +21,5 @@ attributes:
       include: ["*"]
     process_disk_io:
       include: ["*"]
+    process_network_io:
+      include: ["*"]

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -67,6 +67,7 @@ var (
 		"process_memory_usage_bytes",
 		"process_memory_virtual_bytes",
 		"process_disk_io_bytes_total",
+		"process_network_io_bytes_total",
 	}
 )
 

--- a/test/integration/process_test.go
+++ b/test/integration/process_test.go
@@ -65,6 +65,11 @@ func testProcesses(attribMatcher map[string]string) func(t *testing.T) {
 			require.NoError(t, err)
 			matchAttributes(t, results, attribMatcher)
 		})
+		test.Eventually(t, testTimeout, func(t require.TestingT) {
+			results, err := pq.Query(`process_network_io_bytes_total`)
+			require.NoError(t, err)
+			matchAttributes(t, results, attribMatcher)
+		})
 	}
 }
 


### PR DESCRIPTION
`process.network.io` metric, which can be aggregated by `network.io.direction=transmit/receive`