### PR TITLE
Using experimental OTEL API for removing metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,13 @@ issues:
   exclude-dirs:
     - configs
     - docs
+  exclude-rules:
+    # revive returns false indent-error-flow errors in some cases where
+    # an "else" clause is required to access the if condition context
+    - path: .*
+      linters:
+        - revive
+      text: indent-error-flow
 run:
   go: "1.22"
   build-tags:

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -808,10 +808,6 @@ the last update is greater than this Time-To-Leave (TTL) value.
 
 The purpose of this value is to avoid reporting indefinitely finished application instances.
 
-Due to the current limitations of the OpenTelemetry SDK, this value is not effective for
-histogram metrics. If expiring old histogram metric instances is mandatory, consider using
-the Prometheus exporter, or an intermediate OpenTelemetry collector such as [Grafana Alloy](/docs/alloy/latest/).
-
 | YAML       | Environment variable          | Type            | Default                      |
 |------------|-------------------------------|-----------------|------------------------------|
 | `features` | `BEYLA_OTEL_METRICS_FEATURES` | list of strings | `["application", "network"]` |

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,10 @@ replace go.opentelemetry.io/otel/metric => github.com/grafana/opentelemetry-go/m
 
 replace go.opentelemetry.io/otel/trace => github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1
 
+replace go.opentelemetry.io/otel/sdk => github.com/grafana/opentelemetry-go/sdk v1.27.0-grafana.1
+
+replace go.opentelemetry.io/otel/sdk/metric => github.com/grafana/opentelemetry-go/sdk/metric v1.27.0-grafana.1
+
 require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,12 @@ require (
 	sigs.k8s.io/e2e-framework v0.3.0
 )
 
+replace go.opentelemetry.io/otel => github.com/grafana/opentelemetry-go v1.27.0-grafana.1
+
+replace go.opentelemetry.io/otel/metric => github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1
+
+replace go.opentelemetry.io/otel/trace => github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1
+
 require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,10 @@ github.com/grafana/opentelemetry-go v1.27.0-grafana.1 h1:C7zzm8GaQH7LQU4jnLbF6UJ
 github.com/grafana/opentelemetry-go v1.27.0-grafana.1/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
 github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1 h1:rVI0qUyjlYIwdl0EWHcHNdhdkftekmV0vYdoKePl9+U=
 github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
+github.com/grafana/opentelemetry-go/sdk v1.27.0-grafana.1 h1:WdKFfSBQ9JI+FshIFQHoew5e8naSXoI1ISX/IY6V9rk=
+github.com/grafana/opentelemetry-go/sdk v1.27.0-grafana.1/go.mod h1:Ha9vbLwJE6W86YstIywK2xFfPjbWlCuwPtMkKdz/Y4A=
+github.com/grafana/opentelemetry-go/sdk/metric v1.27.0-grafana.1 h1:iGv2+T3PyGMN+SBRh11kIyLAw2q7bvrKVqO4zrU+gTI=
+github.com/grafana/opentelemetry-go/sdk/metric v1.27.0-grafana.1/go.mod h1:we7jJVrYN2kh3mVBlswtPU22K0SA+769l93J6bsyvqw=
 github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1 h1:b4w6laH2s/bB/+VFO4DXrficMaDLRW2LnS3/KPJHE+0=
 github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
@@ -328,10 +332,6 @@ go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.27.0 h1:/jlt1Y8gXWiHG9
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.27.0/go.mod h1:bmToOGOBZ4hA9ghphIc1PAf66VA8KOtsuy3+ScStG20=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.27.0 h1:/0YaXu3755A/cFbtXp+21lkXgI0QE5avTWA2HjU9/WE=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.27.0/go.mod h1:m7SFxp0/7IxmJPLIY3JhOcU9CoFzDaCPL6xxQIxhA+o=
-go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kTWmI=
-go.opentelemetry.io/otel/sdk v1.27.0/go.mod h1:Ha9vbLwJE6W86YstIywK2xFfPjbWlCuwPtMkKdz/Y4A=
-go.opentelemetry.io/otel/sdk/metric v1.27.0 h1:5uGNOlpXi+Hbo/DRoI31BSb1v+OGcpv2NemcCrOL8gI=
-go.opentelemetry.io/otel/sdk/metric v1.27.0/go.mod h1:we7jJVrYN2kh3mVBlswtPU22K0SA+769l93J6bsyvqw=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,12 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/go-offsets-tracker v0.1.7 h1:2zBQ7iiGzvyXY7LA8kaaSiEqH/Yx82UcfRabbY5aOG4=
 github.com/grafana/go-offsets-tracker v0.1.7/go.mod h1:qcQdu7zlUKIFNUdBJlLyNHuJGW0SKWKjkrN6jtt+jds=
+github.com/grafana/opentelemetry-go v1.27.0-grafana.1 h1:C7zzm8GaQH7LQU4jnLbF6UJczv0Oe5cgiualNm5ifZo=
+github.com/grafana/opentelemetry-go v1.27.0-grafana.1/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1 h1:rVI0qUyjlYIwdl0EWHcHNdhdkftekmV0vYdoKePl9+U=
+github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
+github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1 h1:b4w6laH2s/bB/+VFO4DXrficMaDLRW2LnS3/KPJHE+0=
+github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
@@ -306,8 +312,6 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.5
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0/go.mod h1:BMsdeOxN04K0L5FNUBfjFdvwWGNe/rkmSwH4Aelu/X0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 h1:9l89oX4ba9kHbBol3Xin3leYJ+252h0zszDtBwyKe2A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0/go.mod h1:XLZfZboOJWHNKUv7eH0inh0E9VV6eWDFB/9yJyTLPp0=
-go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
-go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0 h1:bFgvUr3/O4PHj3VQcFEuYKvRZJX1SJDQ+11JXuSB3/w=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0/go.mod h1:xJntEd2KL6Qdg5lwp97HMLQDVeAhrYxmzFseAMDPQ8I=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0 h1:CIHWikMsN3wO+wq1Tp5VGdVRTcON+DmOJSfDjXypKOc=
@@ -324,14 +328,10 @@ go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.27.0 h1:/jlt1Y8gXWiHG9
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.27.0/go.mod h1:bmToOGOBZ4hA9ghphIc1PAf66VA8KOtsuy3+ScStG20=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.27.0 h1:/0YaXu3755A/cFbtXp+21lkXgI0QE5avTWA2HjU9/WE=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.27.0/go.mod h1:m7SFxp0/7IxmJPLIY3JhOcU9CoFzDaCPL6xxQIxhA+o=
-go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
-go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
 go.opentelemetry.io/otel/sdk v1.27.0 h1:mlk+/Y1gLPLn84U4tI8d3GNJmGT/eXe3ZuOXN9kTWmI=
 go.opentelemetry.io/otel/sdk v1.27.0/go.mod h1:Ha9vbLwJE6W86YstIywK2xFfPjbWlCuwPtMkKdz/Y4A=
 go.opentelemetry.io/otel/sdk/metric v1.27.0 h1:5uGNOlpXi+Hbo/DRoI31BSb1v+OGcpv2NemcCrOL8gI=
 go.opentelemetry.io/otel/sdk/metric v1.27.0/go.mod h1:we7jJVrYN2kh3mVBlswtPU22K0SA+769l93J6bsyvqw=
-go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
-go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/pkg/internal/export/otel/expirer.go
+++ b/pkg/internal/export/otel/expirer.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -22,19 +19,8 @@ func plog() *slog.Logger {
 	return slog.With("component", "otel.Expirer")
 }
 
