### PR TITLE
OTEL process attributes moved to resource-level

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -178,7 +178,6 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	var processAttributes = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&appKubeAttributes, &hostAttributes, &promProcessAttributes},
 		Attributes: map[attr.Name]Default{
-			// real resource attributes
 			attr.ProcCPUState:  true,
 			attr.ProcDiskIODir: true,
 			attr.ProcNetIODir:  true,

--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -159,23 +159,29 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 	}
 
-	var processAttributes = AttrReportGroup{
-		SubGroups: []*AttrReportGroup{&appKubeAttributes, &hostAttributes},
-		// TODO: attributes below are resource-level, but in App O11y we don't treat processes as resources,
-		// but applications. Let's first consider how to match processes and Applications before marking this spec
-		// as stable
+	// the following attributes are only reported as metric attributes in Prometheus,
+	// as the OTEL standard defines them as resource attributes.
+	var promProcessAttributes = AttrReportGroup{
+		Disabled: !promEnabled,
 		Attributes: map[attr.Name]Default{
 			attr.ProcCommand:     true,
-			attr.ProcCPUState:    true,
 			attr.ProcOwner:       true,
 			attr.ProcParentPid:   true,
 			attr.ProcPid:         true,
-			attr.ProcDiskIODir:   true,
-			attr.ProcNetIODir:    true,
 			attr.ProcCommandLine: false,
 			attr.ProcCommandArgs: false,
 			attr.ProcExecName:    false,
 			attr.ProcExecPath:    false,
+		},
+	}
+
+	var processAttributes = AttrReportGroup{
+		SubGroups: []*AttrReportGroup{&appKubeAttributes, &hostAttributes, &promProcessAttributes},
+		Attributes: map[attr.Name]Default{
+			// real resource attributes
+			attr.ProcCPUState:  true,
+			attr.ProcDiskIODir: true,
+			attr.ProcNetIODir:  true,
 		},
 	}
 

--- a/pkg/internal/export/otel/common.go
+++ b/pkg/internal/export/otel/common.go
@@ -75,6 +75,7 @@ func getResourceAttrs(service *svc.ID) []attribute.KeyValue {
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
 		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
 		semconv.TelemetrySDKNameKey.String("beyla"),
+		semconv.HostName(service.HostName),
 	}
 
 	if service.Namespace != "" {

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -162,7 +162,7 @@ type MetricsReporter struct {
 	cfg        *MetricsConfig
 	attributes *attributes.AttrSelector
 	exporter   metric.Exporter
-	reporters  ReporterPool[*Metrics]
+	reporters  ReporterPool[*svc.ID, *Metrics]
 	is         instrumentations.InstrumentationSelection
 
 	// user-selected fields for each of the reported metrics
@@ -276,7 +276,7 @@ func newMetricsReporter(
 			request.SpanOTELGetters, mr.attributes.For(attributes.MessagingProcessDuration))
 	}
 
-	mr.reporters = NewReporterPool(cfg.ReportersCacheLen, cfg.TTL, timeNow,
+	mr.reporters = NewReporterPool[*svc.ID, *Metrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
 		func(id svc.UID, v *expirable[*Metrics]) {
 			if mr.cfg.SpanMetricsEnabled() {
 				attrOpt := instrument.WithAttributeSet(mr.metricResourceAttributes(v.value.service))

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -18,6 +18,7 @@ import (
 	instrument "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
@@ -517,7 +518,7 @@ func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) 
 func (mr *MetricsReporter) newMetricSet(service *svc.ID) (*Metrics, error) {
 	mlog := mlog().With("service", service)
 	mlog.Debug("creating new Metrics reporter")
-	resources := getResourceAttrs(service)
+	resources := resource.NewWithAttributes(semconv.SchemaURL, getAppResourceAttrs(service)...)
 
 	opts := []metric.Option{
 		metric.WithResource(resources),

--- a/pkg/internal/export/otel/metrics_proc.go
+++ b/pkg/internal/export/otel/metrics_proc.go
@@ -52,7 +52,7 @@ type procMetricsExporter struct {
 	clock *expire.CachedClock
 
 	exporter  metric.Exporter
-	reporters ReporterPool[*procMetrics]
+	reporters ReporterPool[*svc.ID, *procMetrics]
 
 	log *slog.Logger
 
@@ -165,7 +165,7 @@ func newProcMetricsExporter(
 		mr.netObserver = netAggregatedObserver
 	}
 
-	mr.reporters = NewReporterPool[*procMetrics](cfg.Metrics.ReportersCacheLen, cfg.Metrics.TTL, timeNow,
+	mr.reporters = NewReporterPool[*svc.ID, *procMetrics](cfg.Metrics.ReportersCacheLen, cfg.Metrics.TTL, timeNow,
 		func(id svc.UID, v *expirable[*procMetrics]) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")

--- a/pkg/internal/export/otel/traces.go
+++ b/pkg/internal/export/otel/traces.go
@@ -370,7 +370,7 @@ func GenerateTraces(span *request.Span, userAttrs map[attr.Name]struct{}) ptrace
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ss := rs.ScopeSpans().AppendEmpty()
-	resourceAttrs := attrsToMap(getResourceAttrs(&span.ServiceID).Attributes())
+	resourceAttrs := attrsToMap(getAppResourceAttrs(&span.ServiceID))
 	resourceAttrs.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
 	resourceAttrs.CopyTo(rs.Resource().Attributes())
 

--- a/pkg/internal/export/prom/prom_proc_test.go
+++ b/pkg/internal/export/prom/prom_proc_test.go
@@ -54,13 +54,13 @@ func TestProcPrometheusEndpoint_AggregatedMetrics(t *testing.T) {
 
 	// WHEN it receives process metrics
 	metrics <- []*process.Status{
-		{Service: &svc.ID{}, Command: "foo",
+		{ID: process.ID{Service: &svc.ID{}, Command: "foo"},
 			CPUUtilisationWait: 3, CPUUtilisationSystem: 2, CPUUtilisationUser: 1,
 			CPUTimeUserDelta: 30, CPUTimeWaitDelta: 20, CPUTimeSystemDelta: 10,
 			IOReadBytesDelta: 123, IOWriteBytesDelta: 456,
 			NetRcvBytesDelta: 12, NetTxBytesDelta: 34,
 		},
-		{Service: &svc.ID{}, Command: "bar",
+		{ID: process.ID{Service: &svc.ID{}, Command: "bar"},
 			CPUUtilisationWait: 31, CPUUtilisationSystem: 21, CPUUtilisationUser: 11,
 			CPUTimeUserDelta: 301, CPUTimeWaitDelta: 201, CPUTimeSystemDelta: 101,
 			IOReadBytesDelta: 321, IOWriteBytesDelta: 654,
@@ -83,7 +83,7 @@ func TestProcPrometheusEndpoint_AggregatedMetrics(t *testing.T) {
 
 	// AND WHEN new metrics are received
 	metrics <- []*process.Status{
-		{Service: &svc.ID{}, Command: "foo",
+		{ID: process.ID{Service: &svc.ID{}, Command: "foo"},
 			CPUUtilisationWait: 4, CPUUtilisationSystem: 1, CPUUtilisationUser: 2,
 			CPUTimeUserDelta: 3, CPUTimeWaitDelta: 2, CPUTimeSystemDelta: 1,
 			IOReadBytesDelta: 31, IOWriteBytesDelta: 10,
@@ -141,7 +141,7 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 
 	// WHEN it receives process metrics
 	metrics <- []*process.Status{
-		{Service: &svc.ID{}, Command: "foo",
+		{ID: process.ID{Service: &svc.ID{}, Command: "foo"},
 			CPUUtilisationWait: 3, CPUUtilisationSystem: 2, CPUUtilisationUser: 1,
 			CPUTimeUserDelta: 30, CPUTimeWaitDelta: 20, CPUTimeSystemDelta: 10,
 			IOReadBytesDelta: 123, IOWriteBytesDelta: 456,
@@ -166,7 +166,7 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 
 	// AND WHEN new metrics are received
 	metrics <- []*process.Status{
-		{Service: &svc.ID{}, Command: "foo",
+		{ID: process.ID{Service: &svc.ID{}, Command: "foo"},
 			CPUUtilisationWait: 4, CPUUtilisationSystem: 1, CPUUtilisationUser: 2,
 			CPUTimeUserDelta: 3, CPUTimeWaitDelta: 2, CPUTimeSystemDelta: 1,
 			IOReadBytesDelta: 3, IOWriteBytesDelta: 2,

--- a/pkg/internal/infraolly/process/harvest.go
+++ b/pkg/internal/infraolly/process/harvest.go
@@ -118,20 +118,20 @@ func (ps *Harvester) Harvest(svcID *svc.ID) (*Status, error) {
 // populateStaticData populates the status with the process data won't vary during the process life cycle
 func (ps *Harvester) populateStaticData(status *Status, process *linuxProcess) error {
 	process.fetchCommandInfo()
-	status.Command = process.stats.command
-	status.CommandArgs = process.commandArgs
-	status.CommandLine = process.commandLine
-	status.ExecPath = process.execPath
-	status.ExecName = process.execName
+	status.ID.Command = process.stats.command
+	status.ID.CommandArgs = process.commandArgs
+	status.ID.CommandLine = process.commandLine
+	status.ID.ExecPath = process.execPath
+	status.ID.ExecName = process.execName
 
-	status.ProcessID = process.Pid()
+	status.ID.ProcessID = process.Pid()
 
 	var err error
-	if status.User, err = process.Username(); err != nil {
-		ps.log.Debug("can't get username for process", "pid", status.ProcessID, "error", err)
+	if status.ID.User, err = process.Username(); err != nil {
+		ps.log.Debug("can't get username for process", "pid", status.ID.ProcessID, "error", err)
 	}
 
-	status.ParentProcessID = process.stats.ppid
+	status.ID.ParentProcessID = process.stats.ppid
 
 	return nil
 }

--- a/pkg/internal/infraolly/process/harvest_test.go
+++ b/pkg/internal/infraolly/process/harvest_test.go
@@ -74,15 +74,15 @@ func TestLinuxHarvester_Harvest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	assert.Equal(t, int32(os.Getpid()), status.ProcessID)
-	assert.Equal(t, "process.test", status.Command)
-	assert.Contains(t, status.CommandLine, os.Args[0])
-	assert.NotEmpty(t, status.User)
+	assert.Equal(t, int32(os.Getpid()), status.ID.ProcessID)
+	assert.Equal(t, "process.test", status.ID.Command)
+	assert.Contains(t, status.ID.CommandLine, os.Args[0])
+	assert.NotEmpty(t, status.ID.User)
 	assert.Contains(t, "RSD", status.Status,
 		"process status must be R (running), S (interruptible sleep) or D (uninterruptible sleep)")
 	assert.NotZero(t, status.MemoryVMSBytes)
 	assert.NotZero(t, status.MemoryRSSBytes)
-	assert.NotZero(t, status.ParentProcessID)
+	assert.NotZero(t, status.ID.ParentProcessID)
 	assert.NotZero(t, status.ThreadCount)
 }
 
@@ -105,11 +105,11 @@ func TestLinuxHarvester_Harvest_FullCommandLine(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, status)
 
-		assert.Equal(t, "sleep", status.ExecName)
-		assert.Equal(t, "/bin/sleep", status.ExecPath)
-		assert.Equal(t, "/bin/sleep 1m", status.CommandLine)
-		assert.Equal(t, "sleep", status.Command)
-		assert.Equal(t, []string{"1m"}, status.CommandArgs)
+		assert.Equal(t, "sleep", status.ID.ExecName)
+		assert.Equal(t, "/bin/sleep", status.ID.ExecPath)
+		assert.Equal(t, "/bin/sleep 1m", status.ID.CommandLine)
+		assert.Equal(t, "sleep", status.ID.Command)
+		assert.Equal(t, []string{"1m"}, status.ID.CommandArgs)
 	})
 }
 
@@ -127,8 +127,8 @@ func TestLinuxHarvester_Do_InvalidateCache_DifferentCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	// The status is updated
-	assert.NotEmpty(t, status.Command)
-	assert.NotEqual(t, "something old", status.Command)
+	assert.NotEmpty(t, status.ID.Command)
+	assert.NotEqual(t, "something old", status.ID.Command)
 }
 
 func TestLinuxHarvester_Do_InvalidateCache_DifferentPid(t *testing.T) {
@@ -145,5 +145,5 @@ func TestLinuxHarvester_Do_InvalidateCache_DifferentPid(t *testing.T) {
 	require.NoError(t, err)
 
 	// The status is updated
-	assert.NotEqual(t, -1, status.ParentProcessID)
+	assert.NotEqual(t, -1, status.ID.ParentProcessID)
 }

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -19,6 +19,12 @@ func pslog() *slog.Logger {
 type ID struct {
 	Service *svc.ID
 
+	// UID for a process. Even if the Service field has its own UID,
+	// a service might have multiple processes, so Application and Process
+	// will be different resources, each one with its own UID,
+	// which will be the composition of Service.Instance-ProcessID
+	UID svc.UID
+
 	ProcessID       int32
 	ParentProcessID int32
 	User            string
@@ -30,7 +36,7 @@ type ID struct {
 }
 
 func (i *ID) GetUID() svc.UID {
-	return i.Service.UID
+	return i.UID
 }
 
 // Status of a process after being harvested
@@ -71,6 +77,7 @@ func NewStatus(pid int32, svcID *svc.ID) *Status {
 	return &Status{ID: ID{
 		ProcessID: pid,
 		Service:   svcID,
+		UID:       svcID.UID + svc.UID("-"+strconv.Itoa(int(pid))),
 	}}
 }
 

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -16,15 +16,26 @@ func pslog() *slog.Logger {
 	return slog.With("component", "process.Collector")
 }
 
+type ID struct {
+	Service *svc.ID
+
+	ProcessID       int32
+	ParentProcessID int32
+	User            string
+	Command         string
+	CommandArgs     []string
+	CommandLine     string
+	ExecName        string
+	ExecPath        string
+}
+
+func (i *ID) GetUID() svc.UID {
+	return i.Service.UID
+}
+
 // Status of a process after being harvested
 type Status struct {
-	ProcessID   int32
-	User        string
-	Command     string
-	CommandArgs []string
-	CommandLine string
-	ExecName    string
-	ExecPath    string
+	ID ID
 
 	// Despite values below are absolute counters, the OTEL and Prometheus APIs require that
 	// they are specified as deltas
@@ -43,10 +54,9 @@ type Status struct {
 	MemoryRSSBytesDelta int64
 	MemoryVMSBytesDelta int64
 
-	Status          string
-	ParentProcessID int32
-	ThreadCount     int32
-	FdCount         int32
+	Status      string
+	ThreadCount int32
+	FdCount     int32
 
 	IOReadCount       uint64
 	IOWriteCount      uint64
@@ -55,56 +65,24 @@ type Status struct {
 
 	NetTxBytesDelta  int64
 	NetRcvBytesDelta int64
-
-	Service *svc.ID
 }
 
 func NewStatus(pid int32, svcID *svc.ID) *Status {
-	return &Status{
+	return &Status{ID: ID{
 		ProcessID: pid,
 		Service:   svcID,
-	}
+	}}
 }
 
+// OTELGetters is currently empty as most attributes are resource-level,
+// but left as a placeholder for future attribute additions.
 // nolint:cyclop
 func OTELGetters(name attr.Name) (attributes.Getter[*Status, attribute.KeyValue], bool) {
 	var g attributes.Getter[*Status, attribute.KeyValue]
 	switch name {
-	case attr.HostName:
-		g = func(s *Status) attribute.KeyValue { return attribute.Key(attr.HostName).String(s.Service.HostName) }
-	case attr.ProcCommand:
-		g = func(s *Status) attribute.KeyValue { return attribute.Key(attr.ProcCommand).String(s.Command) }
-	case attr.ProcCommandLine:
-		g = func(s *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcCommandLine).String(s.CommandLine)
-		}
-	case attr.ProcExecName:
-		g = func(status *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcExecName).String(status.ExecName)
-		}
-	case attr.ProcExecPath:
-		g = func(status *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcExecPath).String(status.ExecPath)
-		}
-	case attr.ProcCommandArgs:
-		g = func(status *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcCommandArgs).StringSlice(status.CommandArgs)
-		}
-	case attr.ProcOwner:
-		g = func(s *Status) attribute.KeyValue { return attribute.Key(attr.ProcOwner).String(s.User) }
-	case attr.ProcParentPid:
-		g = func(s *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcParentPid).Int(int(s.ParentProcessID))
-		}
-	case attr.ProcPid:
-		g = func(s *Status) attribute.KeyValue {
-			return attribute.Key(attr.ProcPid).Int(int(s.ProcessID))
-		}
 	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the OTEL exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
-	default:
-		g = func(s *Status) attribute.KeyValue { return attribute.String(string(name), s.Service.Metadata[name]) }
 	}
 	return g, g != nil
 }
@@ -114,28 +92,28 @@ func PromGetters(name attr.Name) (attributes.Getter[*Status, string], bool) {
 	var g attributes.Getter[*Status, string]
 	switch name {
 	case attr.HostName:
-		g = func(s *Status) string { return s.Service.HostName }
+		g = func(s *Status) string { return s.ID.Service.HostName }
 	case attr.ProcCommand:
-		g = func(s *Status) string { return s.Command }
+		g = func(s *Status) string { return s.ID.Command }
 	case attr.ProcCommandLine:
-		g = func(s *Status) string { return s.CommandLine }
+		g = func(s *Status) string { return s.ID.CommandLine }
 	case attr.ProcExecName:
-		g = func(status *Status) string { return status.ExecName }
+		g = func(status *Status) string { return status.ID.ExecName }
 	case attr.ProcExecPath:
-		g = func(status *Status) string { return status.ExecPath }
+		g = func(status *Status) string { return status.ID.ExecPath }
 	case attr.ProcCommandArgs:
-		g = func(status *Status) string { return strings.Join(status.CommandArgs, ",") }
+		g = func(status *Status) string { return strings.Join(status.ID.CommandArgs, ",") }
 	case attr.ProcOwner:
-		g = func(s *Status) string { return s.User }
+		g = func(s *Status) string { return s.ID.User }
 	case attr.ProcParentPid:
-		g = func(s *Status) string { return strconv.Itoa(int(s.ParentProcessID)) }
+		g = func(s *Status) string { return strconv.Itoa(int(s.ID.ParentProcessID)) }
 	case attr.ProcPid:
-		g = func(s *Status) string { return strconv.Itoa(int(s.ProcessID)) }
+		g = func(s *Status) string { return strconv.Itoa(int(s.ID.ProcessID)) }
 	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the prometheus exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
 	default:
-		g = func(s *Status) string { return s.Service.Metadata[name] }
+		g = func(s *Status) string { return s.ID.Service.Metadata[name] }
 	}
 	return g, g != nil
 }

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -78,6 +78,10 @@ type ID struct {
 	HostName string
 }
 
+func (i *ID) GetUID() UID {
+	return i.UID
+}
+
 func (i *ID) String() string {
 	if i.Namespace != "" {
 		return i.Namespace + "/" + i.Name


### PR DESCRIPTION
Moved some OTEL process attributes from metric to resource-level, to be compliant with the specification: https://opentelemetry.io/docs/specs/semconv/resource/process/