### PR TITLE
Allow for easier network metrics enablement

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
 version: 1.2.1
-appVersion: 1.6.2
+appVersion: main
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
 version: 1.2.1
-appVersion: main
+appVersion: 1.6.2
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -835,7 +835,7 @@ The purpose of this value is to avoid reporting indefinitely finished applicatio
 
 | YAML       | Environment variable          | Type            | Default                      |
 |------------|-------------------------------|-----------------|------------------------------|
-| `features` | `BEYLA_OTEL_METRICS_FEATURES` | list of strings | `["application", "network"]` |
+| `features` | `BEYLA_OTEL_METRICS_FEATURES` | list of strings | `["application"]` |
 
 A list of metric groups which are allowed to be exported. Each group belongs to a different feature
 of Beyla: application-level metrics or network metrics.
@@ -853,8 +853,8 @@ of Beyla: application-level metrics or network metrics.
   the OpenTelemetry service names used in Beyla. In Kubernetes environments, the OpenTelemetry service name set by the service name
   discovery is the best choice for service graph metrics.
 - If the list contains `network`, the Beyla OpenTelemetry exporter exports network-level
-  metrics; but only if there is defined an OpenTelemetry endpoint and the
-  [network metrics are enabled]({{< relref "../network" >}}).
+  metrics; but only if there is an OpenTelemetry endpoint defined. For network-level metrics options visit the
+  [network metrics]({{< relref "../network" >}}) configuration documentation.
 
 Usually you do not need to change this configuration option, unless, for example, a Beyla instance
 instruments both network and applications, and you want to disable application-level metrics because
@@ -1214,7 +1214,7 @@ The `buckets` object allows overriding the bucket boundaries of diverse histogra
 
 | YAML       | Environment variable        | Type            | Default                      |
 |------------|-----------------------------|-----------------|------------------------------|
-| `features` | `BEYLA_PROMETHEUS_FEATURES` | list of strings | `["application", "network"]` |
+| `features` | `BEYLA_PROMETHEUS_FEATURES` | list of strings | `["application"]` |
 
 A list of metric groups that are allowed to be exported. Each group belongs to a different feature
 of Beyla: application-level metrics or network metrics.
@@ -1232,8 +1232,8 @@ of Beyla: application-level metrics or network metrics.
   the OpenTelemetry service names used in Beyla. In Kubernetes environments, the OpenTelemetry service name set by the service name
   discovery is the best choice for service graph metrics.
 - If the list contains `network`, the Beyla Prometheus exporter exports network-level
-  metrics; but only if the Prometheus `port` property is defined and the
-  [network metrics are enabled]({{< relref "../network" >}}).
+  metrics; but only if the Prometheus `port` property is defined. For network-level metrics options visit the
+  [network metrics]({{< relref "../network" >}}) configuration documentation.
 
 Usually you do not need to change this configuration option, unless, for example, a Beyla instance
 instruments both network and applications, and you want to disable application-level metrics because

--- a/docs/sources/network/config.md
+++ b/docs/sources/network/config.md
@@ -52,7 +52,9 @@ network metrics (in the previous example, `otel_metrics_export`, but it also acc
 | -------- | ----------------------- | ------- | ------- |
 | `enable` | `BEYLA_NETWORK_METRICS` | boolean | `false` |
 
-Enables network metrics reporting in Beyla.
+Explicitly enables network metrics reporting in Beyla. You can also enable network metrics reporting
+by adding `network` to the list of `features` for [otel_metrics_export]({{< relref "../configure/options.md#otel-metrics-exporter" >}}))
+or [prometheus_export]({{< relref "../configure/options.md#prometheus-http-endpoint" >}})).
 
 | YAML                 | Environment variable               | Type     | Default             |
 | -------------------- | ---------------------------------- | -------- | ------------------- |

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -288,6 +288,26 @@ func TestConfig_OtelGoAutoEnv(t *testing.T) {
 	assert.True(t, cfg.Exec.IsSet()) // Exec maps to BEYLA_EXECUTABLE_NAME
 }
 