-// dataPoint implements a metric value of a given type,
-// for a set of attributes
-// Example of implementers: FloatVal and IntCounter
-type dataPoint[T any] interface {
-	// Load the current value for a given set of attributes
-	Load() T
-	// Attributes return the attributes of the current dataPoint
-	Attributes() attribute.Set
-}
-
-// observer records measurements for a given metric type
-type observer[T any] interface {
-	Observe(T, ...metric.ObserveOption)
+type removableMetric[VT any] interface {
+	Remove(context.Context, ...metric.RemoveOption)
 }
 
 // Expirer drops metrics from labels that haven't been updated during a given timeout.
@@ -43,11 +29,16 @@ type observer[T any] interface {
 // Record: type of the record that holds the metric data request.Span, ebpf.Record, process.Status...
 // Metric: type of the dataPoint kind: IntCounter, FloatVal...
 // VT: type of the value inside the datapoint: int, float64...
-type Expirer[Record any, OT observer[VT], Metric dataPoint[VT], VT any] struct {
-	instancer func(set attribute.Set) Metric
-	attrs     []attributes.Field[Record, attribute.KeyValue]
-	entries   *expire.ExpiryMap[Metric]
-	log       *slog.Logger
+type Expirer[Record any, Metric removableMetric[ValType], ValType any] struct {
+	attrs   []attributes.Field[Record, attribute.KeyValue]
+	metric  Metric
+	entries *expire.ExpiryMap[*expiryMapEntry[Metric, ValType]]
+	log     *slog.Logger
+}
+
+type expiryMapEntry[Metric removableMetric[ValType], ValType any] struct {
+	metric     Metric
+	attributes attribute.Set
 }
 
 // NewExpirer creates an expirer that wraps data points of a given type. Its labeled instances are dropped
@@ -57,18 +48,18 @@ type Expirer[Record any, OT observer[VT], Metric dataPoint[VT], VT any] struct {
 // - attrs: attributes for that given data point
 // - clock: function that provides the current time
 // - ttl: time to live of the datapoints whose attribute sets haven't been updated
-func NewExpirer[Record any, OT observer[VT], Metric dataPoint[VT], VT any](
-	instancer func(set attribute.Set) Metric,
+func NewExpirer[Record any, Metric removableMetric[ValType], ValType any](
+	metric Metric,
 	attrs []attributes.Field[Record, attribute.KeyValue],
 	clock expire.Clock,
 	ttl time.Duration,
-) *Expirer[Record, OT, Metric, VT] {
-	exp := Expirer[Record, OT, Metric, VT]{
-		instancer: instancer,
-		attrs:     attrs,
-		entries:   expire.NewExpiryMap[Metric](clock, ttl),
+) *Expirer[Record, Metric, ValType] {
+	exp := Expirer[Record, Metric, ValType]{
+		metric:  metric,
+		attrs:   attrs,
+		entries: expire.NewExpiryMap[*expiryMapEntry[Metric, ValType]](clock, ttl),
+		log:     plog().With("type", fmt.Sprintf("%T", metric)),
 	}
-	exp.log = plog().With("type", fmt.Sprintf("%T", exp))
 	return &exp
 }
 
@@ -76,27 +67,18 @@ func NewExpirer[Record any, OT observer[VT], Metric dataPoint[VT], VT any](
 // s accessed for the first time, a new data point is created.
 // If not, a cached copy is returned and the "last access" cache time is updated.
 // Extra attributes can be explicitly added (e.g. process_cpu_state="wait")
-func (ex *Expirer[Record, OT, Metric, VT]) ForRecord(r Record, extraAttrs ...attribute.KeyValue) Metric {
+func (ex *Expirer[Record, Metric, ValType]) ForRecord(r Record, extraAttrs ...attribute.KeyValue) (Metric, attribute.Set) {
 	recordAttrs, attrValues := ex.recordAttributes(r, extraAttrs...)
-	return ex.entries.GetOrCreate(attrValues, func() Metric {
+	return ex.entries.GetOrCreate(attrValues, func() *expiryMapEntry[Metric, ValType] {
 		ex.log.With("labelValues", attrValues).Debug("storing new metric label set")
-		return ex.instancer(recordAttrs)
-	})
+		return &expiryMapEntry[Metric, ValType]{
+			metric:     ex.metric,
+			attributes: recordAttrs,
+		}
+	}).metric, recordAttrs
 }
 
-func (ex *Expirer[Record, OT, Metric, VT]) Collect(_ context.Context, observer OT) error {
-	if old := ex.entries.DeleteExpired(); len(old) > 0 {
-		ex.log.With("labelValues", old).Debug("deleting old OTEL metric")
-	}
-
-	for _, v := range ex.entries.All() {
-		observer.Observe(v.Load(), metric.WithAttributeSet(v.Attributes()))
-	}
-
-	return nil
-}
-
-func (ex *Expirer[Record, OT, Metric, VT]) recordAttributes(m Record, extraAttrs ...attribute.KeyValue) (attribute.Set, []string) {
+func (ex *Expirer[Record, Metric, ValType]) recordAttributes(m Record, extraAttrs ...attribute.KeyValue) (attribute.Set, []string) {
 	keyVals := make([]attribute.KeyValue, 0, len(ex.attrs)+len(extraAttrs))
 	vals := make([]string, 0, len(ex.attrs)+len(extraAttrs))
 
@@ -113,88 +95,11 @@ func (ex *Expirer[Record, OT, Metric, VT]) recordAttributes(m Record, extraAttrs
 	return attribute.NewSet(keyVals...), vals
 }
 
-type metricAttributes struct {
-	attributes attribute.Set
-}
-
-func (g *metricAttributes) Attributes() attribute.Set {
-	return g.attributes
-}
-
-// IntCounter data point type
-type IntCounter struct {
-	metricAttributes
-	val atomic.Int64
-}
-
-func NewIntCounter(attributes attribute.Set) *IntCounter {
-	return &IntCounter{metricAttributes: metricAttributes{attributes: attributes}}
-}
-func (g *IntCounter) Load() int64 {
-	return g.val.Load()
-}
-
-func (g *IntCounter) Add(v int64) {
-	g.val.Add(v)
-}
-
-// FloatCounter is a Counter metric for float64 values
-type FloatCounter struct {
-	metricAttributes
-	mt  sync.RWMutex
-	val float64
-}
-
-func NewFloatCounter(attributes attribute.Set) *FloatCounter {
-	return &FloatCounter{metricAttributes: metricAttributes{attributes: attributes}}
-}
-
-func (g *FloatCounter) Load() float64 {
-	g.mt.RLock()
-	defer g.mt.RUnlock()
-	return g.val
-}
-
-func (g *FloatCounter) Add(v float64) {
-	g.mt.Lock()
-	defer g.mt.Unlock()
-	g.val += v
-}
-
-// Gauge data point type
-type Gauge struct {
-	metricAttributes
-	// Go standard library does not provide atomic packages so we need to
-	// store the float as bytes and then convert it with the math package
-	floatBits uint64
-}
-
-func NewGauge(attributes attribute.Set) *Gauge {
-	return &Gauge{metricAttributes: metricAttributes{attributes: attributes}}
-}
-
-func (g *Gauge) Load() float64 {
-	return math.Float64frombits(atomic.LoadUint64(&g.floatBits))
-}
-
-func (g *Gauge) Set(val float64) {
-	atomic.StoreUint64(&g.floatBits, math.Float64bits(val))
-}
-
-// IntGauge is a gauge whose values are integers
-type IntGauge struct {
-	metricAttributes
-	val atomic.Int64
-}
-
-func NewIntGauge(attributes attribute.Set) *IntGauge {
-	return &IntGauge{metricAttributes: metricAttributes{attributes: attributes}}
-}
-
-func (g *IntGauge) Load() int64 {
-	return g.val.Load()
-}
-
-func (g *IntGauge) Set(v int64) {
-	g.val.Store(v)
+func (ex *Expirer[Record, Metric, ValType]) RemoveOutdated(ctx context.Context) {
+	if old := ex.entries.DeleteExpired(); len(old) > 0 {
+		for _, om := range old {
+			ex.log.Debug("deleting old OTEL metric", "labelValues", om)
+			om.metric.Remove(ctx, metric.WithAttributeSet(om.attributes))
+		}
+	}
 }

--- a/pkg/internal/export/otel/expirer_test.go
+++ b/pkg/internal/export/otel/expirer_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/test/collector"
 )
 
 const timeout = 20 * time.Second
 
-func TestMetricsExpiration(t *testing.T) {
+func TestNetMetricsExpiration(t *testing.T) {
 	defer restoreEnvAfterExecution()()
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
@@ -68,14 +69,14 @@ func TestMetricsExpiration(t *testing.T) {
 		assert.Equal(t, map[string]string{"src.name": "baz", "dst.name": "bae"}, metric.Attributes)
 		assert.EqualValues(t, 456, metric.IntVal)
 	})
-	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
+	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
 	now.Advance(2 * time.Minute)
 	metrics <- []*ebpf.Record{
 		{Attrs: ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
 			NetFlowRecordT: ebpf.NetFlowRecordT{Metrics: ebpf.NetFlowMetrics{Bytes: 123}}},
 	}
 
-	// THEN THE metrics that have been received during the timeout period are still visible
+	// THEN THE metrics that have been received during the TTL period are still visible
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		assert.Equal(t, map[string]string{"src.name": "foo", "dst.name": "bar"}, metric.Attributes)
@@ -116,6 +117,114 @@ func TestMetricsExpiration(t *testing.T) {
 		metric := readChan(t, otlp.Records(), timeout)
 		assert.Equal(t, map[string]string{"src.name": "baz", "dst.name": "bae"}, metric.Attributes)
 		assert.EqualValues(t, 456, metric.IntVal)
+	})
+}
+
+func TestAppMetricsExpiration(t *testing.T) {
+	defer restoreEnvAfterExecution()()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	otelExporter, err := ReportMetrics(
+		ctx,
+		&global.ContextInfo{}, &MetricsConfig{
+			Interval:          50 * time.Millisecond,
+			CommonEndpoint:    otlp.ServerEndpoint,
+			MetricsProtocol:   ProtocolHTTPProtobuf,
+			Features:          []string{FeatureApplication},
+			TTL:               3 * time.Minute,
+			ReportersCacheLen: 100,
+		}, attributes.Selection{
+			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
+				Include: []string{"url.path"},
+			},
+		})()
+
+	require.NoError(t, err)
+
+	metrics := make(chan []request.Span, 20)
+	go otelExporter(metrics)
+
+	// WHEN it receives metrics
+	metrics <- []request.Span{
+		{Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 100, End: 200},
+		{Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 150, End: 175},
+	}
+
+	// THEN the metrics are exported
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		metric := readChan(t, otlp.Records(), timeout)
+		assert.Equal(t, "http.server.request.duration", metric.Name)
+		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.EqualValues(t, 100/float64(time.Second), metric.FloatVal)
+	})
+
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		metric := readChan(t, otlp.Records(), timeout)
+		require.Equal(t, "http.server.request.duration", metric.Name)
+		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.EqualValues(t, 25/float64(time.Second), metric.FloatVal)
+	})
+
+	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
+	now.Advance(2 * time.Minute)
+	metrics <- []request.Span{
+		{Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 250, End: 280},
+	}
+
+	// THEN THE metrics that have been received during the TTL period are still visible
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		metric := readChan(t, otlp.Records(), timeout)
+		require.Equal(t, "http.server.request.duration", metric.Name)
+		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.EqualValues(t, 130/float64(time.Second), metric.FloatVal)
+	})
+
+	now.Advance(2 * time.Minute)
+	metrics <- []request.Span{
+		{Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 300, End: 310},
+	}
+
+	// makes sure that the records channel is emptied and any remaining
+	// old metric is sent and then the channel is re-emptied
+	otlp.ResetRecords()
+	readChan(t, otlp.Records(), timeout)
+	otlp.ResetRecords()
+
+	// BUT not the metrics that haven't been received during that time.
+	// We just know it because OTEL will only sends foo/bar metric.
+	// If this test is flaky: it means it is actually failing
+	// repeating 10 times to make sure that only this metric is forwarded
+	for i := 0; i < 10; i++ {
+		metric := readChan(t, otlp.Records(), timeout)
+		if metric.Name != "http.server.request.duration" {
+			// ignore other HTTP metrics (e.g. request size)
+			i--
+			continue
+		}
+		require.Equal(t, "http.server.request.duration", metric.Name)
+		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.EqualValues(t, 140/float64(time.Second), metric.FloatVal)
+	}
+
+	// AND WHEN the metrics labels that disappeared are received again
+	now.Advance(2 * time.Minute)
+	metrics <- []request.Span{
+		{Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 450, End: 520},
+	}
+
+	// THEN they are reported again, starting from zero in the case of counters
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		metric := readChan(t, otlp.Records(), timeout)
+		require.Equal(t, "http.server.request.duration", metric.Name)
+		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.EqualValues(t, 70/float64(time.Second), metric.FloatVal)
 	})
 }
 

--- a/pkg/internal/export/otel/expirer_test.go
+++ b/pkg/internal/export/otel/expirer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
@@ -31,6 +30,7 @@ func TestMetricsExpiration(t *testing.T) {
 	timeNow = now.Now
 
 	otelExporter, err := NetMetricsExporterProvider(
+		ctx,
 		&global.ContextInfo{}, &NetMetricsConfig{
 			Metrics: &MetricsConfig{
 				Interval:        50 * time.Millisecond,
@@ -104,38 +104,6 @@ func TestMetricsExpiration(t *testing.T) {
 		assert.Equal(t, map[string]string{"src.name": "baz", "dst.name": "bae"}, metric.Attributes)
 		assert.EqualValues(t, 456, metric.IntVal)
 	})
-}
-
-func TestGauge(t *testing.T) {
-	g := NewGauge(attribute.Set{})
-	g.Set(123.456)
-	assert.Equal(t, 123.456, g.Load())
-	g.Set(456.123)
-	assert.Equal(t, 456.123, g.Load())
-}
-
-func TestIntGauge(t *testing.T) {
-	g := NewIntGauge(attribute.Set{})
-	g.Set(123)
-	assert.EqualValues(t, 123, g.Load())
-	g.Set(456)
-	assert.EqualValues(t, 456, g.Load())
-}
-
-func TestIntCounter(t *testing.T) {
-	g := NewIntCounter(attribute.Set{})
-	g.Add(123)
-	assert.EqualValues(t, 123, g.Load())
-	g.Add(123)
-	assert.EqualValues(t, 246, g.Load())
-}
-
-func TestFloatCounter(t *testing.T) {
-	g := NewFloatCounter(attribute.Set{})
-	g.Add(123.4)
-	assert.EqualValues(t, 123.4, g.Load())
-	g.Add(123.3)
-	assert.EqualValues(t, 246.7, g.Load())
 }
 
 type syncedClock struct {

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -336,63 +336,63 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 		return fmt.Errorf("creating http duration histogram metric: %w", err)
 	}
 	m.httpDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		httpDuration, mr.attrHTTPDuration, timeNow, mr.cfg.TTL)
+		m.ctx, httpDuration, mr.attrHTTPDuration, timeNow, mr.cfg.TTL)
 
 	httpClientDuration, err := meter.Float64Histogram(attributes.HTTPClientDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating http duration histogram metric: %w", err)
 	}
 	m.httpClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		httpClientDuration, mr.attrHTTPClientDuration, timeNow, mr.cfg.TTL)
+		m.ctx, httpClientDuration, mr.attrHTTPClientDuration, timeNow, mr.cfg.TTL)
 
 	grpcDuration, err := meter.Float64Histogram(attributes.RPCServerDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating grpc duration histogram metric: %w", err)
 	}
 	m.grpcDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		grpcDuration, mr.attrGRPCServer, timeNow, mr.cfg.TTL)
+		m.ctx, grpcDuration, mr.attrGRPCServer, timeNow, mr.cfg.TTL)
 
 	grpcClientDuration, err := meter.Float64Histogram(attributes.RPCClientDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating grpc duration histogram metric: %w", err)
 	}
 	m.grpcClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		grpcClientDuration, mr.attrGRPCClient, timeNow, mr.cfg.TTL)
