### PR TITLE
Exclude src_port from kubernetes neto11y tests

### DIFF
--- a/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
@@ -24,6 +24,7 @@ data:
         beyla.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
+          exclude: ["src_port"]
 ---
 kind: Service
 apiVersion: v1

--- a/test/integration/k8s/manifests/06-beyla-netolly-sk-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-sk-promexport.yml
@@ -24,6 +24,7 @@ data:
         beyla.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
+          exclude: ["src_port"]
 ---
 kind: Service
 apiVersion: v1

--- a/test/integration/k8s/manifests/06-beyla-netolly.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly.yml
@@ -24,6 +24,7 @@ data:
         beyla.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
+          exclude: ["src_port"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Some tests expecting to have 1 item after querying net o11y metrics are flaky because prometheus sometimes returns two metrics, due to the duplicity of src_port labels (two requests without reusing the connection).