### PR TITLE
Revert "Differentiation between metric and resource attributes (#984)"

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -42,7 +42,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// attributes to be reported exclusively for prometheus exporters
 	var prometheusAttributes = AttrReportGroup{
 		Disabled: !promEnabled,
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.TargetInstance:   true,
 			attr.ServiceNamespace: true,
 		},
@@ -52,7 +52,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// but Grafana Cloud takes it from the metric
 	var appAttributes = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&prometheusAttributes},
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.ServiceName:      true,
 			attr.ServiceNamespace: true,
 		},
@@ -62,7 +62,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// kubernetes metadata is enabled
 	var networkKubeAttributes = AttrReportGroup{
 		Disabled: !kubeEnabled,
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.K8sSrcOwnerName: true,
 			attr.K8sSrcNamespace: true,
 			attr.K8sDstOwnerName: true,
@@ -85,7 +85,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// is defined
 	var networkCIDR = AttrReportGroup{
 		Disabled: !cidrEnabled,
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.DstCIDR: true,
 			attr.SrcCIDR: true,
 		},
@@ -95,7 +95,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// kubernetes metadata is enabled
 	var appKubeAttributes = AttrReportGroup{
 		Disabled: !kubeEnabled,
-		ResourceAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.K8sNamespaceName:   true,
 			attr.K8sPodName:         true,
 			attr.K8sDeploymentName:  true,
@@ -111,24 +111,24 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 
 	var httpRoutes = AttrReportGroup{
 		Disabled: !groups.Has(GroupHTTPRoutes),
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.HTTPRoute: true,
 		},
 	}
 
 	var serverInfo = AttrReportGroup{
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.ClientAddr: Default(peerInfoEnabled),
 		},
 	}
 	var httpClientInfo = AttrReportGroup{
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.ServerAddr: true,
 			attr.ServerPort: true,
 		},
 	}
 	var grpcClientInfo = AttrReportGroup{
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.ServerAddr: true,
 		},
 	}
@@ -138,14 +138,14 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// via the deprecated BEYLA_METRICS_REPORT_TARGET config option
 	var deprecatedHTTPPath = AttrReportGroup{
 		Disabled: !groups.Has(GroupTarget),
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.HTTPUrlPath: true,
 		},
 	}
 
 	var httpCommon = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&httpRoutes, &deprecatedHTTPPath},
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.HTTPRequestMethod:      true,
 			attr.HTTPResponseStatusCode: true,
 			attr.HTTPUrlPath:            false,
@@ -154,7 +154,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 
 	// TODO: populate it with host resource attributes in https://opentelemetry.io/docs/specs/semconv/resource/host/
 	var hostAttributes = AttrReportGroup{
-		ResourceAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.HostName: true,
 		},
 	}
@@ -164,7 +164,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		// TODO: attributes below are resource-level, but in App O11y we don't treat processes as resources,
 		// but applications. Let's first consider how to match processes and Applications before marking this spec
 		// as stable
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.ProcCommand:     true,
 			attr.ProcCPUState:    true,
 			attr.ProcOwner:       true,
@@ -181,7 +181,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 
 	var messagingAttributes = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes},