+		m.ctx, grpcClientDuration, mr.attrGRPCClient, timeNow, mr.cfg.TTL)
 
 	dbClientDuration, err := meter.Float64Histogram(attributes.DBClientDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating db client duration histogram metric: %w", err)
 	}
 	m.dbClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		dbClientDuration, mr.attrDBClient, timeNow, mr.cfg.TTL)
+		m.ctx, dbClientDuration, mr.attrDBClient, timeNow, mr.cfg.TTL)
 
 	msgPublishDuration, err := meter.Float64Histogram(attributes.MessagingPublishDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating messaging client publish duration histogram metric: %w", err)
 	}
 	m.msgPublishDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		msgPublishDuration, mr.attrMessagingPublish, timeNow, mr.cfg.TTL)
+		m.ctx, msgPublishDuration, mr.attrMessagingPublish, timeNow, mr.cfg.TTL)
 
 	msgProcessDuration, err := meter.Float64Histogram(attributes.MessagingProcessDuration.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating messaging client process duration histogram metric: %w", err)
 	}
 	m.msgProcessDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		msgProcessDuration, mr.attrMessagingProcess, timeNow, mr.cfg.TTL)
+		m.ctx, msgProcessDuration, mr.attrMessagingProcess, timeNow, mr.cfg.TTL)
 
 	httpRequestSize, err := meter.Float64Histogram(attributes.HTTPServerRequestSize.OTEL, instrument.WithUnit("By"))
 	if err != nil {
 		return fmt.Errorf("creating http size histogram metric: %w", err)
 	}
 	m.httpRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		httpRequestSize, mr.attrHTTPRequestSize, timeNow, mr.cfg.TTL)
+		m.ctx, httpRequestSize, mr.attrHTTPRequestSize, timeNow, mr.cfg.TTL)
 
 	httpClientRequestSize, err := meter.Float64Histogram(attributes.HTTPClientRequestSize.OTEL, instrument.WithUnit("By"))
 	if err != nil {
 		return fmt.Errorf("creating http size histogram metric: %w", err)
 	}
 	m.httpClientRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		httpClientRequestSize, mr.attrHTTPClientRequestSize, timeNow, mr.cfg.TTL)
+		m.ctx, httpClientRequestSize, mr.attrHTTPClientRequestSize, timeNow, mr.cfg.TTL)
 
 	return nil
 }

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -682,14 +682,6 @@ func (mr *MetricsReporter) serviceGraphAttributes(span *request.Span) attribute.
 	return attribute.NewSet(attrs...)
 }
 
-func getAttributes(span *request.Span, getters []attributes.Field[*request.Span, attribute.KeyValue]) []attribute.KeyValue {
-	attributes := make([]attribute.KeyValue, 0, len(getters))
-	for _, get := range getters {
-		attributes = append(attributes, get.Get(span))
-	}
-	return attributes
-}
-
 // nolint:cyclop
 func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 	t := span.Timings()

--- a/pkg/internal/export/otel/metrics_net.go
+++ b/pkg/internal/export/otel/metrics_net.go
@@ -60,15 +60,24 @@ func newMeterProvider(res *resource.Resource, exporter *metric.Exporter, interva
 }
 
 type netMetricsExporter struct {
-	metrics *Expirer[*ebpf.Record, metric2.Int64Observer, *IntCounter, int64]
+	ctx     context.Context
+	metrics *Expirer[*ebpf.Record, metric2.Int64Counter, float64]
 	clock   *expire.CachedClock
 }
 
-func NetMetricsExporterProvider(ctxInfo *global.ContextInfo, cfg *NetMetricsConfig) (pipe.FinalFunc[[]*ebpf.Record], error) {
+func NetMetricsExporterProvider(ctx context.Context, ctxInfo *global.ContextInfo, cfg *NetMetricsConfig) (pipe.FinalFunc[[]*ebpf.Record], error) {
 	if !cfg.Enabled() {
 		// This node is not going to be instantiated. Let the pipes library just ignore it.
 		return pipe.IgnoreFinal[[]*ebpf.Record](), nil
 	}
+	exporter, err := newMetricsExporter(ctx, ctxInfo, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return exporter.Do, nil
+}
+
+func newMetricsExporter(ctx context.Context, ctxInfo *global.ContextInfo, cfg *NetMetricsConfig) (*netMetricsExporter, error) {
 	log := nmlog()
 	log.Debug("instantiating network metrics exporter provider")
 	exporter, err := InstantiateMetricsExporter(context.Background(), cfg.Metrics, log)
@@ -93,31 +102,31 @@ func NetMetricsExporterProvider(ctxInfo *global.ContextInfo, cfg *NetMetricsConf
 		attrProv.For(attributes.BeylaNetworkFlow))
 
 	clock := expire.NewCachedClock(timeNow)
-	expirer := NewExpirer[*ebpf.Record, metric2.Int64Observer](NewIntCounter, attrs, clock.Time, cfg.Metrics.TTL)
-	ebpfEvents := provider.Meter("network_ebpf_events")
 
-	_, err = ebpfEvents.Int64ObservableCounter(
-		attributes.BeylaNetworkFlow.OTEL,
+	ebpfEvents := provider.Meter("network_ebpf_events")
+	bytesMetric, err := ebpfEvents.Int64Counter(attributes.BeylaNetworkFlow.OTEL,
 		metric2.WithDescription("total bytes_sent value of network flows observed by probe since its launch"),
-		metric2.WithUnit("{bytes}"),
-		metric2.WithInt64Callback(expirer.Collect),
+		metric2.WithUnit("{bytes}"), // TODO: By?
 	)
 	if err != nil {
 		log.Error("creating observable counter", "error", err)
 		return nil, err
 	}
+	expirer := NewExpirer[*ebpf.Record, metric2.Int64Counter, float64](bytesMetric, attrs, clock.Time, cfg.Metrics.TTL)
 	log.Debug("restricting attributes not in this list", "attributes", cfg.AttributeSelectors)
-	return (&netMetricsExporter{
+	return &netMetricsExporter{
+		ctx:     ctx,
 		metrics: expirer,
 		clock:   clock,
-	}).Do, nil
+	}, nil
 }
 
 func (me *netMetricsExporter) Do(in <-chan []*ebpf.Record) {
 	for i := range in {
 		me.clock.Update()
 		for _, v := range i {
-			me.metrics.ForRecord(v).Add(int64(v.Metrics.Bytes))
+			flowBytes, attrs := me.metrics.ForRecord(v)
+			flowBytes.Add(me.ctx, int64(v.Metrics.Bytes), metric2.WithAttributeSet(attrs))
 		}
 	}
 }

--- a/pkg/internal/export/otel/metrics_net_test.go
+++ b/pkg/internal/export/otel/metrics_net_test.go
@@ -104,6 +104,10 @@ func TestMetricAttributes_Filter(t *testing.T) {
 				"k8s.src.name",
 				"k8s.dst.name",
 			}},
+		}, Metrics: &MetricsConfig{
+			MetricsEndpoint:   "http://foo",
+			Interval:          10 * time.Millisecond,
+			ReportersCacheLen: 100,
 		}})
 	require.NoError(t, err)
 

--- a/pkg/internal/export/otel/metrics_net_test.go
+++ b/pkg/internal/export/otel/metrics_net_test.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,11 @@ func TestMetricAttributes(t *testing.T) {
 		&global.ContextInfo{},
 		&NetMetricsConfig{AttributeSelectors: map[attributes.Section]attributes.InclusionLists{
 			attributes.BeylaNetworkFlow.Section: {Include: []string{"*"}},
+		}, Metrics: &MetricsConfig{
+			MetricsEndpoint:   "http://foo",
+			Interval:          10 * time.Millisecond,
+			ReportersCacheLen: 100,
+			TTL:               5 * time.Minute,
 		}})
 	require.NoError(t, err)
 

