### PR TITLE
Selection of metric attributes by "glob" in metric name

### DIFF
--- a/pkg/internal/export/attributes/attr_select.go
+++ b/pkg/internal/export/attributes/attr_select.go
@@ -3,6 +3,7 @@ package attributes
 import (
 	"maps"
 	"path"
+	"slices"
 	"strings"
 
 	attr "github.com/grafana/beyla/pkg/internal/export/attributes/names"
@@ -68,4 +69,22 @@ func (incl Selection) Normalize() {
 	// clear the current map before copying again normalized values
 	maps.DeleteFunc(incl, func(_ Section, _ InclusionLists) bool { return true })
 	maps.Copy(incl, normalized)
+}
+
+func (incl Selection) Matching(metricName Name) []InclusionLists {
+	if incl == nil {
+		return nil
+	}
+	var matchingMetricGlobs []Section
+	for glob := range incl {
+		if ok, _ := path.Match(string(glob), string(metricName.Section)); ok {
+			matchingMetricGlobs = append(matchingMetricGlobs, glob)
+		}
+	}
+	slices.Sort(matchingMetricGlobs)
+	inclusionLists := make([]InclusionLists, 0, len(matchingMetricGlobs))
+	for _, glob := range matchingMetricGlobs {
+		inclusionLists = append(inclusionLists, incl[glob])
+	}
+	return inclusionLists
 }

--- a/pkg/internal/export/attributes/attr_select.go
+++ b/pkg/internal/export/attributes/attr_select.go
@@ -71,6 +71,10 @@ func (incl Selection) Normalize() {
 	maps.Copy(incl, normalized)
 }
 
+// Matching returns all the entries of the inclusion list matching the provided metric name.
+// This would include "glob-like" entries.
+// They are returned from more to less broad scope (for example, for a metric named foo_bar
+// it could return the inclusion lists defined with keys "*", "foo_*" and "foo_bar", in that order).
 func (incl Selection) Matching(metricName Name) []InclusionLists {
 	if incl == nil {
 		return nil

--- a/pkg/internal/export/attributes/attr_select_test.go
+++ b/pkg/internal/export/attributes/attr_select_test.go
@@ -1,0 +1,30 @@
+package attributes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectorMatch(t *testing.T) {
+	fbb := InclusionLists{Include: []string{"foo_bar_baz"}}
+	f := InclusionLists{Include: []string{"foo"}}
+	fbt := InclusionLists{Include: []string{"foo_bar_traca"}}
+	pp := InclusionLists{Include: []string{"pim_pam"}}
+	selection := Selection{
+		"foo.bar.baz":   fbb,
+		"foo.*":         f,
+		"foo.bar.traca": fbt,
+		"pim.pam":       pp,
+	}
+	assert.Equal(t,
+		[]InclusionLists{f, fbb},
+		selection.Matching(Name{Section: "foo.bar.baz"}))
+	assert.Equal(t,
+		[]InclusionLists{f, fbt},
+		selection.Matching(Name{Section: "foo.bar.traca"}))
+	assert.Equal(t,
+		[]InclusionLists{pp},
+		selection.Matching(Name{Section: "pim.pam"}))
+	assert.Empty(t, selection.Matching(Name{Section: "pam.pum"}))
+}

--- a/test/integration/configs/instrumenter-config-java.yml
+++ b/test/integration/configs/instrumenter-config-java.yml
@@ -6,17 +6,7 @@ otel_metrics_export:
   endpoint: http://otelcol:4318
 attributes:
   select:
-    process_cpu_time:
+    process_*:
       include: ["*"]
+    process_cpu_*:
       exclude: ["process_cpu_state"]
-    process_cpu_utilization:
-      include: ["*"]
-      exclude: ["process_cpu_state"]
-    process_memory_usage:
-      include: ["*"]
-    process_memory_virtual:
-      include: ["*"]
-    process_disk_io:
-      include: ["*"]
-    process_network_io:
-      include: ["*"]

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -9,17 +9,7 @@ data:
         enable: true
         cluster_name: beyla
       select:
-        process_cpu_time:
-          include: ["*"]
-        process_cpu_utilization:
-          include: ["*"]
-        process_memory_usage:
-          include: ["*"]
-        process_memory_virtual:
-          include: ["*"]
-        process_disk_io:
-          include: ["*"]
-        process_network_io:
+        process_*:
           include: ["*"]
     print_traces: true
     log_level: debug


### PR DESCRIPTION
This PR would let group the attributes in metric names by glob. 

For example, instead of having to define:
```yaml
attributes:
  select:
    process_cpu_utilization:
      include: ["*"]
    process_cpu_time:
      include: ["*"]
    process_memory_usage:
      include: ["*"]
    process_memory_virtual:
      include: ["*"]
    process_disk_io:
      include: ["*"]
    process_network_io:
      include: ["*"]
```

You can now define:
```yaml
attributes:
  select:
    process_*:
      include: ["*"]
```

Or even:
```yaml
attributes:
  select:
    "*":
      include: ["*"]
```

Documentation will come in another PR.