### PR TITLE
Add detection for PHP language

### DIFF
--- a/pkg/internal/discover/typer.go
+++ b/pkg/internal/discover/typer.go
@@ -150,7 +150,7 @@ func (t *typer) asInstrumentable(execElf *exec.FileInfo) Instrumentable {
 		parent, ok = t.currentPids[parent.Ppid]
 	}
 
-	detectedType := exec.FindProcLanguage(execElf.Pid, execElf.ELF)
+	detectedType := exec.FindProcLanguage(execElf.Pid, execElf.ELF, execElf.CmdExePath)
 
 	log.Debug("instrumented", "comm", execElf.CmdExePath, "pid", execElf.Pid,
 		"child", child, "language", detectedType.String())

--- a/pkg/internal/ebpf/common/pids.go
+++ b/pkg/internal/ebpf/common/pids.go
@@ -213,7 +213,7 @@ func serviceInfo(pid uint32) svc.ID {
 	}
 
 	name := commName(pid)
-	lang := exec.FindProcLanguage(int32(pid), nil)
+	lang := exec.FindProcLanguage(int32(pid), nil, name)
 	result := svc.ID{Name: name, SDKLanguage: lang, ProcPID: int32(pid)}
 
 	activePids.Add(pid, result)

--- a/pkg/internal/exec/proclang.go
+++ b/pkg/internal/exec/proclang.go
@@ -40,3 +40,10 @@ func instrumentableFromSymbolName(symbol string) svc.InstrumentableType {
 
 	return svc.InstrumentableGeneric
 }
+
+func instrumentableFromPath(path string) svc.InstrumentableType {
+	if strings.Contains(path, "php") {
+		return svc.InstrumentablePHP
+	}
+	return svc.InstrumentableGeneric
+}

--- a/pkg/internal/exec/proclang_linux.go
+++ b/pkg/internal/exec/proclang_linux.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
-func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
+func FindProcLanguage(pid int32, elfF *elf.File, path string) svc.InstrumentableType {
 	maps, err := FindLibMaps(pid)
 
 	if err != nil {
@@ -20,6 +20,11 @@ func FindProcLanguage(pid int32, elfF *elf.File) svc.InstrumentableType {
 		if t != svc.InstrumentableGeneric {
 			return t
 		}
+	}
+
+	t := instrumentableFromPath(path)
+	if t != svc.InstrumentableGeneric {
+		return t
 	}
 
 	if elfF == nil {

--- a/pkg/internal/exec/proclang_test.go
+++ b/pkg/internal/exec/proclang_test.go
@@ -40,3 +40,8 @@ func TestSymbolDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("graal"))
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("rust"))
 }
+
+func TestPathDetection(t *testing.T) {
+	assert.Equal(t, svc.InstrumentablePHP, instrumentableFromPath("php"))
+	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromPath("python"))
+}

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -1,7 +1,7 @@
 package svc
 
 import (
-	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	attr "github.com/grafana/beyla/pkg/internal/export/attributes/names"
 )
@@ -17,6 +17,7 @@ const (
 	InstrumentableNodejs
 	InstrumentableRust
 	InstrumentableGeneric
+	InstrumentablePHP
 )
 
 func (it InstrumentableType) String() string {
@@ -34,7 +35,9 @@ func (it InstrumentableType) String() string {
 	case InstrumentableNodejs:
 		return semconv.TelemetrySDKLanguageNodejs.Value.AsString()
 	case InstrumentableRust:
-		return "rust"
+		return semconv.TelemetrySDKLanguageRust.Value.AsString()
+	case InstrumentablePHP:
+		return semconv.TelemetrySDKLanguagePHP.Value.AsString()
 	case InstrumentableGeneric:
 		return "generic"
 	default:


### PR DESCRIPTION
- Added support to detect PHP services. Simply checks that PHP is in the path of executable.
- Update semconv in `svc.go` to use semconv for Rust