--- a/pkg/internal/export/otel/metrics_net_test.go
+++ b/pkg/internal/export/otel/metrics_net_test.go
@@ -40,7 +40,7 @@ func TestMetricAttributes(t *testing.T) {
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
 	me, err := newMetricsExporter(context.Background(),
-		&global.ContextInfo{},
+		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
 		&NetMetricsConfig{AttributeSelectors: map[attributes.Section]attributes.InclusionLists{
 			attributes.BeylaNetworkFlow.Section: {Include: []string{"*"}},
 		}, Metrics: &MetricsConfig{
@@ -97,7 +97,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
 	me, err := newMetricsExporter(context.Background(),
-		&global.ContextInfo{},
+		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
 		&NetMetricsConfig{AttributeSelectors: map[attributes.Section]attributes.InclusionLists{
 			attributes.BeylaNetworkFlow.Section: {Include: []string{
 				"src.address",

--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -210,7 +210,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.cpuTime = NewExpirer[*process.Status, metric2.Float64Counter, float64](
-			cpuTime, me.attrCPUTime, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, cpuTime, me.attrCPUTime, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	if cpuUtilisation, err := meter.Float64Gauge(
@@ -222,7 +222,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.cpuUtilisation = NewExpirer[*process.Status, metric2.Float64Gauge, float64](
-			cpuUtilisation, me.attrCPUUtil, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, cpuUtilisation, me.attrCPUUtil, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	// memory metrics are defined as UpDownCounters in the Otel specification, but we
@@ -237,7 +237,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.memory = NewExpirer[*process.Status, metric2.Int64UpDownCounter, int64](
-			memory, me.attrMemory, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, memory, me.attrMemory, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	if memoryVirtual, err := meter.Int64UpDownCounter(
@@ -249,7 +249,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.memoryVirtual = NewExpirer[*process.Status, metric2.Int64UpDownCounter, int64](
-			memoryVirtual, me.attrMemoryVirtual, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, memoryVirtual, me.attrMemoryVirtual, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	if disk, err := meter.Int64Counter(
@@ -261,7 +261,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.disk = NewExpirer[*process.Status, metric2.Int64Counter, int64](
-			disk, me.attrDisk, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, disk, me.attrDisk, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	if net, err := meter.Int64Counter(
@@ -273,7 +273,7 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 		return nil, err
 	} else {
 		m.net = NewExpirer[*process.Status, metric2.Int64Counter, int64](
-			net, me.attrNet, timeNow, me.cfg.Metrics.TTL)
+			me.ctx, net, me.attrNet, timeNow, me.cfg.Metrics.TTL)
 	}
 	return &m, nil
 }

--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -65,13 +65,13 @@ type procMetricsExporter struct {
 
 	// the observation code for CPU metrics will be different depending on
 	// the "process.cpu.state" attribute being selected or not
-	cpuTimeObserver        func(*procMetrics, *process.Status)
-	cpuUtilisationObserver func(*procMetrics, *process.Status)
+	cpuTimeObserver        func(context.Context, *procMetrics, *process.Status)
+	cpuUtilisationObserver func(context.Context, *procMetrics, *process.Status)
 
 	// the observation code for disk and network metrics will be different depending on
 	// the *.io.direction attributes being selected or not
-	diskObserver func(*procMetrics, *process.Status)
-	netObserver  func(*procMetrics, *process.Status)
+	diskObserver func(context.Context, *procMetrics, *process.Status)
+	netObserver  func(context.Context, *procMetrics, *process.Status)
 }
 
 type procMetrics struct {
@@ -79,12 +79,12 @@ type procMetrics struct {
 	service  *svc.ID
 	provider *metric.MeterProvider
 
-	cpuTime        *Expirer[*process.Status, metric2.Float64Observer, *FloatCounter, float64]
-	cpuUtilisation *Expirer[*process.Status, metric2.Float64Observer, *Gauge, float64]
-	memory         *Expirer[*process.Status, metric2.Int64Observer, *IntGauge, int64]
-	memoryVirtual  *Expirer[*process.Status, metric2.Int64Observer, *IntGauge, int64]
-	disk           *Expirer[*process.Status, metric2.Int64Observer, *IntCounter, int64]
-	net            *Expirer[*process.Status, metric2.Int64Observer, *IntCounter, int64]
+	cpuTime        *Expirer[*process.Status, metric2.Float64Counter, float64]
+	cpuUtilisation *Expirer[*process.Status, metric2.Float64Gauge, float64]
+	memory         *Expirer[*process.Status, metric2.Int64UpDownCounter, int64]
+	memoryVirtual  *Expirer[*process.Status, metric2.Int64UpDownCounter, int64]
+	disk           *Expirer[*process.Status, metric2.Int64Counter, int64]
+	net            *Expirer[*process.Status, metric2.Int64Counter, int64]
 }
 
 func ProcMetricsExporterProvider(
@@ -202,76 +202,78 @@ func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, erro
 
 	meter := m.provider.Meter(reporterName)
 
-	m.cpuTime = NewExpirer[*process.Status, metric2.Float64Observer](
-		NewFloatCounter, me.attrCPUTime, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Float64ObservableCounter(
+	if cpuTime, err := meter.Float64Counter(
 		attributes.ProcessCPUTime.OTEL, metric2.WithUnit("s"),
 		metric2.WithDescription("Total CPU seconds broken down by different states"),
-		metric2.WithFloat64Callback(m.cpuTime.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessCPUUtilization.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.cpuTime = NewExpirer[*process.Status, metric2.Float64Counter, float64](
+			cpuTime, me.attrCPUTime, timeNow, me.cfg.Metrics.TTL)
 	}
 
-	m.cpuUtilisation = NewExpirer[*process.Status, metric2.Float64Observer](
-		NewGauge, me.attrCPUUtil, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Float64ObservableGauge(
+	if cpuUtilisation, err := meter.Float64Gauge(
 		attributes.ProcessCPUUtilization.OTEL,
 		metric2.WithDescription("Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process"),
 		metric2.WithUnit("1"),
-		metric2.WithFloat64Callback(m.cpuUtilisation.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessCPUUtilization.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.cpuUtilisation = NewExpirer[*process.Status, metric2.Float64Gauge, float64](
+			cpuUtilisation, me.attrCPUUtil, timeNow, me.cfg.Metrics.TTL)
 	}
 
 	// memory metrics are defined as UpDownCounters in the Otel specification, but we
 	// internally treat them as gauges, as it's aligned to what we get from the /proc filesystem
-	m.memory = NewExpirer[*process.Status, metric2.Int64Observer](
-		NewIntGauge, me.attrMemory, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Int64ObservableUpDownCounter(
+
+	if memory, err := meter.Int64UpDownCounter(
 		attributes.ProcessMemoryUsage.OTEL,
 		metric2.WithDescription("The amount of physical memory in use"),
 		metric2.WithUnit("By"),
-		metric2.WithInt64Callback(m.memory.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessMemoryUsage.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.memory = NewExpirer[*process.Status, metric2.Int64UpDownCounter, int64](
+			memory, me.attrMemory, timeNow, me.cfg.Metrics.TTL)
 	}
-	// memory metrics are defined as UpDownCounters in the Otel specification, but we
-	// internally treat them as gauges, as it's aligned to what we get from the /proc filesystem
-	m.memoryVirtual = NewExpirer[*process.Status, metric2.Int64Observer](
-		NewIntGauge, me.attrMemory, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Int64ObservableUpDownCounter(
+
+	if memoryVirtual, err := meter.Int64UpDownCounter(
 		attributes.ProcessMemoryVirtual.OTEL,
 		metric2.WithDescription("The amount of committed virtual memory"),
 		metric2.WithUnit("By"),
-		metric2.WithInt64Callback(m.memoryVirtual.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessMemoryVirtual.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.memoryVirtual = NewExpirer[*process.Status, metric2.Int64UpDownCounter, int64](
+			memoryVirtual, me.attrMemoryVirtual, timeNow, me.cfg.Metrics.TTL)
 	}
-	m.disk = NewExpirer[*process.Status, metric2.Int64Observer](
-		NewIntCounter, me.attrDisk, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Int64ObservableCounter(
+
+	if disk, err := meter.Int64Counter(
 		attributes.ProcessDiskIO.OTEL,
 		metric2.WithDescription("Disk bytes transferred"),
 		metric2.WithUnit("By"),
-		metric2.WithInt64Callback(m.disk.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessMemoryVirtual.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.disk = NewExpirer[*process.Status, metric2.Int64Counter, int64](
+			disk, me.attrDisk, timeNow, me.cfg.Metrics.TTL)
 	}
-	m.net = NewExpirer[*process.Status, metric2.Int64Observer](
-		NewIntCounter, me.attrNet, timeNow, me.cfg.Metrics.TTL)
-	if _, err := meter.Int64ObservableCounter(
+
+	if net, err := meter.Int64Counter(
 		attributes.ProcessNetIO.OTEL,
 		metric2.WithDescription("Network bytes transferred"),
 		metric2.WithUnit("By"),
-		metric2.WithInt64Callback(m.net.Collect),
 	); err != nil {
 		log.Error("creating observable gauge for "+attributes.ProcessMemoryVirtual.OTEL, "error", err)
 		return nil, err
+	} else {
+		m.net = NewExpirer[*process.Status, metric2.Int64Counter, int64](
+			net, me.attrNet, timeNow, me.cfg.Metrics.TTL)
 	}
 	return &m, nil
 }
@@ -295,55 +297,70 @@ func (me *procMetricsExporter) Do(in <-chan []*process.Status) {
 func (me *procMetricsExporter) observeMetric(reporter *procMetrics, s *process.Status) {
 	me.log.Debug("reporting data for record", "record", s)
 
-	me.cpuTimeObserver(reporter, s)
-	me.cpuUtilisationObserver(reporter, s)
-	reporter.memory.ForRecord(s).Set(s.MemoryRSSBytes)
-	reporter.memoryVirtual.ForRecord(s).Set(s.MemoryVMSBytes)
+	me.cpuTimeObserver(me.ctx, reporter, s)
+	me.cpuUtilisationObserver(me.ctx, reporter, s)
 
-	me.diskObserver(reporter, s)
-	me.netObserver(reporter, s)
+	mem, attrs := reporter.memory.ForRecord(s)
+	mem.Add(me.ctx, s.MemoryRSSBytes, metric2.WithAttributeSet(attrs))
+
+	me.diskObserver(me.ctx, reporter, s)
+	me.netObserver(me.ctx, reporter, s)
 }
 
 // aggregated observers report all the CPU metrics in a single data point
 // to be triggered when the user disables the "process_cpu_state" metric
-func cpuTimeAggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.cpuTime.ForRecord(record).
-		Add(record.CPUTimeUserDelta + record.CPUTimeSystemDelta + record.CPUTimeWaitDelta)
+func cpuTimeAggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	cpu, attrs := reporter.cpuTime.ForRecord(record)
+	cpu.Add(ctx, record.CPUTimeUserDelta+record.CPUTimeSystemDelta+record.CPUTimeWaitDelta,
+		metric2.WithAttributeSet(attrs))
 }
 
-func cpuUtilisationAggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.cpuUtilisation.ForRecord(record).
-		Set(record.CPUUtilisationUser + record.CPUUtilisationSystem + record.CPUUtilisationWait)
+func cpuUtilisationAggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	cpu, attrs := reporter.cpuUtilisation.ForRecord(record)
+	cpu.Record(ctx, record.CPUUtilisationUser+record.CPUUtilisationSystem+record.CPUUtilisationWait,
+		metric2.WithAttributeSet(attrs))
 }
 
 // disaggregated observers report three CPU metrics: system, user and wait time
 // to be triggered when the user enables the "process_cpu_state" metric
-func cpuTimeDisaggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.cpuTime.ForRecord(record, stateWaitAttr).Add(record.CPUTimeWaitDelta)
-	reporter.cpuTime.ForRecord(record, stateUserAttr).Add(record.CPUTimeUserDelta)
-	reporter.cpuTime.ForRecord(record, stateSystemAttr).Add(record.CPUTimeSystemDelta)
+func cpuTimeDisaggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	cpu, attrs := reporter.cpuTime.ForRecord(record, stateWaitAttr)
+	cpu.Add(ctx, record.CPUTimeWaitDelta, metric2.WithAttributeSet(attrs))
+	cpu, attrs = reporter.cpuTime.ForRecord(record, stateUserAttr)
+	cpu.Add(ctx, record.CPUTimeUserDelta, metric2.WithAttributeSet(attrs))
+	cpu, attrs = reporter.cpuTime.ForRecord(record, stateSystemAttr)
+	cpu.Add(ctx, record.CPUTimeSystemDelta, metric2.WithAttributeSet(attrs))
 }
 
-func cpuUtilisationDisaggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.cpuUtilisation.ForRecord(record, stateWaitAttr).Set(record.CPUUtilisationWait)
-	reporter.cpuUtilisation.ForRecord(record, stateUserAttr).Set(record.CPUUtilisationUser)
-	reporter.cpuUtilisation.ForRecord(record, stateSystemAttr).Set(record.CPUUtilisationSystem)
+func cpuUtilisationDisaggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	cpu, attrs := reporter.cpuUtilisation.ForRecord(record, stateWaitAttr)
+	cpu.Record(ctx, record.CPUUtilisationWait, metric2.WithAttributeSet(attrs))
+	cpu, attrs = reporter.cpuUtilisation.ForRecord(record, stateUserAttr)
+	cpu.Record(ctx, record.CPUUtilisationUser, metric2.WithAttributeSet(attrs))
+	cpu, attrs = reporter.cpuUtilisation.ForRecord(record, stateSystemAttr)
+	cpu.Record(ctx, record.CPUUtilisationSystem, metric2.WithAttributeSet(attrs))
 }
 
-func diskAggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.disk.ForRecord(record).Add(int64(record.IOReadBytesDelta + record.IOWriteBytesDelta))
+func diskAggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	disk, attrs := reporter.disk.ForRecord(record)
+	disk.Add(ctx, int64(record.IOReadBytesDelta+record.IOWriteBytesDelta), metric2.WithAttributeSet(attrs))
 }
 
-func diskDisaggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.disk.ForRecord(record, diskIODirRead).Add(int64(record.IOReadBytesDelta))
-	reporter.disk.ForRecord(record, diskIODirWrite).Add(int64(record.IOWriteBytesDelta))
+func diskDisaggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	disk, attrs := reporter.disk.ForRecord(record, diskIODirRead)
+	disk.Add(ctx, int64(record.IOReadBytesDelta), metric2.WithAttributeSet(attrs))
+	disk, attrs = reporter.disk.ForRecord(record, diskIODirWrite)
+	disk.Add(ctx, int64(record.IOWriteBytesDelta), metric2.WithAttributeSet(attrs))
 }
 
-func netAggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.net.ForRecord(record).Add(record.NetTxBytesDelta + record.NetRcvBytesDelta)
+func netAggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	net, attrs := reporter.net.ForRecord(record)
+	net.Add(ctx, record.NetTxBytesDelta+record.NetRcvBytesDelta, metric2.WithAttributeSet(attrs))
 }
 
-func netDisaggregatedObserver(reporter *procMetrics, record *process.Status) {
-	reporter.net.ForRecord(record, netIODirTx).Add(record.NetTxBytesDelta)
-	reporter.net.ForRecord(record, netIODirRcv).Add(record.NetRcvBytesDelta)
+func netDisaggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
+	net, attrs := reporter.net.ForRecord(record, netIODirTx)
+	net.Add(ctx, record.NetTxBytesDelta, metric2.WithAttributeSet(attrs))
+	net, attrs = reporter.net.ForRecord(record, netIODirRcv)
+	net.Add(ctx, record.NetRcvBytesDelta, metric2.WithAttributeSet(attrs))
 }

--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -303,6 +303,9 @@ func (me *procMetricsExporter) observeMetric(reporter *procMetrics, s *process.S
 	mem, attrs := reporter.memory.ForRecord(s)
 	mem.Add(me.ctx, s.MemoryRSSBytes, metric2.WithAttributeSet(attrs))
 
+	vmem, attrs := reporter.memoryVirtual.ForRecord(s)
+	vmem.Add(me.ctx, s.MemoryVMSBytes, metric2.WithAttributeSet(attrs))
+
 	me.diskObserver(me.ctx, reporter, s)
 	me.netObserver(me.ctx, reporter, s)
 }

--- a/pkg/internal/export/otel/metrics_proc_test.go
+++ b/pkg/internal/export/otel/metrics_proc_test.go
@@ -67,49 +67,49 @@ func TestProcMetrics_Aggregated(t *testing.T) {
 
 	// THEN the metrics are exported adding system/user/wait times into a single datapoint
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 60, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 603, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 6, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 63, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.disk.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 123+456, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.disk.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 321+654, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.network.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 33, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.network.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 3, metric.IntVal)
@@ -127,37 +127,37 @@ func TestProcMetrics_Aggregated(t *testing.T) {
 
 	// THEN the counter is updated by adding values and the gauges change their values
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 66, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 603, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 7, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "bar"}, metric.Attributes)
 		require.EqualValues(t, 63, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.disk.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 123+456+1+2, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.network.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo"}, metric.Attributes)
 		require.EqualValues(t, 63, metric.IntVal)
@@ -209,67 +209,67 @@ func TestProcMetrics_Disaggregated(t *testing.T) {
 
 	// THEN the metrics are exported aggregated by system/user/wait times
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "user"}, metric.Attributes)
 		require.EqualValues(t, 30, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "system"}, metric.Attributes)
 		require.EqualValues(t, 10, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "wait"}, metric.Attributes)
 		require.EqualValues(t, 20, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "user"}, metric.Attributes)
 		require.EqualValues(t, 1, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "system"}, metric.Attributes)
 		require.EqualValues(t, 2, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, map[string]string{
 			"process.command": "foo", "process.cpu.state": "wait"}, metric.Attributes)
 		require.EqualValues(t, 3, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.disk.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo", "disk.io.direction": "write"}, metric.Attributes)
 		require.EqualValues(t, 456, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.disk.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo", "disk.io.direction": "read"}, metric.Attributes)
 		require.EqualValues(t, 123, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.network.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo", "network.io.direction": "receive"}, metric.Attributes)
 		require.EqualValues(t, 10, metric.IntVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		metric := readChan(t, otlp.Records, timeout)
+		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.network.io", metric.Name)
 		require.Equal(t, map[string]string{"process.command": "foo", "network.io.direction": "transmit"}, metric.Attributes)
 		require.EqualValues(t, 20, metric.IntVal)

--- a/pkg/internal/export/prom/prom_net.go
+++ b/pkg/internal/export/prom/prom_net.go
@@ -119,5 +119,5 @@ func (r *netMetricsReporter) observe(flow *ebpf.Record) {
 	for _, attr := range r.attrs {
 		labelValues = append(labelValues, attr.Get(flow))
 	}
-	r.flowBytes.WithLabelValues(labelValues...).Add(float64(flow.Metrics.Bytes))
+	r.flowBytes.WithLabelValues(labelValues...).metric.Add(float64(flow.Metrics.Bytes))
 }

--- a/pkg/internal/export/prom/prom_proc.go
+++ b/pkg/internal/export/prom/prom_proc.go
@@ -203,9 +203,9 @@ func (r *procMetricsReporter) observeMetric(proc *process.Status) {
 	r.cpuTimeObserver(proc)
 	r.cpuUtilizationObserver(proc)
 	r.memory.WithLabelValues(labelValues(proc, r.memoryAttrs)...).
-		Set(float64(proc.MemoryRSSBytes))
+		metric.Set(float64(proc.MemoryRSSBytes))
 	r.memoryVirtual.WithLabelValues(labelValues(proc, r.memoryVirtualAttrs)...).
-		Set(float64(proc.MemoryVMSBytes))
+		metric.Set(float64(proc.MemoryVMSBytes))
 	r.diskObserver(proc)
 	r.netObserver(proc)
 }
@@ -214,12 +214,12 @@ func (r *procMetricsReporter) observeMetric(proc *process.Status) {
 // to be triggered when the user disables the "process_cpu_state" metric
 func (r *procMetricsReporter) observeAggregatedCPUTime(proc *process.Status) {
 	r.cpuTime.WithLabelValues(labelValues(proc, r.cpuTimeAttrs)...).
-		Add(proc.CPUTimeUserDelta + proc.CPUTimeSystemDelta + proc.CPUTimeWaitDelta)
+		metric.Add(proc.CPUTimeUserDelta + proc.CPUTimeSystemDelta + proc.CPUTimeWaitDelta)
 }
 
 func (r *procMetricsReporter) observeAggregatedCPUUtilization(proc *process.Status) {
 	r.cpuUtilization.WithLabelValues(labelValues(proc, r.cpuUtilizationAttrs)...).
-		Set(proc.CPUUtilisationUser + proc.CPUUtilisationSystem + proc.CPUUtilisationWait)
+		metric.Set(proc.CPUUtilisationUser + proc.CPUUtilisationSystem + proc.CPUUtilisationWait)
 }
 
 // disaggregated observers report three CPU metrics: system, user and wait time
@@ -228,52 +228,52 @@ func (r *procMetricsReporter) observeDisaggregatedCPUTime(proc *process.Status) 
 	commonLabelValues := labelValues(proc, r.cpuTimeAttrs)
 
 	userLabels := append([]string{"user"}, commonLabelValues...)
-	r.cpuTime.WithLabelValues(userLabels...).Add(proc.CPUTimeUserDelta)
+	r.cpuTime.WithLabelValues(userLabels...).metric.Add(proc.CPUTimeUserDelta)
 
 	systemLabels := append([]string{"system"}, commonLabelValues...)
-	r.cpuTime.WithLabelValues(systemLabels...).Add(proc.CPUTimeSystemDelta)
+	r.cpuTime.WithLabelValues(systemLabels...).metric.Add(proc.CPUTimeSystemDelta)
 
 	waitLabels := append([]string{"wait"}, commonLabelValues...)
-	r.cpuTime.WithLabelValues(waitLabels...).Add(proc.CPUTimeWaitDelta)
+	r.cpuTime.WithLabelValues(waitLabels...).metric.Add(proc.CPUTimeWaitDelta)
 }
 
 func (r *procMetricsReporter) observeDisaggregatedCPUUtilization(proc *process.Status) {
 	commonLabelValues := labelValues(proc, r.cpuUtilizationAttrs)
 
 	userLabels := append([]string{"user"}, commonLabelValues...)
-	r.cpuUtilization.WithLabelValues(userLabels...).Set(proc.CPUUtilisationUser)
+	r.cpuUtilization.WithLabelValues(userLabels...).metric.Set(proc.CPUUtilisationUser)
 
 	systemLabels := append([]string{"system"}, commonLabelValues...)
-	r.cpuUtilization.WithLabelValues(systemLabels...).Set(proc.CPUUtilisationSystem)
+	r.cpuUtilization.WithLabelValues(systemLabels...).metric.Set(proc.CPUUtilisationSystem)
 
 	waitLabels := append([]string{"wait"}, commonLabelValues...)
-	r.cpuUtilization.WithLabelValues(waitLabels...).Set(proc.CPUUtilisationWait)
+	r.cpuUtilization.WithLabelValues(waitLabels...).metric.Set(proc.CPUUtilisationWait)
 }
 
 func (r *procMetricsReporter) observeAggregatedDisk(proc *process.Status) {
 	r.disk.WithLabelValues(labelValues(proc, r.diskAttrs)...).
-		Add(float64(proc.IOReadBytesDelta + proc.IOWriteBytesDelta))
+		metric.Add(float64(proc.IOReadBytesDelta + proc.IOWriteBytesDelta))
 }
 
 func (r *procMetricsReporter) observeDisaggregatedDisk(proc *process.Status) {
 	commonLabels := labelValues(proc, r.diskAttrs)
 	readLabels := append([]string{"read"}, commonLabels...)
-	r.disk.WithLabelValues(readLabels...).Add(float64(proc.IOReadBytesDelta))
+	r.disk.WithLabelValues(readLabels...).metric.Add(float64(proc.IOReadBytesDelta))
 	writeLabels := append([]string{"write"}, commonLabels...)
-	r.disk.WithLabelValues(writeLabels...).Add(float64(proc.IOWriteBytesDelta))
+	r.disk.WithLabelValues(writeLabels...).metric.Add(float64(proc.IOWriteBytesDelta))
 }
 
 func (r *procMetricsReporter) observeAggregatedNet(proc *process.Status) {
 	r.net.WithLabelValues(labelValues(proc, r.netAttrs)...).
-		Add(float64(proc.NetTxBytesDelta + proc.NetRcvBytesDelta))
+		metric.Add(float64(proc.NetTxBytesDelta + proc.NetRcvBytesDelta))
 }
 
 func (r *procMetricsReporter) observeDisaggregatedNet(proc *process.Status) {
 	commonLabels := labelValues(proc, r.netAttrs)
 	readLabels := append([]string{"transmit"}, commonLabels...)
-	r.net.WithLabelValues(readLabels...).Add(float64(proc.NetTxBytesDelta))
+	r.net.WithLabelValues(readLabels...).metric.Add(float64(proc.NetTxBytesDelta))
 	writeLabels := append([]string{"receive"}, commonLabels...)
-	r.net.WithLabelValues(writeLabels...).Add(float64(proc.NetRcvBytesDelta))
+	r.net.WithLabelValues(writeLabels...).metric.Add(float64(proc.NetRcvBytesDelta))
 }
 
 // attributesWithExplicit returns, for a metric name definition,

--- a/pkg/internal/netolly/agent/pipeline.go
+++ b/pkg/internal/netolly/agent/pipeline.go
@@ -133,7 +133,7 @@ func (f *Flows) pipelineBuilder(ctx context.Context) (*pipe.Builder[*FlowsPipeli
 	// whether each node is going to be instantiated or just ignored.
 	f.cfg.Attributes.Select.Normalize()
 	pipe.AddFinalProvider(pb, otelExport, func() (pipe.FinalFunc[[]*ebpf.Record], error) {
-		return otel.NetMetricsExporterProvider(f.ctxInfo, &otel.NetMetricsConfig{
+		return otel.NetMetricsExporterProvider(ctx, f.ctxInfo, &otel.NetMetricsConfig{
 			Metrics:            &f.cfg.Metrics,
 			AttributeSelectors: f.cfg.Attributes.Select,
 		})

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -81,7 +81,7 @@ func TestBasicPipeline(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.Records, testTimeout)
+	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	assert.Equal(t, collector.MetricRecord{
@@ -132,11 +132,11 @@ func TestTracerPipeline(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event := testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerTraceEvent(t, "in queue", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerTraceEvent(t, "processing", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchTraceEvent(t, "GET", event)
 }
 
@@ -166,11 +166,11 @@ func TestTracerReceiverPipeline(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event := testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerTraceEvent(t, "in queue", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerTraceEvent(t, "processing", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchTraceEvent(t, "GET", event)
 }
 
@@ -200,9 +200,9 @@ func BenchmarkTestTracerPipeline(b *testing.B) {
 
 		go pipe.Run(ctx)
 		t := &testing.T{}
-		testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
-		testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
-		testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
+		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
+		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	}
 }
 
@@ -233,7 +233,7 @@ func TestTracerPipelineBadTimestamps(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event := testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchNestedEvent(t, "GET", "GET", "/attach", "200", ptrace.SpanKindServer, event)
 }
 
@@ -271,7 +271,7 @@ func TestRouteConsolidation(t *testing.T) {
 	// expect to receive 3 events without any guaranteed order
 	events := map[string]collector.MetricRecord{}
 	for i := 0; i < 3; i++ {
-		ev := testutil.ReadChannel(t, tc.Records, testTimeout)
+		ev := testutil.ReadChannel(t, tc.Records(), testTimeout)
 		events[ev.Attributes[string(semconv.HTTPRouteKey)]] = ev
 	}
 	for _, event := range events {
@@ -358,7 +358,7 @@ func TestGRPCPipeline(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.Records, testTimeout)
+	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	assert.Equal(t, collector.MetricRecord{
@@ -406,11 +406,11 @@ func TestTraceGRPCPipeline(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event := testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerGRPCTraceEvent(t, "in queue", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInnerGRPCTraceEvent(t, "processing", event)
-	event = testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event = testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchGRPCTraceEvent(t, "foo.bar", event)
 }
 
@@ -437,7 +437,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.Records, testTimeout)
+	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	assert.Equal(t, collector.MetricRecord{
@@ -479,7 +479,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 
 	go pipe.Run(ctx)
 
-	event := testutil.ReadChannel(t, tc.TraceRecords, testTimeout)
+	event := testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
 	matchInfoEvent(t, "PATCH", event)
 }
 
@@ -520,10 +520,10 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 
 	// expect to receive only the records matching the Filters criteria
 	events := map[string]map[string]string{}
-	event := testutil.ReadChannel(t, tc.Records, testTimeout)
+	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.Equal(t, "http.server.request.duration", event.Name)
 	events[event.Attributes["url.path"]] = event.Attributes
-	event = testutil.ReadChannel(t, tc.Records, testTimeout)
+	event = testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.Equal(t, "http.server.request.duration", event.Name)
 	events[event.Attributes["url.path"]] = event.Attributes
 

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -99,7 +99,8 @@ func TestBasicPipeline(t *testing.T) {
 			string(semconv.TelemetrySDKLanguageKey): "go",
 			string(semconv.TelemetrySDKNameKey):     "beyla",
 		},
-		Type: pmetric.MetricTypeHistogram,
+		Type:     pmetric.MetricTypeHistogram,
+		FloatVal: 2 / float64(time.Second),
 	}, event)
 
 }
@@ -326,7 +327,8 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.TelemetrySDKLanguageKey): "go",
 			string(semconv.TelemetrySDKNameKey):     "beyla",
 		},
-		Type: pmetric.MetricTypeHistogram,
+		Type:     pmetric.MetricTypeHistogram,
+		FloatVal: 2 / float64(time.Second),
 	}, events["/**"])
 }
 
@@ -376,7 +378,8 @@ func TestGRPCPipeline(t *testing.T) {
 			string(semconv.TelemetrySDKLanguageKey): "go",
 			string(semconv.TelemetrySDKNameKey):     "beyla",
 		},
-		Type: pmetric.MetricTypeHistogram,
+		Type:     pmetric.MetricTypeHistogram,
+		FloatVal: 2 / float64(time.Second),
 	}, event)
 }
 
@@ -455,7 +458,8 @@ func TestBasicPipelineInfo(t *testing.T) {
 			string(semconv.TelemetrySDKLanguageKey): "go",
 			string(semconv.TelemetrySDKNameKey):     "beyla",
 		},
-		Type: pmetric.MetricTypeHistogram,
+		Type:     pmetric.MetricTypeHistogram,
+		FloatVal: 1 / float64(time.Second),
 	}, event)
 }
 

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -175,10 +175,15 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 					})
 				case pmetric.MetricTypeHistogram:
 					forEach[pmetric.HistogramDataPoint](m.Histogram().DataPoints(), func(hdp pmetric.HistogramDataPoint) {
+						// for simplicity, reporting only sum histogram data
+						if !hdp.HasSum() {
+							return
+						}
 						mr := MetricRecord{
 							Name:               m.Name(),
 							Unit:               m.Unit(),
 							Type:               m.Type(),
+							FloatVal:           hdp.Sum(),
 							Attributes:         map[string]string{},
 							ResourceAttributes: resourceAttrs,
 						}

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sync/atomic"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -23,8 +24,8 @@ import (
 type TestCollector struct {
 	ServerEndpoint string
 	// TODO: add also traces history
-	Records      chan MetricRecord
-	TraceRecords chan TraceRecord
+	records      atomic.Value // chan MetricRecord
+	traceRecords atomic.Value // chan TraceRecord
 }
 
 var log *slog.Logger
@@ -38,10 +39,9 @@ func init() {
 
 func Start(ctx context.Context) (*TestCollector, error) {
 
-	tc := TestCollector{
-		Records:      make(chan MetricRecord, 100),
-		TraceRecords: make(chan TraceRecord, 100),
-	}
+	tc := TestCollector{}
+	tc.ResetRecords()
+	tc.ResetTraceRecords()
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		body, err := io.ReadAll(request.Body)
 		if err != nil {
@@ -110,13 +110,29 @@ func (tc *TestCollector) traceEvent(writer http.ResponseWriter, body []byte) {
 					})
 					// remove ServiceInstanceIDKey to avoid flakiness
 					delete(tr.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
-					tc.TraceRecords <- tr
+					tc.TraceRecords() <- tr
 				default:
 					slog.Warn("unsupported trace kind", "kind", s.Kind().String())
 				}
 			})
 		})
 	})
+}
+
+func (tc *TestCollector) ResetRecords() {
+	tc.records.Store(make(chan MetricRecord, 100))
+}
+
+func (tc *TestCollector) ResetTraceRecords() {
+	tc.traceRecords.Store(make(chan TraceRecord, 100))
+}
+
+func (tc *TestCollector) Records() chan MetricRecord {
+	return tc.records.Load().(chan MetricRecord)
+}
+
+func (tc *TestCollector) TraceRecords() chan TraceRecord {
+	return tc.traceRecords.Load().(chan TraceRecord)
 }
 
 func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
@@ -155,7 +171,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records <- mr
+						tc.Records() <- mr
 					})
 				case pmetric.MetricTypeHistogram:
 					forEach[pmetric.HistogramDataPoint](m.Histogram().DataPoints(), func(hdp pmetric.HistogramDataPoint) {
@@ -170,7 +186,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records <- mr
+						tc.Records() <- mr
 					})
 				case pmetric.MetricTypeGauge:
 					forEach[pmetric.NumberDataPoint](m.Gauge().DataPoints(), func(ndp pmetric.NumberDataPoint) {
@@ -187,7 +203,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records <- mr
+						tc.Records() <- mr
 					})
 				default:
 					slog.Warn("unsupported metric type", "type", m.Type().String())

--- a/vendor/go.opentelemetry.io/otel/CHANGELOG.md
+++ b/vendor/go.opentelemetry.io/otel/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Add a `Remove` method to metric instruments.
+
 ## [1.27.0/0.49.0/0.3.0] 2024-05-21
 
 ### Added

--- a/vendor/go.opentelemetry.io/otel/internal/global/instruments.go
+++ b/vendor/go.opentelemetry.io/otel/internal/global/instruments.go
@@ -229,6 +229,12 @@ func (i *sfCounter) Add(ctx context.Context, incr float64, opts ...metric.AddOpt
 	}
 }
 
+func (i *sfCounter) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Counter).Remove(ctx, opts...)
+	}
+}
+
 type sfUpDownCounter struct {
 	embedded.Float64UpDownCounter
 
@@ -252,6 +258,12 @@ func (i *sfUpDownCounter) setDelegate(m metric.Meter) {
 func (i *sfUpDownCounter) Add(ctx context.Context, incr float64, opts ...metric.AddOption) {
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Float64UpDownCounter).Add(ctx, incr, opts...)
+	}
+}
+
+func (i *sfUpDownCounter) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64UpDownCounter).Remove(ctx, opts...)
 	}
 }
 
@@ -281,6 +293,12 @@ func (i *sfHistogram) Record(ctx context.Context, x float64, opts ...metric.Reco
 	}
 }
 
+func (i *sfHistogram) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Histogram).Remove(ctx, opts...)
+	}
+}
+
 type sfGauge struct {
 	embedded.Float64Gauge
 
@@ -304,6 +322,12 @@ func (i *sfGauge) setDelegate(m metric.Meter) {
 func (i *sfGauge) Record(ctx context.Context, x float64, opts ...metric.RecordOption) {
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Float64Gauge).Record(ctx, x, opts...)
+	}
+}
+
+func (i *sfGauge) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Gauge).Remove(ctx, opts...)
 	}
 }
 
@@ -333,6 +357,12 @@ func (i *siCounter) Add(ctx context.Context, x int64, opts ...metric.AddOption) 
 	}
 }
 
+func (i *siCounter) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Counter).Remove(ctx, opts...)
+	}
+}
+
 type siUpDownCounter struct {
 	embedded.Int64UpDownCounter
 
@@ -356,6 +386,12 @@ func (i *siUpDownCounter) setDelegate(m metric.Meter) {
 func (i *siUpDownCounter) Add(ctx context.Context, x int64, opts ...metric.AddOption) {
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Int64UpDownCounter).Add(ctx, x, opts...)
+	}
+}
+
+func (i *siUpDownCounter) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64UpDownCounter).Remove(ctx, opts...)
 	}
 }
 
