### PR TITLE
avoid ipv6 loopback address reported as src or dst of span

### DIFF
--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -239,11 +239,11 @@ func (connInfo *BPFConnInfo) reqHostInfo() (source, target string) {
 	srcStr := src.String()
 	dstStr := dst.String()
 
-	if src.IsUnspecified() {
+	if src.IsUnspecified() || src.Equal(net.IPv6loopback) {
 		srcStr = ""
 	}
 
-	if dst.IsUnspecified() {
+	if dst.IsUnspecified() || dst.Equal(net.IPv6loopback) {
 		dstStr = ""
 	}
 


### PR DESCRIPTION
address first part of https://github.com/grafana/beyla/issues/895