### PR TITLE
Fix race condition in Expiry Map

### DIFF
--- a/pkg/internal/export/expire/expiry_map.go
+++ b/pkg/internal/export/expire/expiry_map.go
@@ -89,8 +89,8 @@ func (ex *ExpiryMap[T]) DeleteExpired() []T {
 // if DeleteExpired is not invoked before it.
 // TODO: use https://tip.golang.org/wiki/RangefuncExperiment when available
 func (ex *ExpiryMap[T]) All() []T {
-	items := make([]T, 0, len(ex.entries))
 	ex.mt.RLock()
+	items := make([]T, 0, len(ex.entries))
 	for _, e := range ex.entries {
 		items = append(items, e.val)
 	}


### PR DESCRIPTION
Fixes this race condition:
```
WARNING: DATA RACE
Write at 0x00c00052a300 by goroutine 89:
  runtime.mapassign_faststr()
      /opt/hostedtoolcache/go/1.22.4/x64/src/runtime/map_faststr.go:203 +0x0
  github.com/grafana/beyla/pkg/internal/export/expire.(*ExpiryMap[go.shape.*uint8]).GetOrCreate()
      /home/runner/work/beyla/beyla/pkg/internal/export/expire/expiry_map.go:58 +0x459

(....)

Previous read at 0x00c00052a300 by goroutine 107:
  github.com/grafana/beyla/pkg/internal/export/expire.(*ExpiryMap[go.shape.*uint8]).All()
      /home/runner/work/beyla/beyla/pkg/internal/export/expire/expiry_map.go:92 +0xc4

(....)

```