@@ -385,6 +421,12 @@ func (i *siHistogram) Record(ctx context.Context, x int64, opts ...metric.Record
 	}
 }
 
+func (i *siHistogram) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Histogram).Remove(ctx, opts...)
+	}
+}
+
 type siGauge struct {
 	embedded.Int64Gauge
 
@@ -408,5 +450,11 @@ func (i *siGauge) setDelegate(m metric.Meter) {
 func (i *siGauge) Record(ctx context.Context, x int64, opts ...metric.RecordOption) {
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Int64Gauge).Record(ctx, x, opts...)
+	}
+}
+
+func (i *siGauge) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Gauge).Remove(ctx, opts...)
 	}
 }

--- a/vendor/go.opentelemetry.io/otel/metric/noop/noop.go
+++ b/vendor/go.opentelemetry.io/otel/metric/noop/noop.go
@@ -176,12 +176,18 @@ type Int64Counter struct{ embedded.Int64Counter }
 // Add performs no operation.
 func (Int64Counter) Add(context.Context, int64, ...metric.AddOption) {}
 
+// Remove performs no operation.
+func (Int64Counter) Remove(context.Context, ...metric.RemoveOption) {}
+
 // Float64Counter is an OpenTelemetry Counter used to record float64
 // measurements. It produces no telemetry.
 type Float64Counter struct{ embedded.Float64Counter }
 
 // Add performs no operation.
 func (Float64Counter) Add(context.Context, float64, ...metric.AddOption) {}
