### PR TITLE
enable by default: server_address and server_port attributes

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -135,7 +135,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 
 	// TODO Beyla 2.0 remove
 	// this just defaults the path as default when the target report is enabled
-	// via the deprecated BEYLA_METRICS_REPORT_PEER config option
+	// via the deprecated BEYLA_METRICS_REPORT_TARGET config option
 	var deprecatedHTTPPath = AttrReportGroup{
 		Disabled: !groups.Has(GroupTarget),
 		MetricAttributes: map[attr.Name]Default{

--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -123,13 +123,13 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	}
 	var httpClientInfo = AttrReportGroup{
 		MetricAttributes: map[attr.Name]Default{
-			attr.ServerAddr: Default(peerInfoEnabled),
-			attr.ServerPort: Default(peerInfoEnabled),
+			attr.ServerAddr: true,
+			attr.ServerPort: true,
 		},
 	}
 	var grpcClientInfo = AttrReportGroup{
 		MetricAttributes: map[attr.Name]Default{
-			attr.ServerAddr: Default(peerInfoEnabled),
+			attr.ServerAddr: true,
 		},
 	}
 


### PR DESCRIPTION
The above attributes should not increase cardinality too much, and letting them by default would facilitate the landing on Beyla+Asserts.

The user still hs the possibility to disable them by means of the attributes selection YAML section.