### PR TITLE
Make sure we have enough access for span metrics

### DIFF
--- a/charts/beyla/templates/cluster-role.yaml
+++ b/charts/beyla/templates/cluster-role.yaml
@@ -15,12 +15,8 @@ rules:
     resources: [ "replicasets" ]
     verbs: [ "list", "watch" ]
   - apiGroups: [ "" ]
-    {{- if or (eq .Values.preset "network") .Values.config.data.network }}
     resources: [ "pods", "services", "nodes" ]
-    {{- else }}
-    resources: [ "pods" ]
-    {{- end }}
-    verbs: [ "list", "watch" ]
+    verbs: [ "list", "watch", "get" ]
   {{- with .Values.rbac.extraClusterRoleRules }}
   {{- toYaml . | nindent 2 }}
   {{- end}}


### PR DESCRIPTION
We now fetch the service names in app observability too. Make the permissions the same for neto11y and appo11y.