-		MetricAttributes: map[attr.Name]Default{
+		Attributes: map[attr.Name]Default{
 			attr.MessagingSystem:      true,
 			attr.MessagingDestination: true,
 		},
@@ -190,7 +190,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	return map[Section]AttrReportGroup{
 		BeylaNetworkFlow.Section: {
 			SubGroups: []*AttrReportGroup{&networkCIDR, &networkKubeAttributes},
-			MetricAttributes: map[attr.Name]Default{
+			Attributes: map[attr.Name]Default{
 				attr.BeylaIP:    false,
 				attr.Transport:  false,
 				attr.SrcAddress: false,
@@ -217,7 +217,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 		RPCClientDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &grpcClientInfo},
-			MetricAttributes: map[attr.Name]Default{
+			Attributes: map[attr.Name]Default{
 				attr.RPCMethod:         true,
 				attr.RPCSystem:         true,
 				attr.RPCGRPCStatusCode: true,
@@ -225,7 +225,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 		RPCServerDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &serverInfo},
-			MetricAttributes: map[attr.Name]Default{
+			Attributes: map[attr.Name]Default{
 				attr.RPCMethod:         true,
 				attr.RPCSystem:         true,
 				attr.RPCGRPCStatusCode: true,
@@ -236,7 +236,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 		DBClientDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes},
-			MetricAttributes: map[attr.Name]Default{
+			Attributes: map[attr.Name]Default{
 				attr.DBOperation: true,
 				attr.DBSystem:    true,
 				attr.ErrorType:   true,
@@ -249,7 +249,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			SubGroups: []*AttrReportGroup{&messagingAttributes},
 		},
 		Traces.Section: {
-			MetricAttributes: map[attr.Name]Default{
+			Attributes: map[attr.Name]Default{
 				attr.DBQueryText: false,
 			},
 		},
@@ -268,9 +268,7 @@ func AllAttributeNames() map[attr.Name]struct{} {
 	names := map[attr.Name]struct{}{}
 	// -1 to enable all the metric group flags
 	for _, section := range getDefinitions(-1) {
-		allNames := section.All()
-		maps.Copy(names, allNames.Metric)
-		maps.Copy(names, allNames.Resource)
+		maps.Copy(names, section.All())
 	}
 	return names
 }

--- a/pkg/internal/export/attributes/attr_getters.go
+++ b/pkg/internal/export/attributes/attr_getters.go
@@ -24,25 +24,16 @@ type NamedGetters[T, O any] func(name attr.Name) (Getter[T, O], bool)
 // It differentiates two name formats: the exposed name for the attribute (uses _ for word separation, as
 // required by Prometheus); and the internal name of the attribute (uses . for word separation, as internally Beyla
 // stores the metadata).
-func PrometheusGetters[T, O any](getter NamedGetters[T, O], names Sections[[]attr.Name]) []Field[T, O] {
-	// at the moment we will still keep prometheus attributes as metric-level
-	// TODO: move resource-level attributes to target_info metrics
-	attrNames := make([]attr.Name, 0, len(names.Metric)+len(names.Resource))
-	attrNames = append(attrNames, names.Metric...)
-	attrNames = append(attrNames, names.Resource...)
-	return buildGetterList(getter, attrNames, attr.Name.Prom)
+func PrometheusGetters[T, O any](getter NamedGetters[T, O], names []attr.Name) []Field[T, O] {
+	return buildGetterList(getter, names, attr.Name.Prom)
 }
 
 // OpenTelemetryGetters builds a list of Getter getters for the names provided by the
 // user configuration, ready to be passed to an OpenTelemetry exporter.
-func OpenTelemetryGetters[T, O any](getter NamedGetters[T, O], names Sections[[]attr.Name]) Sections[[]Field[T, O]] {
-	otelToStr := func(name attr.Name) string {
+func OpenTelemetryGetters[T, O any](getter NamedGetters[T, O], names []attr.Name) []Field[T, O] {
+	return buildGetterList(getter, names, func(name attr.Name) string {
 		return string(name.OTEL())
-	}
-	return Sections[[]Field[T, O]]{
-		Resource: buildGetterList(getter, names.Resource, otelToStr),
-		Metric:   buildGetterList(getter, names.Metric, otelToStr),
-	}
+	})
 }
 
 func buildGetterList[T, O any](

--- a/pkg/internal/export/attributes/attr_selector_test.go
+++ b/pkg/internal/export/attributes/attr_selector_test.go
@@ -31,18 +31,15 @@ func TestFor(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"beyla.ip",
-			"k8s.dst.namespace",
-			"k8s.dst.node.ip",
-			"k8s.src.namespace",
-			"k8s.src.node.ip",
-			"src.address",
-			"src.name",
-			"src.port",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"beyla.ip",
+		"k8s.dst.namespace",
+		"k8s.dst.node.ip",
+		"k8s.src.namespace",
+		"k8s.src.node.ip",
+		"src.address",
+		"src.name",
+		"src.port",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -61,22 +58,19 @@ func TestFor_GlobEntries(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"beyla.ip",
-			"k8s.dst.namespace",
-			"k8s.dst.node.ip",
-			"k8s.dst.owner.type",
-			"k8s.dst.type",
-			"k8s.src.namespace",
-			"k8s.src.node.ip",
-			"k8s.src.owner.type",
-			"k8s.src.type",
-			"src.address",
-			"src.name",
-			"src.port",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"beyla.ip",
+		"k8s.dst.namespace",
+		"k8s.dst.node.ip",
+		"k8s.dst.owner.type",
+		"k8s.dst.type",
+		"k8s.src.namespace",
+		"k8s.src.node.ip",
+		"k8s.src.owner.type",
+		"k8s.src.type",
+		"src.address",
+		"src.name",
+		"src.port",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -91,13 +85,10 @@ func TestFor_GlobEntries_NoInclusion(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"k8s.cluster.name",
-			"k8s.src.owner.name",
-			"src.cidr",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"k8s.cluster.name",
+		"k8s.src.owner.name",
+		"src.cidr",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -115,15 +106,12 @@ func TestFor_GlobEntries_Order(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"beyla.ip",
-			"dst.name",
-			"src.address",
-			"src.name",
-			"src.port",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"beyla.ip",
+		"dst.name",
+		"src.address",
+		"src.name",
+		"src.port",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -139,11 +127,8 @@ func TestFor_GlobEntries_Order_Default(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"url.path",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"url.path",
 	}, p.For(HTTPServerDuration))
 }
 
@@ -155,13 +140,10 @@ func TestFor_KubeDisabled(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"beyla.ip",
-			"src.address",
-			"src.name",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"beyla.ip",
+		"src.address",
+		"src.name",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -176,15 +158,12 @@ func TestNilDoesNotCrash(t *testing.T) {
 func TestDefault(t *testing.T) {
 	p, err := NewAttrSelector(GroupKubernetes, nil)
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"k8s.cluster.name",
-			"k8s.dst.namespace",
-			"k8s.dst.owner.name",
-			"k8s.src.namespace",
-			"k8s.src.owner.name",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"k8s.cluster.name",
+		"k8s.dst.namespace",
+		"k8s.dst.owner.name",
+		"k8s.src.namespace",
+		"k8s.src.owner.name",
 	}, p.For(BeylaNetworkFlow))
 }
 
@@ -195,10 +174,7 @@ func TestTraces(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, Sections[[]attr.Name]{
-		Metric: []attr.Name{
-			"db.query.text",
-		},
-		Resource: []attr.Name{},
+	assert.Equal(t, []attr.Name{
+		"db.query.text",
 	}, p.For(Traces))
 }

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -166,15 +166,15 @@ type MetricsReporter struct {
 	is         instrumentations.InstrumentationSelection
 
 	// user-selected fields for each of the reported metrics
-	attrHTTPDuration          attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrHTTPClientDuration    attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrGRPCServer            attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrGRPCClient            attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrDBClient              attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrMessagingPublish      attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrMessagingProcess      attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrHTTPRequestSize       attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
-	attrHTTPClientRequestSize attributes.Sections[[]attributes.Field[*request.Span, attribute.KeyValue]]
+	attrHTTPDuration          []attributes.Field[*request.Span, attribute.KeyValue]
+	attrHTTPClientDuration    []attributes.Field[*request.Span, attribute.KeyValue]
+	attrGRPCServer            []attributes.Field[*request.Span, attribute.KeyValue]
+	attrGRPCClient            []attributes.Field[*request.Span, attribute.KeyValue]
+	attrDBClient              []attributes.Field[*request.Span, attribute.KeyValue]
+	attrMessagingPublish      []attributes.Field[*request.Span, attribute.KeyValue]
+	attrMessagingProcess      []attributes.Field[*request.Span, attribute.KeyValue]
+	attrHTTPRequestSize       []attributes.Field[*request.Span, attribute.KeyValue]
+	attrHTTPClientRequestSize []attributes.Field[*request.Span, attribute.KeyValue]
 }
 
 // Metrics is a set of metrics associated to a given OTEL MeterProvider.
@@ -379,28 +379,28 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 			return fmt.Errorf("creating http duration histogram metric: %w", err)
 		}
 		m.httpDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpDuration, mr.attrHTTPDuration.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, httpDuration, mr.attrHTTPDuration, timeNow, mr.cfg.TTL)
 
 		httpClientDuration, err := meter.Float64Histogram(attributes.HTTPClientDuration.OTEL, instrument.WithUnit("s"))
 		if err != nil {
 			return fmt.Errorf("creating http duration histogram metric: %w", err)
 		}
 		m.httpClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpClientDuration, mr.attrHTTPClientDuration.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, httpClientDuration, mr.attrHTTPClientDuration, timeNow, mr.cfg.TTL)
 
 		httpRequestSize, err := meter.Float64Histogram(attributes.HTTPServerRequestSize.OTEL, instrument.WithUnit("By"))
 		if err != nil {
 			return fmt.Errorf("creating http size histogram metric: %w", err)
 		}
 		m.httpRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpRequestSize, mr.attrHTTPRequestSize.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, httpRequestSize, mr.attrHTTPRequestSize, timeNow, mr.cfg.TTL)
 
 		httpClientRequestSize, err := meter.Float64Histogram(attributes.HTTPClientRequestSize.OTEL, instrument.WithUnit("By"))
 		if err != nil {
 			return fmt.Errorf("creating http size histogram metric: %w", err)
 		}
 		m.httpClientRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpClientRequestSize, mr.attrHTTPClientRequestSize.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, httpClientRequestSize, mr.attrHTTPClientRequestSize, timeNow, mr.cfg.TTL)
 	}
 
 	if mr.is.GRPCEnabled() {
@@ -409,14 +409,14 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 			return fmt.Errorf("creating grpc duration histogram metric: %w", err)
 		}
 		m.grpcDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, grpcDuration, mr.attrGRPCServer.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, grpcDuration, mr.attrGRPCServer, timeNow, mr.cfg.TTL)
 
 		grpcClientDuration, err := meter.Float64Histogram(attributes.RPCClientDuration.OTEL, instrument.WithUnit("s"))
 		if err != nil {
 			return fmt.Errorf("creating grpc duration histogram metric: %w", err)
 		}
 		m.grpcClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, grpcClientDuration, mr.attrGRPCClient.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, grpcClientDuration, mr.attrGRPCClient, timeNow, mr.cfg.TTL)
 	}
 
 	if mr.is.DBEnabled() {
@@ -425,7 +425,7 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 			return fmt.Errorf("creating db client duration histogram metric: %w", err)
 		}
 		m.dbClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, dbClientDuration, mr.attrDBClient.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, dbClientDuration, mr.attrDBClient, timeNow, mr.cfg.TTL)
 	}
 
 	if mr.is.MQEnabled() {
@@ -434,14 +434,14 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 			return fmt.Errorf("creating messaging client publish duration histogram metric: %w", err)
 		}
 		m.msgPublishDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, msgPublishDuration, mr.attrMessagingPublish.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, msgPublishDuration, mr.attrMessagingPublish, timeNow, mr.cfg.TTL)
 
 		msgProcessDuration, err := meter.Float64Histogram(attributes.MessagingProcessDuration.OTEL, instrument.WithUnit("s"))
 		if err != nil {
 			return fmt.Errorf("creating messaging client process duration histogram metric: %w", err)
 		}
 		m.msgProcessDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, msgProcessDuration, mr.attrMessagingProcess.Metric, timeNow, mr.cfg.TTL)
+			m.ctx, msgProcessDuration, mr.attrMessagingProcess, timeNow, mr.cfg.TTL)
 	}
 
 	return nil

