### PR TITLE
[WIP Beyla 2.0]: moving some prom attributes to resource-level

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -43,8 +43,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	var prometheusAttributes = AttrReportGroup{
 		Disabled: !promEnabled,
 		Attributes: map[attr.Name]Default{
-			attr.TargetInstance:   true,
-			attr.ServiceNamespace: true,
+			attr.TargetInstance: true,
 		},
 	}
 	// ServiceName and ServiceNamespace are reported both as resource and metric attributes, as
@@ -88,24 +87,6 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		Attributes: map[attr.Name]Default{
 			attr.DstCIDR: true,
 			attr.SrcCIDR: true,
-		},
-	}
-
-	// attributes to be reported exclusively for application metrics when
-	// kubernetes metadata is enabled
-	var appKubeAttributes = AttrReportGroup{
-		Disabled: !kubeEnabled,
-		Attributes: map[attr.Name]Default{
-			attr.K8sNamespaceName:   true,
-			attr.K8sPodName:         true,
-			attr.K8sDeploymentName:  true,
-			attr.K8sReplicaSetName:  true,
-			attr.K8sDaemonSetName:   true,
-			attr.K8sStatefulSetName: true,
-			attr.K8sNodeName:        true,
-			attr.K8sPodUID:          true,
-			attr.K8sPodStartTime:    true,
-			attr.K8sClusterName:     true,
 		},
 	}
 
@@ -159,11 +140,9 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 	}
 
+	// TODO: remove when we move them to resource-level attributes
 	var processAttributes = AttrReportGroup{
-		SubGroups: []*AttrReportGroup{&appKubeAttributes, &hostAttributes},
-		// TODO: attributes below are resource-level, but in App O11y we don't treat processes as resources,
-		// but applications. Let's first consider how to match processes and Applications before marking this spec
-		// as stable
+		SubGroups: []*AttrReportGroup{&hostAttributes},
 		Attributes: map[attr.Name]Default{
 			attr.ProcCommand:     true,
 			attr.ProcCPUState:    true,
@@ -180,7 +159,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	}
 
 	var messagingAttributes = AttrReportGroup{
-		SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes},
+		SubGroups: []*AttrReportGroup{&appAttributes},
 		Attributes: map[attr.Name]Default{
 			attr.MessagingSystem:      true,
 			attr.MessagingDestination: true,
@@ -204,19 +183,19 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			},
 		},
 		HTTPServerDuration.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &httpCommon, &serverInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &httpCommon, &serverInfo},
 		},
 		HTTPServerRequestSize.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &httpCommon, &serverInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &httpCommon, &serverInfo},
 		},
 		HTTPClientDuration.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &httpCommon, &httpClientInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &httpCommon, &httpClientInfo},
 		},
 		HTTPClientRequestSize.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &httpCommon, &httpClientInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &httpCommon, &httpClientInfo},
 		},
 		RPCClientDuration.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &grpcClientInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &grpcClientInfo},
 			Attributes: map[attr.Name]Default{
 				attr.RPCMethod:         true,
 				attr.RPCSystem:         true,
@@ -224,7 +203,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			},
 		},
 		RPCServerDuration.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &serverInfo},
