### PR TITLE
Improve .NET language detection

### DIFF
--- a/pkg/internal/exec/proclang.go
+++ b/pkg/internal/exec/proclang.go
@@ -30,6 +30,13 @@ func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	return svc.InstrumentableGeneric
 }
 
+func instrumentableFromEnviron(environ string) svc.InstrumentableType {
+	if strings.Contains(environ, "ASPNET") || strings.Contains(environ, "DOTNET") {
+		return svc.InstrumentableDotnet
+	}
+	return svc.InstrumentableGeneric
+}
+
 func instrumentableFromSymbolName(symbol string) svc.InstrumentableType {
 	if strings.Contains(symbol, "rust_panic") {
 		return svc.InstrumentableRust

--- a/pkg/internal/exec/proclang_linux.go
+++ b/pkg/internal/exec/proclang_linux.go
@@ -37,7 +37,10 @@ func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 		return t
 	}
 
-	bytes, _ := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	bytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return svc.InstrumentableGeneric
+	}
 	return instrumentableFromEnviron(string(bytes))
 }
 

--- a/pkg/internal/exec/proclang_linux.go
+++ b/pkg/internal/exec/proclang_linux.go
@@ -23,14 +23,6 @@ func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 		}
 	}
 
-	bytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
-	if err == nil {
-		t := instrumentableFromEnviron(string(bytes))
-		if t != svc.InstrumentableGeneric {
-			return t
-		}
-	}
-
 	if elfF == nil {
 		pidPath := fmt.Sprintf("/proc/%d/exe", pid)
 		elfF, err = elf.Open(pidPath)
@@ -40,7 +32,13 @@ func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 		}
 	}
 
-	return findLanguageFromElf(elfF)
+	t := findLanguageFromElf(elfF)
+	if t != svc.InstrumentableGeneric {
+		return t
+	}
+
+	bytes, _ := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	return instrumentableFromEnviron(string(bytes))
 }
 
 func findLanguageFromElf(elfF *elf.File) svc.InstrumentableType {

--- a/pkg/internal/exec/proclang_linux.go
+++ b/pkg/internal/exec/proclang_linux.go
@@ -4,6 +4,7 @@ import (
 	"debug/elf"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
@@ -17,6 +18,14 @@ func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 
 	for _, m := range maps {
 		t := instrumentableFromModuleMap(m.Pathname)
+		if t != svc.InstrumentableGeneric {
+			return t
+		}
+	}
+
+	bytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err == nil {
+		t := instrumentableFromEnviron(string(bytes))
 		if t != svc.InstrumentableGeneric {
 			return t
 		}

--- a/pkg/internal/exec/proclang_test.go
+++ b/pkg/internal/exec/proclang_test.go
@@ -40,3 +40,9 @@ func TestSymbolDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("graal"))
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("rust"))
 }
+func TestEnvironDetection(t *testing.T) {
+	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromEnviron("ASPNETCORE_HTTP_PORTS=8080"))
+	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromEnviron("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromEnviron("SOME_ENV_VAR=123"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromEnviron("DOT=1"))
+}


### PR DESCRIPTION
We noticed that in cases like cartservice in otel demo we don't detect that's a .NET service.
This PR checks environment variables as detection from modules is not enough.