+func TestConfig_NetworkImplicit(t *testing.T) {
+	// OTEL_GO_AUTO_TARGET_EXE is an alias to BEYLA_EXECUTABLE_NAME
+	// (Compatibility with OpenTelemetry)
+	require.NoError(t, os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"))
+	require.NoError(t, os.Setenv("BEYLA_OTEL_METRIC_FEATURES", "network"))
+	cfg, err := LoadConfig(bytes.NewReader(nil))
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled(FeatureNetO11y)) // Net o11y should be on
+}
+
+func TestConfig_NetworkImplicitProm(t *testing.T) {
+	// OTEL_GO_AUTO_TARGET_EXE is an alias to BEYLA_EXECUTABLE_NAME
+	// (Compatibility with OpenTelemetry)
+	require.NoError(t, os.Setenv("BEYLA_PROMETHEUS_PORT", "9090"))
+	require.NoError(t, os.Setenv("BEYLA_PROMETHEUS_FEATURES", "network"))
+	cfg, err := LoadConfig(bytes.NewReader(nil))
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled(FeatureNetO11y)) // Net o11y should be on
+}
+
 func loadConfig(t *testing.T, env map[string]string) *Config {
 	for k, v := range env {
 		require.NoError(t, os.Setenv(k, v))

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -120,7 +120,7 @@ network:
 				DurationHistogram:    []float64{0, 1, 2},
 				RequestSizeHistogram: otel.DefaultBuckets.RequestSizeHistogram,
 			},
-			Features: []string{"network", "application"},
+			Features: []string{"application"},
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
@@ -140,7 +140,7 @@ network:
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path:     "/metrics",
-			Features: []string{otel.FeatureNetwork, otel.FeatureApplication},
+			Features: []string{otel.FeatureApplication},
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -157,7 +157,7 @@ func (m *MetricsConfig) NetworkMetricsEnabled() bool {
 }
 
 func (m *MetricsConfig) Enabled() bool {
-	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.SpanMetricsEnabled() || m.ServiceGraphMetricsEnabled())
+	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.SpanMetricsEnabled() || m.ServiceGraphMetricsEnabled() || m.NetworkMetricsEnabled())
 }
 
 // MetricsReporter implements the graph node that receives request.Span

--- a/pkg/internal/export/otel/metrics.go
+++ b/pkg/internal/export/otel/metrics.go
@@ -152,6 +152,10 @@ func (m *MetricsConfig) OTelMetricsEnabled() bool {
 	return slices.Contains(m.Features, FeatureApplication)
 }
 
+func (m *MetricsConfig) NetworkMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureNetwork)
+}
+
 func (m *MetricsConfig) Enabled() bool {
 	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.SpanMetricsEnabled() || m.ServiceGraphMetricsEnabled())
 }