+
+// Remove performs no operation.
+func (Float64Counter) Remove(context.Context, ...metric.RemoveOption) {}
 
 // Int64UpDownCounter is an OpenTelemetry UpDownCounter used to record int64
 // measurements. It produces no telemetry.
@@ -190,12 +196,18 @@ type Int64UpDownCounter struct{ embedded.Int64UpDownCounter }
 // Add performs no operation.
 func (Int64UpDownCounter) Add(context.Context, int64, ...metric.AddOption) {}
 
+// Remove performs no operation.
+func (Int64UpDownCounter) Remove(context.Context, ...metric.RemoveOption) {}
+
 // Float64UpDownCounter is an OpenTelemetry UpDownCounter used to record
 // float64 measurements. It produces no telemetry.
 type Float64UpDownCounter struct{ embedded.Float64UpDownCounter }
 
 // Add performs no operation.
 func (Float64UpDownCounter) Add(context.Context, float64, ...metric.AddOption) {}
+
+// Remove performs no operation.
+func (Float64UpDownCounter) Remove(context.Context, ...metric.RemoveOption) {}
 
 // Int64Histogram is an OpenTelemetry Histogram used to record int64
 // measurements. It produces no telemetry.
@@ -204,12 +216,18 @@ type Int64Histogram struct{ embedded.Int64Histogram }
 // Record performs no operation.
 func (Int64Histogram) Record(context.Context, int64, ...metric.RecordOption) {}
 
+// Remove performs no operation.
+func (Int64Histogram) Remove(context.Context, ...metric.RemoveOption) {}
+
 // Float64Histogram is an OpenTelemetry Histogram used to record float64
 // measurements. It produces no telemetry.
 type Float64Histogram struct{ embedded.Float64Histogram }
 
 // Record performs no operation.
 func (Float64Histogram) Record(context.Context, float64, ...metric.RecordOption) {}
