### PR TITLE
Cleanup BTF

### DIFF
--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 
 	common "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/request"
@@ -135,6 +136,8 @@ func (pt *ProcessTracer) tracers() ([]Tracer, error) {
 		tracers = append(tracers, p)
 	}
 
+	btf.FlushKernelSpec()
+
 	return tracers, nil
 }
 
@@ -173,6 +176,8 @@ func RunUtilityTracer(p UtilityTracer, pinPath string) error {
 	}
 
 	go p.Run(context.Background())
+
+	btf.FlushKernelSpec()
 
 	return nil
 }


### PR DESCRIPTION
The Linux BTF memory parsed by ebpf-go holds onto all the symbols. On my machine this is 30 MB. From this issue I found that we can cleanup this memory manually after we've loaded the programs https://github.com/cilium/ebpf/issues/1063. It's hard to tell exactly when for performance reasons, but I want to see if I can pass the tests with manual cleanup on every tracer install.

Beyla started without any programs, resident state size of the memory after pprof which triggers GC:

Before:
```
VmRSS:	           83884 kB
RssAnon:	   50924 kB
RssFile:	   32960 kB
```

After:
```
VmRSS:	           43312 kB
RssAnon:	   10032 kB
RssFile:	   33280 kB
```

From 83MB to 43MB.