### PR TITLE
Add metric for instrumented processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ cleanup-integration-test:
 run-integration-test:
 	@echo "### Running integration tests"
 	go clean -testcache
-	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration
+	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration -run ^TestMultiProcess$
 
 .PHONY: run-integration-test-k8s
 run-integration-test-k8s:

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ cleanup-integration-test:
 run-integration-test:
 	@echo "### Running integration tests"
 	go clean -testcache
-	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration -run ^TestMultiProcess$
+	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration
 
 .PHONY: run-integration-test-k8s
 run-integration-test-k8s:

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -109,4 +109,4 @@ Beyla can be [configured to report internal metrics]({{< relref "./configure/opt
 | `otel_trace_exports`        | Counter    | Length of the trace batches submitted to the remote OTEL collector                       |
 | `otel_trace_export_errors`  | CounterVec | Error count on each failed OTEL trace export, by error type                              |
 | `prometheus_http_requests`  | CounterVec | Number of requests towards the Prometheus Scrape endpoint, faceted by HTTP port and path |
-| `beyla_discovered_services` | GaugeVec   | Discovered services by Beyla, with process name                                    |
+| `beyla_instrumented_processes` | GaugeVec   | Instrumented processes by Beyla, with process name                                    |

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -109,3 +109,4 @@ Beyla can be [configured to report internal metrics]({{< relref "./configure/opt
 | `otel_trace_exports`        | Counter    | Length of the trace batches submitted to the remote OTEL collector                       |
 | `otel_trace_export_errors`  | CounterVec | Error count on each failed OTEL trace export, by error type                              |
 | `prometheus_http_requests`  | CounterVec | Number of requests towards the Prometheus Scrape endpoint, faceted by HTTP port and path |
+| `beyla_discovered_services` | GaugeVec   | Discovered services by Beyla, with process name                                    |

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -95,6 +95,7 @@ func (ta *TraceAttacher) getTracer(ie *Instrumentable) (*ebpf.ProcessTracer, boo
 		ta.log.Debug(".done")
 		return nil, false
 	}
+	ta.Metrics.DiscoverService(ie.FileInfo.ExecutableName())
 	ta.log.Info("instrumenting process", "cmd", ie.FileInfo.CmdExePath, "pid", ie.FileInfo.Pid)
 
 	// builds a tracer for that executable
@@ -205,6 +206,7 @@ func (ta *TraceAttacher) notifyProcessDeletion(ie *Instrumentable) {
 		// notifying the tracer to block any trace from that PID
 		// to avoid that a new process reusing this PID could send traces
 		// unless explicitly allowed
+		ta.Metrics.UndiscoverService(ie.FileInfo.ExecutableName())
 		tracer.BlockPID(uint32(ie.FileInfo.Pid), ie.FileInfo.Ns)
 
 		// if there are no more trace instances for a Go program, we need to notify that

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -28,10 +28,10 @@ type Reporter interface {
 	OTELTraceExportError(err error)
 	// PrometheusRequest is invoked every time the Prometheus exporter is invoked, for a given port and path
 	PrometheusRequest(port, path string)
-	// DiscoverService is invoked every time a new service is discovered by the eBPF tracer
-	DiscoverService(service string)
-	// UndiscoverService is invoked every time a new service is removed from the discovered services by the eBPF tracer
-	UndiscoverService(service string)
+	// InstrumentProcess is invoked every time a new process is instrumented
+	InstrumentProcess(process_name string)
+	// UninstrumentProcess is invoked every time a process is removed from the instrumented processed
+	UninstrumentProcess(process_name string)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
@@ -44,5 +44,5 @@ func (n NoopReporter) OTELMetricExportError(_ error) {}
 func (n NoopReporter) OTELTraceExport(_ int)         {}
 func (n NoopReporter) OTELTraceExportError(_ error)  {}
 func (n NoopReporter) PrometheusRequest(_, _ string) {}
-func (n NoopReporter) DiscoverService(_ string)      {}
-func (n NoopReporter) UndiscoverService(_ string)    {}
+func (n NoopReporter) InstrumentProcess(_ string)    {}
+func (n NoopReporter) UninstrumentProcess(_ string)  {}

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -29,9 +29,9 @@ type Reporter interface {
 	// PrometheusRequest is invoked every time the Prometheus exporter is invoked, for a given port and path
 	PrometheusRequest(port, path string)
 	// InstrumentProcess is invoked every time a new process is instrumented
-	InstrumentProcess(process_name string)
+	InstrumentProcess(processName string)
 	// UninstrumentProcess is invoked every time a process is removed from the instrumented processed
-	UninstrumentProcess(process_name string)
+	UninstrumentProcess(processName string)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -28,6 +28,10 @@ type Reporter interface {
 	OTELTraceExportError(err error)
 	// PrometheusRequest is invoked every time the Prometheus exporter is invoked, for a given port and path
 	PrometheusRequest(port, path string)
+	// DiscoverService is invoked every time a new service is discovered by the eBPF tracer
+	DiscoverService(service string)
+	// UndiscoverService is invoked every time a new service is removed from the discovered services by the eBPF tracer
+	UndiscoverService(service string)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
@@ -40,3 +44,5 @@ func (n NoopReporter) OTELMetricExportError(_ error) {}
 func (n NoopReporter) OTELTraceExport(_ int)         {}
 func (n NoopReporter) OTELTraceExportError(_ error)  {}
 func (n NoopReporter) PrometheusRequest(_, _ string) {}
+func (n NoopReporter) DiscoverService(_ string)      {}
+func (n NoopReporter) UndiscoverService(_ string)    {}

--- a/pkg/internal/imetrics/iprom.go
+++ b/pkg/internal/imetrics/iprom.go
@@ -64,7 +64,7 @@ func NewPrometheusReporter(cfg *PrometheusConfig, manager *connector.PrometheusM
 		}, []string{"port", "path"}),
 		discoveredServices: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "beyla_discovered_services",
-			Help: "discovered services by the eBPF tracer",
+			Help: "discovered services by Beyla",
 		}, []string{"service"}),
 	}
 	manager.Register(cfg.Port, cfg.Path,

--- a/pkg/internal/imetrics/iprom.go
+++ b/pkg/internal/imetrics/iprom.go
@@ -107,10 +107,10 @@ func (p *PrometheusReporter) PrometheusRequest(port, path string) {
 	p.prometheusRequests.WithLabelValues(port, path).Inc()
 }
 
-func (p *PrometheusReporter) InstrumentProcess(process_name string) {
-	p.instrumentedProcesses.WithLabelValues(process_name).Inc()
+func (p *PrometheusReporter) InstrumentProcess(processName string) {
+	p.instrumentedProcesses.WithLabelValues(processName).Inc()
 }
 
-func (p *PrometheusReporter) UninstrumentProcess(process_name string) {
-	p.instrumentedProcesses.WithLabelValues(process_name).Dec()
+func (p *PrometheusReporter) UninstrumentProcess(processName string) {
+	p.instrumentedProcesses.WithLabelValues(processName).Dec()
 }

--- a/test/integration/configs/prometheus-config.yml
+++ b/test/integration/configs/prometheus-config.yml
@@ -11,3 +11,8 @@ scrape_configs:
     static_configs:
       - targets:
           - 'otelcol:8888'
+  - job_name: autoinstrumenter-collector
+    honor_labels: true
+    static_configs:
+      - targets:
+          - '172.17.0.1:8999'

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -134,6 +134,10 @@ services:
       BEYLA_METRICS_REPORT_TARGET: "true"
       BEYLA_METRICS_REPORT_PEER: "true"
       BEYLA_HOSTNAME: "beyla"
+      BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
+      BEYLA_INTERNAL_METRICS_PROMETHEUS_PATH: /metrics
+    ports:
+      - "8999:8999"      
 
   # OpenTelemetry Collector
   otelcol:
@@ -166,6 +170,7 @@ services:
       - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
+      - --log.level=debug
     volumes:
       - ./configs/:/etc/prometheus
     ports:


### PR DESCRIPTION
This PR adds a Gauge to track all services registered by Beyla.
Useful for debugging purpouses. Displays something like this:

```
beyla_instrumented_processes{service="php"} 1
beyla_instrumented_processes{service="productcatalogservice"} 1
beyla_instrumented_processes{service="prometheus"} 1
beyla_instrumented_processes{service="python3.12"} 2
```

Current limtation is for intepreted languanges such Python, Ruby or Java, as we won't visualize
which program are we discovering.