--- a/pkg/internal/export/otel/metrics_net.go
+++ b/pkg/internal/export/otel/metrics_net.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,10 +24,11 @@ import (
 type NetMetricsConfig struct {
 	Metrics            *MetricsConfig
 	AttributeSelectors attributes.Selection
+	GloballyEnabled    bool
 }
 
 func (mc NetMetricsConfig) Enabled() bool {
-	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() && slices.Contains(mc.Metrics.Features, FeatureNetwork)
+	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() && (mc.Metrics.NetworkMetricsEnabled() || mc.GloballyEnabled)
 }
 
 func nmlog() *slog.Logger {

--- a/pkg/internal/export/otel/metrics_test.go
+++ b/pkg/internal/export/otel/metrics_test.go
@@ -528,6 +528,7 @@ func TestMetricsConfig_Enabled(t *testing.T) {
 	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
 	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
 	assert.True(t, (&MetricsConfig{Features: []string{FeatureNetwork, FeatureApplication}, Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}).Enabled())
+	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
@@ -536,7 +537,6 @@ func TestMetricsConfig_Disabled(t *testing.T) {
 	assert.False(t, (&MetricsConfig{Features: []string{FeatureApplication}, Grafana: &GrafanaOTLP{Submit: []string{"metrics"}}}).Enabled())
 	// application feature is not enabled
 	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
-	assert.False(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
 	assert.False(t, (&MetricsConfig{Grafana: &GrafanaOTLP{Submit: []string{"traces", "metrics"}, InstanceID: "33221"}}).Enabled())
 }
 

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -138,7 +138,7 @@ func (p *PrometheusConfig) EndpointEnabled() bool {
 
 // nolint:gocritic
 func (p *PrometheusConfig) Enabled() bool {
-	return p.EndpointEnabled() && (p.OTelMetricsEnabled() || p.SpanMetricsEnabled() || p.ServiceGraphMetricsEnabled())
+	return p.EndpointEnabled() && (p.OTelMetricsEnabled() || p.SpanMetricsEnabled() || p.ServiceGraphMetricsEnabled() || p.NetworkMetricsEnabled())
 }
 
 type metricsReporter struct {

--- a/pkg/internal/export/prom/prom.go
+++ b/pkg/internal/export/prom/prom.go
@@ -128,6 +128,10 @@ func (p *PrometheusConfig) ServiceGraphMetricsEnabled() bool {
 	return slices.Contains(p.Features, otel.FeatureGraph)
 }
 
+func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
+	return slices.Contains(p.Features, otel.FeatureNetwork)
+}
+
 func (p *PrometheusConfig) EndpointEnabled() bool {
 	return p.Port != 0 || p.Registry != nil
 }

--- a/pkg/internal/export/prom/prom_net.go
+++ b/pkg/internal/export/prom/prom_net.go
@@ -3,7 +3,6 @@ package prom
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/mariomac/pipes/pipe"
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,7 +10,6 @@ import (
 	"github.com/grafana/beyla/pkg/internal/connector"
 	"github.com/grafana/beyla/pkg/internal/export/attributes"
 	"github.com/grafana/beyla/pkg/internal/export/expire"
-	"github.com/grafana/beyla/pkg/internal/export/otel"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 )
@@ -22,11 +20,12 @@ import (
 type NetPrometheusConfig struct {
 	Config             *PrometheusConfig
 	AttributeSelectors attributes.Selection
+	GloballyEnabled    bool
 }
 
 // nolint:gocritic
 func (p NetPrometheusConfig) Enabled() bool {
-	return p.Config != nil && p.Config.Port != 0 && slices.Contains(p.Config.Features, otel.FeatureNetwork)
+	return p.Config != nil && p.Config.Port != 0 && (p.Config.NetworkMetricsEnabled() || p.GloballyEnabled)
 }
 
 type netMetricsReporter struct {

--- a/pkg/internal/netolly/agent/pipeline.go
+++ b/pkg/internal/netolly/agent/pipeline.go
@@ -136,12 +136,14 @@ func (f *Flows) pipelineBuilder(ctx context.Context) (*pipe.Builder[*FlowsPipeli
 		return otel.NetMetricsExporterProvider(ctx, f.ctxInfo, &otel.NetMetricsConfig{
 			Metrics:            &f.cfg.Metrics,
 			AttributeSelectors: f.cfg.Attributes.Select,
+			GloballyEnabled:    f.cfg.NetworkFlows.Enable,
 		})
 	})
 	pipe.AddFinalProvider(pb, promExport, func() (pipe.FinalFunc[[]*ebpf.Record], error) {
 		return prom.NetPrometheusEndpoint(ctx, f.ctxInfo, &prom.NetPrometheusConfig{
 			Config:             &f.cfg.Prometheus,
 			AttributeSelectors: f.cfg.Attributes.Select,
+			GloballyEnabled:    f.cfg.NetworkFlows.Enable,
 		})
 	})
 	pipe.AddFinalProvider(pb, printer, func() (pipe.FinalFunc[[]*ebpf.Record], error) {

--- a/test/integration/docker-compose-netolly-direction.yml
+++ b/test/integration/docker-compose-netolly-direction.yml
@@ -41,7 +41,7 @@ services:
       BEYLA_CONFIG_PATH: /configs/instrumenter-config-netolly${BEYLA_CONFIG_SUFFIX}.yml
       GOCOVERDIR: "/coverage"
       BEYLA_NETWORK_SOURCE: ${BEYLA_NETWORK_SOURCE}
-      BEYLA_NETWORK_METRICS: "true"
+      BEYLA_OTEL_METRICS_FEATURES: "network" # implicitly enabling network metrics without a global enable
       BEYLA_NETWORK_PRINT_FLOWS: "true"
       BEYLA_NETWORK_DEDUPER: ${BEYLA_NETWORK_DEDUPER}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318

--- a/test/integration/docker-compose-netolly.yml
+++ b/test/integration/docker-compose-netolly.yml
@@ -32,7 +32,7 @@ services:
       BEYLA_CONFIG_PATH: /configs/instrumenter-config-netolly${BEYLA_CONFIG_SUFFIX}.yml
       GOCOVERDIR: "/coverage"
       BEYLA_NETWORK_SOURCE: ${BEYLA_NETWORK_SOURCE}
-      BEYLA_NETWORK_METRICS: "true"
+      BEYLA_NETWORK_METRICS: "true" # explicitly enabling network metrics
       BEYLA_NETWORK_PRINT_FLOWS: "true"
       BEYLA_NETWORK_DEDUPER: ${BEYLA_NETWORK_DEDUPER}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318

--- a/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
@@ -86,8 +86,8 @@ spec:
               value: "/testoutput"
             - name: BEYLA_CONFIG_PATH
               value: /config/beyla-config.yml
-            - name: BEYLA_NETWORK_METRICS
-              value: "true"
+            - name: BEYLA_PROMETHEUS_FEATURES # implicitly enabling network metrics for Prometheus scrape
+              value: "network"
             - name: BEYLA_NETWORK_CACHE_ACTIVE_TIMEOUT
               value: "100ms"
             - name: BEYLA_NETWORK_CACHE_MAX_FLOWS


### PR DESCRIPTION
Enabling network metrics could be confusing if the documentation isn't always properly read. Essentially we had an internal default of enabled metrics features "application,network", however to actually enable network metrics collection we had to explicitly turn on network monitoring. This duality created some friction. For example, we'd fail to enable properly network metrics with these configuration options:

```
  BEYLA_OTEL_METRIC_FEATURES: "application"
  BEYLA_NETWORK_METRICS: "true"
  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:...
```

If we read what the configuration says:
1. We want to have metric features "application".
2. We want to enable network metrics collection.

A properly working configuration would've been:

```
  BEYLA_OTEL_METRIC_FEATURES: "application,network"
  BEYLA_NETWORK_METRICS: "true"
  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:...
```

So kind of double enabling network metrics.

At the same time, the following configuration doesn't enable network metrics:

```
  BEYLA_OTEL_METRIC_FEATURES: "application,network"
  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:...
```
Since we are missing the flag to enable network metrics, even though we've specified in the features we want network metrics.

I think the correct way to enable any metric collection feature is to list it explicitly in the `features` section, e.g. "application,network" should enable both, no further option should be required. 

This PR resolves this, but to keep backwards compatibility I kept the explicit enablement of the network metrics via BEYLA_NETWORK_METRICS: "true", which is equivalent to adding the "network" keyword in the `features` section for both OTel and Prometheus export.