### PR TITLE
remove client.address as default attribute on RPC metrics

### DIFF
--- a/pkg/internal/export/attributes/attr_defs.go
+++ b/pkg/internal/export/attributes/attr_defs.go
@@ -236,9 +236,6 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 				attr.RPCMethod:         true,
 				attr.RPCSystem:         true,
 				attr.RPCGRPCStatusCode: true,
-				// Overriding default serverInfo configuration because we want
-				// to report it by default
-				attr.ClientAddr: true,
 			},
 		},
 		DBClientDuration.Section: {

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -44,7 +44,7 @@ func gctx(groups attributes.AttrGroups) *global.ContextInfo {
 }
 
 var allMetrics = attributes.Selection{
-	attributes.HTTPServerDuration.Section: attributes.InclusionLists{Include: []string{"*"}},
+	"*": attributes.InclusionLists{Include: []string{"*"}},
 }
 
 func allMetricsBut(patterns ...string) attributes.Selection {


### PR DESCRIPTION
Enabling this attribute by default could lead to thousands/millions of new series for public services with high number of clients.