### PR TITLE
Set heuristic as default value for unmatched routes arg

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -694,7 +694,7 @@ that only traces matching the `ignored_patterns` will be discarded, while metric
 
 | YAML        | Environment variable | Type   | Default    |
 | ----------- | ------- | ------ | ---------- |
-| `unmatched` | --      | string | `wildcard` |
+| `unmatched` | --      | string | `heuristic` |
 
 Specifies what to do when a trace HTTP path does not match any of the `patterns` entries.
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -109,7 +109,7 @@ var DefaultConfig = Config{
 			InformersSyncTimeout: 30 * time.Second,
 		},
 	},
-	Routes:       &transform.RoutesConfig{},
+	Routes:       &transform.RoutesConfig{Unmatch: transform.UnmatchHeuristic},
 	NetworkFlows: defaultNetworkConfig,
 	Processes: process.CollectConfig{
 		RunMode:  process.RunModePrivileged,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -172,7 +172,9 @@ network:
 				},
 			},
 		},
-		Routes: &transform.RoutesConfig{},
+		Routes: &transform.RoutesConfig{
+			Unmatch: transform.UnmatchHeuristic,
+		},
 		NameResolver: &transform.NameResolverConfig{
 			CacheLen: 1024,
 			CacheTTL: 5 * time.Minute,


### PR DESCRIPTION
It seems that the most used value for `unmatched` parameter in `routes` block 
is `heuristic` as it produces values that are closer to manual instrumentation.

This PR sets `heuristic as default value for this config argument.