+
+// Remove performs no operation.
+func (Float64Histogram) Remove(context.Context, ...metric.RemoveOption) {}
 
 // Int64Gauge is an OpenTelemetry Gauge used to record instantaneous int64
 // measurements. It produces no telemetry.
@@ -218,12 +236,18 @@ type Int64Gauge struct{ embedded.Int64Gauge }
 // Record performs no operation.
 func (Int64Gauge) Record(context.Context, int64, ...metric.RecordOption) {}
 
+// Remove performs no operation.
+func (Int64Gauge) Remove(context.Context, ...metric.RemoveOption) {}
+
 // Float64Gauge is an OpenTelemetry Gauge used to record instantaneous float64
 // measurements. It produces no telemetry.
 type Float64Gauge struct{ embedded.Float64Gauge }
 
 // Record performs no operation.
 func (Float64Gauge) Record(context.Context, float64, ...metric.RecordOption) {}
+
+// Remove performs no operation.
+func (Float64Gauge) Remove(context.Context, ...metric.RemoveOption) {}
 
 // Int64ObservableCounter is an OpenTelemetry ObservableCounter used to record
 // int64 measurements. It produces no telemetry.

--- a/vendor/go.opentelemetry.io/otel/metric/syncfloat64.go
+++ b/vendor/go.opentelemetry.io/otel/metric/syncfloat64.go
@@ -25,6 +25,12 @@ type Float64Counter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr float64, options ...AddOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Float64CounterConfig contains options for synchronous counter instruments that
@@ -78,6 +84,12 @@ type Float64UpDownCounter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr float64, options ...AddOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Float64UpDownCounterConfig contains options for synchronous counter
@@ -131,6 +143,12 @@ type Float64Histogram interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, incr float64, options ...RecordOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Float64HistogramConfig contains options for synchronous histogram
@@ -189,6 +207,12 @@ type Float64Gauge interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, value float64, options ...RecordOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Float64GaugeConfig contains options for synchronous gauge instruments that

--- a/vendor/go.opentelemetry.io/otel/metric/syncint64.go
+++ b/vendor/go.opentelemetry.io/otel/metric/syncint64.go
@@ -25,6 +25,12 @@ type Int64Counter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr int64, options ...AddOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Int64CounterConfig contains options for synchronous counter instruments that
@@ -78,6 +84,12 @@ type Int64UpDownCounter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr int64, options ...AddOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Int64UpDownCounterConfig contains options for synchronous counter
@@ -131,6 +143,12 @@ type Int64Histogram interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, incr int64, options ...RecordOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Int64HistogramConfig contains options for synchronous histogram instruments
@@ -189,6 +207,12 @@ type Int64Gauge interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, value int64, options ...RecordOption)
+
+	// Removes an existing timeseries
+	//
+	// Use the WithAttributeSet or WithAttributes option to include measurement
+	// attributes.
+	Remove(ctx context.Context, options ...RemoveOption)
 }
 
 // Int64GaugeConfig contains options for synchronous gauge instruments that

--- a/vendor/go.opentelemetry.io/otel/sdk/metric/instrument.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/metric/instrument.go
@@ -175,6 +175,7 @@ func (i instID) normalize() instID {
 
 type int64Inst struct {
 	measures []aggregate.Measure[int64]
+	removers []aggregate.Remove
 
 	embedded.Int64Counter
 	embedded.Int64UpDownCounter
@@ -199,6 +200,14 @@ func (i *int64Inst) Record(ctx context.Context, val int64, opts ...metric.Record
 	i.aggregate(ctx, val, c.Attributes())
 }
 
+func (i *int64Inst) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	c := metric.NewRemoveConfig(opts)
+
+	for _, rem := range i.removers {
+		rem(ctx, c.Attributes())
+	}
+}
+
 func (i *int64Inst) aggregate(ctx context.Context, val int64, s attribute.Set) { // nolint:revive  // okay to shadow pkg with method.
 	for _, in := range i.measures {
 		in(ctx, val, s)
@@ -207,6 +216,7 @@ func (i *int64Inst) aggregate(ctx context.Context, val int64, s attribute.Set) {
 
 type float64Inst struct {
 	measures []aggregate.Measure[float64]
+	removers []aggregate.Remove
 
 	embedded.Float64Counter
 	embedded.Float64UpDownCounter
@@ -229,6 +239,14 @@ func (i *float64Inst) Add(ctx context.Context, val float64, opts ...metric.AddOp
 func (i *float64Inst) Record(ctx context.Context, val float64, opts ...metric.RecordOption) {
 	c := metric.NewRecordConfig(opts)
 	i.aggregate(ctx, val, c.Attributes())
+}
+
+func (i *float64Inst) Remove(ctx context.Context, opts ...metric.RemoveOption) {
+	c := metric.NewRemoveConfig(opts)
+
+	for _, rem := range i.removers {
+		rem(ctx, c.Attributes())
+	}
 }
 
 func (i *float64Inst) aggregate(ctx context.Context, val float64, s attribute.Set) {
@@ -319,7 +337,10 @@ func (o *observable[N]) appendMeasures(meas []aggregate.Measure[N]) {
 	o.measures = append(o.measures, meas...)
 }
 
-type measures[N int64 | float64] []aggregate.Measure[N]
+type (
+	measures[N int64 | float64] []aggregate.Measure[N]
+	removers                    []aggregate.Remove
+)
 
 // observe records the val for the set of attrs.
 func (m measures[N]) observe(val N, s attribute.Set) {

--- a/vendor/go.opentelemetry.io/otel/sdk/metric/internal/aggregate/histogram.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/metric/internal/aggregate/histogram.go
@@ -51,6 +51,7 @@ type histValues[N int64 | float64] struct {
 	newRes   func() exemplar.Reservoir
 	limit    limiter[*buckets[N]]
 	values   map[attribute.Distinct]*buckets[N]
+	stale    map[attribute.Distinct]*buckets[N]
 	valuesMu sync.Mutex
 }
 
@@ -67,6 +68,7 @@ func newHistValues[N int64 | float64](bounds []float64, noSum bool, limit int, r
 		newRes: r,
 		limit:  newLimiter[*buckets[N]](limit),
 		values: make(map[attribute.Distinct]*buckets[N]),
+		stale:  make(map[attribute.Distinct]*buckets[N]),
 	}
 }
 
@@ -107,6 +109,18 @@ func (s *histValues[N]) measure(ctx context.Context, value N, fltrAttr attribute
 		b.sum(value)
 	}
 	b.res.Offer(ctx, t, exemplar.NewValue(value), droppedAttr)
+}
+
+func (s *histValues[N]) remove(ctx context.Context, fltrAttr attribute.Set) {
+	s.valuesMu.Lock()
+	defer s.valuesMu.Unlock()
+
+	key := fltrAttr.Equivalent()
+
+	if val, ok := s.values[key]; ok {
+		s.stale[key] = val
+		delete(s.values, key)
+	}
 }
 
 // newHistogram returns an Aggregator that summarizes a set of measurements as
@@ -169,6 +183,7 @@ func (s *histogram[N]) delta(dest *metricdata.Aggregation) int {
 	}
 	// Unused attribute sets do not report.
 	clear(s.values)
+	clear(s.stale)
 	// The delta collection cycle resets.
 	s.start = t
 
@@ -192,7 +207,7 @@ func (s *histogram[N]) cumulative(dest *metricdata.Aggregation) int {
 	// Do not allow modification of our copy of bounds.
 	bounds := slices.Clone(s.bounds)
 
-	n := len(s.values)
+	n := len(s.values) + len(s.stale)
 	hDPts := reset(h.DataPoints, n, n)
 
 	var i int
@@ -227,6 +242,17 @@ func (s *histogram[N]) cumulative(dest *metricdata.Aggregation) int {
 		// sets that become "stale" need to be forgotten so this will not
 		// overload the system.
 	}
+	for _, val := range s.stale {
+		hDPts[i].Attributes = val.attrs
+		hDPts[i].StartTime = s.start
+		hDPts[i].Time = t
+		hDPts[i].NoRecordedValue = true
+		i++
+	}
+
+	// Stale attribute sets for which a no-record marker was emitted are not
+	// reported anymore.
+	clear(s.stale)
 
 	h.DataPoints = hDPts
 	*dest = h

--- a/vendor/go.opentelemetry.io/otel/sdk/metric/metricdata/data.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/metric/metricdata/data.go
@@ -84,6 +84,11 @@ type DataPoint[N int64 | float64] struct {
 
 	// Exemplars is the sampled Exemplars collected during the timeseries.
 	Exemplars []Exemplar[N] `json:",omitempty"`
+
+	// This DataPoint is valid but has no recorded value.  This value
+	// is used to reflect explicitly missing data in a series, as for
+	// an equivalent to the Prometheus "staleness marker".
+	NoRecordedValue bool `json:",omitempty"`
 }
 
 // Histogram represents the histogram of all measurements of values from an instrument.
@@ -125,6 +130,11 @@ type HistogramDataPoint[N int64 | float64] struct {
 
 	// Exemplars is the sampled Exemplars collected during the timeseries.
 	Exemplars []Exemplar[N] `json:",omitempty"`
+
+	// This DataPoint is valid but has no recorded value.  This value
+	// is used to reflect explicitly missing data in a series, as for
+	// an equivalent to the Prometheus "staleness marker".
+	NoRecordedValue bool `json:",omitempty"`
 }
 
 // ExponentialHistogram represents the histogram of all measurements of values from an instrument.
@@ -182,6 +192,11 @@ type ExponentialHistogramDataPoint[N int64 | float64] struct {
 
 	// Exemplars is the sampled Exemplars collected during the timeseries.
 	Exemplars []Exemplar[N] `json:",omitempty"`
+
+	// This DataPoint is valid but has no recorded value.  This value
+	// is used to reflect explicitly missing data in a series, as for
+	// an equivalent to the Prometheus "staleness marker".
+	NoRecordedValue bool `json:",omitempty"`
 }
 
 // ExponentialBucket are a set of bucket counts, encoded in a contiguous array

--- a/vendor/go.opentelemetry.io/otel/sdk/metric/pipeline.go
+++ b/vendor/go.opentelemetry.io/otel/sdk/metric/pipeline.go
@@ -213,10 +213,11 @@ func newInserter[N int64 | float64](p *pipeline, vc *cache[string, instID]) *ins
 //
 // If an instrument is determined to use a Drop aggregation, that instrument is
 // not inserted nor returned.
-func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation) ([]aggregate.Measure[N], error) {
+func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation) ([]aggregate.Measure[N], []aggregate.Remove, error) {
 	var (
 		matched  bool
 		measures []aggregate.Measure[N]
+		removers []aggregate.Remove
 	)
 
 	errs := &multierror{wrapped: errCreatingAggregators}
@@ -227,7 +228,7 @@ func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation)
 			continue
 		}
 		matched = true
-		in, id, err := i.cachedAggregator(inst.Scope, inst.Kind, stream, readerAggregation)
+		in, rem, id, err := i.cachedAggregator(inst.Scope, inst.Kind, stream, readerAggregation)
 		if err != nil {
 			errs.append(err)
 		}
@@ -240,10 +241,11 @@ func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation)
 		}
 		seen[id] = struct{}{}
 		measures = append(measures, in)
+		removers = append(removers, rem)
 	}
 
 	if matched {
-		return measures, errs.errorOrNil()
+		return measures, removers, errs.errorOrNil()
 	}
 
 	// Apply implicit default view if no explicit matched.
@@ -252,7 +254,7 @@ func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation)
 		Description: inst.Description,
 		Unit:        inst.Unit,
 	}
-	in, _, err := i.cachedAggregator(inst.Scope, inst.Kind, stream, readerAggregation)
+	in, rem, _, err := i.cachedAggregator(inst.Scope, inst.Kind, stream, readerAggregation)
 	if err != nil {
 		errs.append(err)
 	}