+			SubGroups: []*AttrReportGroup{&appAttributes, &serverInfo},
 			Attributes: map[attr.Name]Default{
 				attr.RPCMethod:         true,
 				attr.RPCSystem:         true,
@@ -235,7 +214,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			},
 		},
 		DBClientDuration.Section: {
-			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes},
+			SubGroups: []*AttrReportGroup{&appAttributes},
 			Attributes: map[attr.Name]Default{
 				attr.DBOperation: true,
 				attr.DBSystem:    true,

--- a/pkg/internal/export/attributes/names/attrs.go
+++ b/pkg/internal/export/attributes/names/attrs.go
@@ -126,13 +126,16 @@ const (
 	// https://prometheus.io/docs/guides/multi-target-exporter/
 	TargetInstance = Name("target.instance")
 
-	// ServiceName and ServiceNamespace are going to be used only on Prometheus
-	// as metric attributes. The OTEL exporter already uses them as Resource
-	// attributes, which can't be enabled/disabled by the users
+	// ServiceName and ServiceNamespace might be used both as Resource and Metric attributes.
 	ServiceName      = Name(semconv.ServiceNameKey)
 	ServiceNamespace = Name(semconv.ServiceNamespaceKey)
 
-	HostName = Name(semconv.HostNameKey)
+	HostName             = Name(semconv.HostNameKey)
+	ServiceInstanceID    = Name(semconv.ServiceInstanceIDKey)
+	TelemetrySDKLanguage = Name(semconv.TelemetrySDKLanguageKey)
+	TelemetrySDKName     = Name(semconv.TelemetrySDKNameKey)
+
+	Job = Name("job")
 )
 
 // traces related attributes

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -18,6 +18,7 @@ import (
 	instrument "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
@@ -517,8 +518,7 @@ func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) 
 func (mr *MetricsReporter) newMetricSet(service *svc.ID) (*Metrics, error) {
 	mlog := mlog().With("service", service)
 	mlog.Debug("creating new Metrics reporter")
-	resources := getResourceAttrs(service)
-
+	resources := resource.NewWithAttributes(semconv.SchemaURL, getResourceAttrs(service)...)
 	opts := []metric.Option{
 		metric.WithResource(resources),
 		metric.WithReader(metric.NewPeriodicReader(mr.exporter,

--- a/pkg/internal/export/otel/metrics_net.go
+++ b/pkg/internal/export/otel/metrics_net.go
@@ -35,7 +35,7 @@ func nmlog() *slog.Logger {
 	return slog.With("component", "otel.NetworkMetricsExporter")
 }
 
-func newResource() *resource.Resource {
+func newNetworkResource() *resource.Resource {
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName("beyla-network-flows"),
 		semconv.ServiceInstanceID(uuid.New().String()),
@@ -87,7 +87,7 @@ func newMetricsExporter(ctx context.Context, ctxInfo *global.ContextInfo, cfg *N
 		return nil, err
 	}
 
-	provider, err := newMeterProvider(newResource(), &exporter, cfg.Metrics.Interval)
+	provider, err := newMeterProvider(newNetworkResource(), &exporter, cfg.Metrics.Interval)
 
 	if err != nil {
 		log.Error("", "error", err)

--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	metric2 "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
 	attr2 "github.com/grafana/beyla/pkg/internal/export/attributes/names"
@@ -189,7 +191,7 @@ func newProcMetricsExporter(
 func (me *procMetricsExporter) newMetricSet(service *svc.ID) (*procMetrics, error) {
 	log := me.log.With("service", service)
 	log.Debug("creating new Metrics exporter")
-	resources := getResourceAttrs(service)
+	resources := resource.NewWithAttributes(semconv.SchemaURL, getResourceAttrs(service)...)
 	opts := []metric.Option{
 		metric.WithResource(resources),
 		metric.WithReader(metric.NewPeriodicReader(me.exporter,

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -370,7 +370,7 @@ func GenerateTraces(span *request.Span, userAttrs map[attr.Name]struct{}) ptrace
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ss := rs.ScopeSpans().AppendEmpty()
-	resourceAttrs := attrsToMap(getResourceAttrs(&span.ServiceID).Attributes())
+	resourceAttrs := attrsToMap(getResourceAttrs(&span.ServiceID))
 	resourceAttrs.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
 	resourceAttrs.CopyTo(rs.Resource().Attributes())
 

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -75,8 +75,6 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			return semconv.MessagingDestinationName("")
 		}
 	}
-	// default: unlike the Prometheus getters, we don't check here for service name nor k8s metadata
-	// because they are already attributes of the Resource instead of the attributes.
 	return getter, getter != nil
 }
 
@@ -146,14 +144,10 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 			}
 			return ""
 		}
-	// resource metadata values below. Unlike OTEL, they are included here because they
-	// belong to the metric, instead of the Resource
 	case attr.ServiceName:
 		getter = func(s *Span) string { return s.ServiceID.Name }
 	case attr.ServiceNamespace:
 		getter = func(s *Span) string { return s.ServiceID.Namespace }
-	default:
-		getter = func(s *Span) string { return s.ServiceID.Metadata[attrName] }
 	}
 	return getter, getter != nil
 }


### PR DESCRIPTION
Moving the attributes to the `target_info` metric in Prometheus, so the Grafana dashboards, alerts, etc... should work the same independently of the exporter type.
