### PR TITLE
Fix default config value in Helm chart

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -188,9 +188,10 @@ config:
         enable: true
     ## internal metrics reporting. Refer: https://grafana.com/docs/beyla/latest/configure/options/#internal-metrics-reporter
     ## If set, user can expose the metrics endpoint via k8s service by configuring .Values.service section
-    prometheus_export:
-      port: 9090
-      path: /metrics
+    internal_metrics:
+      prometheus:
+        port: 9090
+        path: /metrics
 
 ## Env variables that will override configmap values
 ## For example:


### PR DESCRIPTION
Current default values for Helm chart is enabling Prometheus export by default.
This is problematic in the scenarios of pushing metrics via OTEL and configuring
a Prometheus scrapper for internal  metrics (specially because I used also 9090).

The comment says that block is for internal metric reportings, which is not the case.
Changing to configure internal metrics instead.