### PR TITLE
Enable ServiceNamespace in appAttributes

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -53,7 +53,8 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	var appAttributes = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&prometheusAttributes},
 		Attributes: map[attr.Name]Default{
-			attr.ServiceName: true,
+			attr.ServiceName:     true,
+			attr.ServerNamespace: true,
 		},
 	}
 


### PR DESCRIPTION
In #980 we added service_namespace as part of attributes, 
but we forgot to enable in `attr_defs.go`. This PR enables it.