--- a/pkg/internal/export/otel/metrics_net.go
+++ b/pkg/internal/export/otel/metrics_net.go
@@ -113,7 +113,7 @@ func newMetricsExporter(ctx context.Context, ctxInfo *global.ContextInfo, cfg *N
 		log.Error("creating observable counter", "error", err)
 		return nil, err
 	}
-	expirer := NewExpirer[*ebpf.Record, metric2.Int64Counter, float64](ctx, bytesMetric, attrs.Metric, clock.Time, cfg.Metrics.TTL)
+	expirer := NewExpirer[*ebpf.Record, metric2.Int64Counter, float64](ctx, bytesMetric, attrs, clock.Time, cfg.Metrics.TTL)
 	log.Debug("restricting attributes not in this list", "attributes", cfg.AttributeSelectors)
 	return &netMetricsExporter{
 		ctx:       ctx,

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -154,10 +154,7 @@ func GetUserSelectedAttributes(attrs attributes.Selection) (map[attr.Name]struct
 	}
 	traceAttrsArr := attribProvider.For(attributes.Traces)
 	traceAttrs := make(map[attr.Name]struct{})
-	for _, a := range traceAttrsArr.Metric {
-		traceAttrs[a] = struct{}{}
-	}
-	for _, a := range traceAttrsArr.Resource {
+	for _, a := range traceAttrsArr {
 		traceAttrs[a] = struct{}{}
 	}
 

--- a/pkg/internal/export/prom/prom_proc.go
+++ b/pkg/internal/export/prom/prom_proc.go
@@ -291,8 +291,7 @@ func attributesWithExplicit(
 	// we need to be aware of the user willing to add it to explicitly choose between
 	// observeAggregatedCPU and observeDisaggregatedCPU
 	// Similar for "process_disk_io" or "process_network_io"
-	containsExplicit = slices.Contains(attrNames.Metric, explicitAttribute) ||
-		slices.Contains(attrNames.Resource, explicitAttribute)
+	containsExplicit = slices.Contains(attrNames, explicitAttribute)
 	getters = attributes.PrometheusGetters(process.PromGetters, attrNames)
 
 	if containsExplicit {


### PR DESCRIPTION
This reverts commit 84af0d18, as it was not a good approach.

PR #984 allowed specifying resource attributes per metric, but actually the same resource owns multiple metrics, so we must not let users to define different resource attributes depending on the exposed metric, as the result would be unpredictable.

In a future PR, the user will be able to define resource attributes per metric type: application, process, and network.