@@ -260,7 +262,11 @@ func (i *inserter[N]) Instrument(inst Instrument, readerAggregation Aggregation)
 		// Ensured to have not seen given matched was false.
 		measures = append(measures, in)
 	}
-	return measures, errs.errorOrNil()
+	if rem != nil {
+		// Ensured to have not seen given matched was false.
+		removers = append(removers, rem)
+	}
+	return measures, removers, errs.errorOrNil()
 }
 
 // addCallback registers a single instrument callback to be run when
@@ -277,6 +283,7 @@ var aggIDCount uint64
 type aggVal[N int64 | float64] struct {
 	ID      uint64
 	Measure aggregate.Measure[N]
+	Remove  aggregate.Remove
 	Err     error
 }
 
@@ -319,7 +326,7 @@ func (i *inserter[N]) readerDefaultAggregation(kind InstrumentKind) Aggregation 
 //
 // If the instrument defines an unknown or incompatible aggregation, an error
 // is returned.
-func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind InstrumentKind, stream Stream, readerAggregation Aggregation) (meas aggregate.Measure[N], aggID uint64, err error) {
+func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind InstrumentKind, stream Stream, readerAggregation Aggregation) (meas aggregate.Measure[N], remove aggregate.Remove, aggID uint64, err error) {
 	switch stream.Aggregation.(type) {
 	case nil:
 		// The aggregation was not overridden with a view. Use the aggregation
@@ -331,7 +338,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 	}
 
 	if err := isAggregatorCompatible(kind, stream.Aggregation); err != nil {
-		return nil, 0, fmt.Errorf(
+		return nil, nil, 0, fmt.Errorf(
 			"creating aggregator with instrumentKind: %d, aggregation %v: %w",
 			kind, stream.Aggregation, err,
 		)
@@ -358,12 +365,12 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 		// unrecognized input). Use that value directly.
 		b.AggregationLimit, _ = x.CardinalityLimit.Lookup()
 
-		in, out, err := i.aggregateFunc(b, stream.Aggregation, kind)
+		in, remove, out, err := i.aggregateFunc(b, stream.Aggregation, kind)
 		if err != nil {
-			return aggVal[N]{0, nil, err}
+			return aggVal[N]{0, nil, nil, err}
 		}
 		if in == nil { // Drop aggregator.
-			return aggVal[N]{0, nil, nil}
+			return aggVal[N]{0, nil, nil, nil}
 		}
 		i.pipeline.addSync(scope, instrumentSync{
 			// Use the first-seen name casing for this and all subsequent
@@ -374,9 +381,9 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 			compAgg:     out,
 		})
 		id := atomic.AddUint64(&aggIDCount, 1)
-		return aggVal[N]{id, in, err}
+		return aggVal[N]{id, in, remove, err}
 	})
-	return cv.Measure, cv.ID, cv.Err
+	return cv.Measure, cv.Remove, cv.ID, cv.Err
 }
 
 // logConflict validates if an instrument with the same case-insensitive name
@@ -440,7 +447,7 @@ func (i *inserter[N]) instID(kind InstrumentKind, stream Stream) instID {
 // aggregateFunc returns new aggregate functions matching agg, kind, and
 // monotonic. If the agg is unknown or temporality is invalid, an error is
 // returned.
-func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg Aggregation, kind InstrumentKind) (meas aggregate.Measure[N], comp aggregate.ComputeAggregation, err error) {
+func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg Aggregation, kind InstrumentKind) (meas aggregate.Measure[N], remove aggregate.Remove, comp aggregate.ComputeAggregation, err error) {
 	switch a := agg.(type) {
 	case AggregationDefault:
 		return i.aggregateFunc(b, DefaultAggregationSelector(kind), kind)
@@ -449,22 +456,22 @@ func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg Aggregation, kin
 	case AggregationLastValue:
 		switch kind {
 		case InstrumentKindGauge:
-			meas, comp = b.LastValue()
+			meas, remove, comp = b.LastValue()
 		case InstrumentKindObservableGauge:
-			meas, comp = b.PrecomputedLastValue()
+			meas, remove, comp = b.PrecomputedLastValue()
 		}
 	case AggregationSum:
 		switch kind {
 		case InstrumentKindObservableCounter:
-			meas, comp = b.PrecomputedSum(true)
+			meas, remove, comp = b.PrecomputedSum(true)
 		case InstrumentKindObservableUpDownCounter:
-			meas, comp = b.PrecomputedSum(false)
+			meas, remove, comp = b.PrecomputedSum(false)
 		case InstrumentKindCounter, InstrumentKindHistogram:
-			meas, comp = b.Sum(true)
+			meas, remove, comp = b.Sum(true)
 		default:
 			// InstrumentKindUpDownCounter, InstrumentKindObservableGauge, and
 			// instrumentKindUndefined or other invalid instrument kinds.
-			meas, comp = b.Sum(false)
+			meas, remove, comp = b.Sum(false)
 		}
 	case AggregationExplicitBucketHistogram:
 		var noSum bool
@@ -475,7 +482,7 @@ func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg Aggregation, kin
 			// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/metrics/sdk.md#histogram-aggregations
 			noSum = true
 		}
-		meas, comp = b.ExplicitBucketHistogram(a.Boundaries, a.NoMinMax, noSum)
+		meas, remove, comp = b.ExplicitBucketHistogram(a.Boundaries, a.NoMinMax, noSum)
 	case AggregationBase2ExponentialHistogram:
 		var noSum bool
 		switch kind {
@@ -485,13 +492,13 @@ func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg Aggregation, kin
 			// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/metrics/sdk.md#histogram-aggregations
 			noSum = true
 		}
-		meas, comp = b.ExponentialBucketHistogram(a.MaxSize, a.MaxScale, a.NoMinMax, noSum)
+		meas, remove, comp = b.ExponentialBucketHistogram(a.MaxSize, a.MaxScale, a.NoMinMax, noSum)
 
 	default:
 		err = errUnknownAggregation
 	}
 
-	return meas, comp, err
+	return meas, remove, comp, err
 }
 
 // isAggregatorCompatible checks if the aggregation can be used by the instrument.
@@ -599,25 +606,28 @@ func newResolver[N int64 | float64](p pipelines, vc *cache[string, instID]) reso
 
 // Aggregators returns the Aggregators that must be updated by the instrument
 // defined by key.
-func (r resolver[N]) Aggregators(id Instrument) ([]aggregate.Measure[N], error) {
+func (r resolver[N]) Aggregators(id Instrument) ([]aggregate.Measure[N], []aggregate.Remove, error) {
 	var measures []aggregate.Measure[N]
+	var removers []aggregate.Remove
 
 	errs := &multierror{}
 	for _, i := range r.inserters {
-		in, err := i.Instrument(id, i.readerDefaultAggregation(id.Kind))
+		in, rem, err := i.Instrument(id, i.readerDefaultAggregation(id.Kind))
 		if err != nil {
 			errs.append(err)
 		}
 		measures = append(measures, in...)
+		removers = append(removers, rem...)
 	}
-	return measures, errs.errorOrNil()
+	return measures, removers, errs.errorOrNil()
 }
 
 // HistogramAggregators returns the histogram Aggregators that must be updated by the instrument
 // defined by key. If boundaries were provided on instrument instantiation, those take precedence
 // over boundaries provided by the reader.
-func (r resolver[N]) HistogramAggregators(id Instrument, boundaries []float64) ([]aggregate.Measure[N], error) {
+func (r resolver[N]) HistogramAggregators(id Instrument, boundaries []float64) ([]aggregate.Measure[N], []aggregate.Remove, error) {
 	var measures []aggregate.Measure[N]
+	var removers []aggregate.Remove
 
 	errs := &multierror{}
 	for _, i := range r.inserters {
@@ -626,13 +636,14 @@ func (r resolver[N]) HistogramAggregators(id Instrument, boundaries []float64) (
 			histAgg.Boundaries = boundaries
 			agg = histAgg
 		}
-		in, err := i.Instrument(id, agg)
+		in, rem, err := i.Instrument(id, agg)
 		if err != nil {
 			errs.append(err)
 		}
 		measures = append(measures, in...)
+		removers = append(removers, rem...)
 	}
-	return measures, errs.errorOrNil()
+	return measures, removers, errs.errorOrNil()
 }
 
 type multierror struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -629,7 +629,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry
 go.opentelemetry.io/otel/metric
 go.opentelemetry.io/otel/metric/embedded
 go.opentelemetry.io/otel/metric/noop
-# go.opentelemetry.io/otel/sdk v1.27.0
+# go.opentelemetry.io/otel/sdk v1.27.0 => github.com/grafana/opentelemetry-go/sdk v1.27.0-grafana.1
 ## explicit; go 1.21
 go.opentelemetry.io/otel/sdk
 go.opentelemetry.io/otel/sdk/instrumentation
@@ -637,7 +637,7 @@ go.opentelemetry.io/otel/sdk/internal
 go.opentelemetry.io/otel/sdk/internal/env
 go.opentelemetry.io/otel/sdk/resource
 go.opentelemetry.io/otel/sdk/trace
-# go.opentelemetry.io/otel/sdk/metric v1.27.0
+# go.opentelemetry.io/otel/sdk/metric v1.27.0 => github.com/grafana/opentelemetry-go/sdk/metric v1.27.0-grafana.1
 ## explicit; go 1.21
 go.opentelemetry.io/otel/sdk/metric
 go.opentelemetry.io/otel/sdk/metric/internal
@@ -1329,3 +1329,5 @@ sigs.k8s.io/yaml
 # go.opentelemetry.io/otel => github.com/grafana/opentelemetry-go v1.27.0-grafana.1
 # go.opentelemetry.io/otel/metric => github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1
 # go.opentelemetry.io/otel/trace => github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1
+# go.opentelemetry.io/otel/sdk => github.com/grafana/opentelemetry-go/sdk v1.27.0-grafana.1
+# go.opentelemetry.io/otel/sdk/metric => github.com/grafana/opentelemetry-go/sdk/metric v1.27.0-grafana.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -575,7 +575,7 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/inte
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
-# go.opentelemetry.io/otel v1.27.0
+# go.opentelemetry.io/otel v1.27.0 => github.com/grafana/opentelemetry-go v1.27.0-grafana.1
 ## explicit; go 1.21
 go.opentelemetry.io/otel
 go.opentelemetry.io/otel/attribute
@@ -624,7 +624,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/envconfig
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry
-# go.opentelemetry.io/otel/metric v1.27.0
+# go.opentelemetry.io/otel/metric v1.27.0 => github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1
 ## explicit; go 1.21
 go.opentelemetry.io/otel/metric
 go.opentelemetry.io/otel/metric/embedded
@@ -645,7 +645,7 @@ go.opentelemetry.io/otel/sdk/metric/internal/aggregate
 go.opentelemetry.io/otel/sdk/metric/internal/exemplar
 go.opentelemetry.io/otel/sdk/metric/internal/x
 go.opentelemetry.io/otel/sdk/metric/metricdata
-# go.opentelemetry.io/otel/trace v1.27.0
+# go.opentelemetry.io/otel/trace v1.27.0 => github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1
 ## explicit; go 1.21
 go.opentelemetry.io/otel/trace
 go.opentelemetry.io/otel/trace/embedded
@@ -1326,3 +1326,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# go.opentelemetry.io/otel => github.com/grafana/opentelemetry-go v1.27.0-grafana.1
+# go.opentelemetry.io/otel/metric => github.com/grafana/opentelemetry-go/metric v1.27.0-grafana.1
+# go.opentelemetry.io/otel/trace => github.com/grafana/opentelemetry-go/trace v1.27.0-grafana.1


### PR DESCRIPTION
It replaces the current observable-based OTEL api for removing counters and gauges to a general-purpose experimental API that also allows removing Histograms: https://github.com/grafana/opentelemetry-go/tree/v1.27.0-grafana.1 (kudos to @pyohannes !).

Tasks:

- [x] Update documentation.
- [x] Testing histograms removal for the app metrics exporter.