### PR TITLE
Disable DNS name resolver by default

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -56,7 +56,6 @@ var DefaultConfig = Config{
 		},
 	},
 	NameResolver: &transform.NameResolverConfig{
-		Enable:   false,
 		CacheLen: 1024,
 		CacheTTL: 5 * time.Minute,
 	},

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -56,6 +56,7 @@ var DefaultConfig = Config{
 		},
 	},
 	NameResolver: &transform.NameResolverConfig{
+		Sources:  []string{"k8s"},
 		CacheLen: 1024,
 		CacheTTL: 5 * time.Minute,
 	},

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -56,6 +56,7 @@ var DefaultConfig = Config{
 		},
 	},
 	NameResolver: &transform.NameResolverConfig{
+		Enable:   false,
 		CacheLen: 1024,
 		CacheTTL: 5 * time.Minute,
 	},

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -65,6 +65,7 @@ network:
 	require.NoError(t, os.Setenv("BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT", "3210"))
 	require.NoError(t, os.Setenv("GRAFANA_CLOUD_SUBMIT", "metrics,traces"))
 	require.NoError(t, os.Setenv("KUBECONFIG", "/foo/bar"))
+	require.NoError(t, os.Setenv("BEYLA_NAME_RESOLVER_SOURCES", "k8s,dns"))
 	defer unsetEnv(t, map[string]string{
 		"KUBECONFIG":      "",
 		"BEYLA_OPEN_PORT": "", "BEYLA_EXECUTABLE_NAME": "", "OTEL_SERVICE_NAME": "", "BEYLA_NOOP_TRACES": "",
@@ -176,6 +177,7 @@ network:
 			Unmatch: transform.UnmatchHeuristic,
 		},
 		NameResolver: &transform.NameResolverConfig{
+			Sources:  []string{"k8s", "dns"},
 			CacheLen: 1024,
 			CacheTTL: 5 * time.Minute,
 		},

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 
 	attr "github.com/grafana/beyla/pkg/export/attributes/names"
-	"github.com/grafana/beyla/pkg/internal/helpers"
+	maps2 "github.com/grafana/beyla/pkg/internal/helpers/maps"
 )
 
 // Default is true if an attribute must be reported by default,
@@ -52,7 +52,7 @@ func (p *AttrSelector) For(metricName Name) []attr.Name {
 	allInclusionLists := p.selector.Matching(metricName)
 	if len(allInclusionLists) == 0 {
 		// if the user did not provide any selector, return the default attributes for that metric
-		attrs := helpers.SetToSlice(attributeNames.Default())
+		attrs := maps2.SetToSlice(attributeNames.Default())
 		slices.Sort(attrs)
 		return attrs
 	}
@@ -68,7 +68,7 @@ func (p *AttrSelector) For(metricName Name) []attr.Name {
 		p.rmExcludedAttributes(matchingAttrs, il)
 	}
 
-	sas := helpers.SetToSlice(matchingAttrs)
+	sas := maps2.SetToSlice(matchingAttrs)
 	slices.Sort(sas)
 	return sas
 }

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/internal/ebpf"
 	"github.com/grafana/beyla/pkg/internal/goexec"
-	"github.com/grafana/beyla/pkg/internal/helpers"
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
@@ -31,7 +31,7 @@ type TraceAttacher struct {
 	// processInstances keeps track of the instances of each process. This will help making sure
 	// that we don't remove the BPF resources of an executable until all their instances are removed
 	// are stopped
-	processInstances helpers.MultiCounter[uint64]
+	processInstances maps.MultiCounter[uint64]
 
 	// keeps a copy of all the tracers for a given executable path
 	existingTracers map[uint64]*ebpf.ProcessTracer
@@ -45,7 +45,7 @@ func TraceAttacherProvider(ta *TraceAttacher) pipe.FinalProvider[[]Event[Instrum
 func (ta *TraceAttacher) attacherLoop() (pipe.FinalFunc[[]Event[Instrumentable]], error) {
 	ta.log = slog.With("component", "discover.TraceAttacher")
 	ta.existingTracers = map[uint64]*ebpf.ProcessTracer{}
-	ta.processInstances = helpers.MultiCounter[uint64]{}
+	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.pinPath = BuildPinPath(ta.Cfg)
 
 	if err := ta.init(); err != nil {

--- a/pkg/internal/discover/watcher_kube.go
+++ b/pkg/internal/discover/watcher_kube.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mariomac/pipes/pipe"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/grafana/beyla/pkg/internal/helpers"
 	"github.com/grafana/beyla/pkg/internal/helpers/container"
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
 	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/services"
 )
@@ -41,7 +41,7 @@ type watcherKubeEnricher struct {
 	// we use our own indexer instead an informer indexer because we need a 1:N relation while
 	// the other indices provide N:1 relation
 	// level-1 key: replicaset ns/name. Level-2 key: Pod name
-	podsByOwner helpers.Map2[nsName, string, *kube.PodInfo]
+	podsByOwner maps.Map2[nsName, string, *kube.PodInfo]
 
 	podsInfoCh chan Event[*kube.PodInfo]
 	rsInfoCh   chan Event[*kube.ReplicaSetInfo]
@@ -84,7 +84,7 @@ func (wk *watcherKubeEnricher) init() error {
 	wk.log = slog.With("component", "discover.watcherKubeEnricher")
 	wk.containerByPID = map[PID]container.Info{}
 	wk.processByContainer = map[string]processAttrs{}
-	wk.podsByOwner = helpers.Map2[nsName, string, *kube.PodInfo]{}
+	wk.podsByOwner = maps.Map2[nsName, string, *kube.PodInfo]{}
 
 	// the podsInfoCh channel will receive any update about pods being created or deleted
 	wk.podsInfoCh = make(chan Event[*kube.PodInfo], 10)

--- a/pkg/internal/helpers/maps/bits.go
+++ b/pkg/internal/helpers/maps/bits.go
@@ -1,0 +1,45 @@
+package maps
+
+// Bits wraps an unsigned integer that can be used as a bit map
+type Bits uint
+
+type builderOpts[T any] struct {
+	transform []func(T) T
+}
+
+// BuilderOpt allows defining option for building Bits map in the MappedBits method
+type BuilderOpt[T any] func(*builderOpts[T])
+
+// WithTransform will apply the provided transformer function to the passed key values
+// in the MappedBits constructor function
+func WithTransform[T any](transformFunc func(T) T) BuilderOpt[T] {
+	return func(o *builderOpts[T]) {
+		o.transform = append(o.transform, transformFunc)
+	}
+}
+
+// MappedBits builds a Bits map from a set of values (e.g. strings) that are mapped in the form
+// value --> corresponding Bits value
+// in the "maps" constructor argument
+func MappedBits[T comparable](values []T, maps map[T]Bits, opts ...BuilderOpt[T]) Bits {
+	bo := builderOpts[T]{}
+	for _, opt := range opts {
+		opt(&bo)
+	}
+
+	b := Bits(0)
+	for _, value := range values {
+		for _, t := range bo.transform {
+			value = t(value)
+		}
+		if val, ok := maps[value]; ok {
+			b |= val
+		}
+	}
+	return b
+}
+
+// Has returns true if the map contains all the value Bits passed as argument
+func (i Bits) Has(value Bits) bool {
+	return i&value == value
+}

--- a/pkg/internal/helpers/maps/bits_test.go
+++ b/pkg/internal/helpers/maps/bits_test.go
@@ -1,0 +1,37 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type key int
+
+var mapper = map[key]Bits{1: 0b0001, 2: 0b0010, 3: 0b0100, 4: 0b1000}
+
+func TestBits_Full(t *testing.T) {
+	bits := MappedBits([]key{1, 2, 3, 4}, mapper)
+	assert.True(t, bits.Has(0b0001))
+	assert.True(t, bits.Has(0b0010))
+	assert.True(t, bits.Has(0b0100))
+	assert.True(t, bits.Has(0b1000))
+}
+
+func TestBits_Empty(t *testing.T) {
+	bits := MappedBits(nil, mapper)
+	assert.False(t, bits.Has(0b0001))
+	assert.False(t, bits.Has(0b0010))
+	assert.False(t, bits.Has(0b0100))
+	assert.False(t, bits.Has(0b1000))
+}
+
+func TestBits_Transform(t *testing.T) {
+	bits := MappedBits([]key{10, 30, 8910}, mapper,
+		WithTransform(func(k key) key { return k / 10 }))
+	assert.True(t, bits.Has(0b0001))
+	assert.False(t, bits.Has(0b0010))
+	assert.True(t, bits.Has(0b0100))
+	assert.False(t, bits.Has(0b1000))
+	assert.False(t, bits.Has(0xb10000)) // key non-existing i the mappers
+}

--- a/pkg/internal/helpers/maps/maps.go
+++ b/pkg/internal/helpers/maps/maps.go
@@ -1,4 +1,4 @@
-package helpers
+package maps
 
 // MultiCounter maps a counter to a given key
 type MultiCounter[K comparable] map[K]*int

--- a/pkg/internal/helpers/maps/maps_test.go
+++ b/pkg/internal/helpers/maps/maps_test.go
@@ -1,4 +1,4 @@
-package helpers
+package maps
 
 import (
 	"slices"

--- a/pkg/internal/kube/informer.go
+++ b/pkg/internal/kube/informer.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
 )
 
 const (
@@ -52,7 +54,7 @@ type Metadata struct {
 
 	containerEventHandlers []ContainerEventHandler
 
-	disabledInformers informerType
+	disabledInformers maps.Bits
 }
 
 // PodInfo contains precollected metadata for Pods.

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
 )
 
 type EnableFlag string
@@ -28,7 +30,7 @@ type MetadataProvider struct {
 	syncTimeout    time.Duration
 
 	enable            atomic.Value
-	disabledInformers informerType
+	disabledInformers maps.Bits
 }
 
 func NewMetadataProvider(

--- a/pkg/internal/kube/informer_type.go
+++ b/pkg/internal/kube/informer_type.go
@@ -1,30 +1,28 @@
 package kube
 
-import "strings"
+import (
+	"strings"
 
-type informerType int
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
+)
 
 const (
-	InformerService = informerType(1 << iota)
+	InformerService = maps.Bits(1 << iota)
 	InformerReplicaSet
 	InformerNode
 )
 
-func informerTypes(str []string) informerType {
-	it := informerType(0)
-	for _, s := range str {
-		switch strings.ToLower(s) {
-		case "service", "services":
-			it |= InformerService
-		case "replicaset", "replicasets":
-			it |= InformerReplicaSet
-		case "node", "nodes":
-			it |= InformerNode
-		}
-	}
-	return it
-}
-
-func (i informerType) Has(it informerType) bool {
-	return i&it != 0
+func informerTypes(str []string) maps.Bits {
+	return maps.MappedBits(
+		str,
+		map[string]maps.Bits{
+			"service":     InformerService,
+			"services":    InformerService,
+			"replicaset":  InformerReplicaSet,
+			"replicasets": InformerReplicaSet,
+			"node":        InformerNode,
+			"nodes":       InformerNode,
+		},
+		maps.WithTransform(strings.ToLower),
+	)
 }

--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -33,7 +33,7 @@ func resolverSources(str []string) maps.Bits {
 
 type NameResolverConfig struct {
 	// Sources for name resolving. Accepted values: dns, k8s
-	Sources []string `yaml:"sources" env:"BEYLA_NAME_RESOLVER_SOURCES" envSeparator:","`
+	Sources []string `yaml:"sources" env:"BEYLA_NAME_RESOLVER_SOURCES" envSeparator:"," envDefault:"k8s"`
 	// CacheLen specifies the max size of the LRU cache that is checked before
 	// performing the name lookup. Default: 256
 	CacheLen int `yaml:"cache_len" env:"BEYLA_NAME_RESOLVER_CACHE_LEN"`

--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -10,14 +10,30 @@ import (
 	"github.com/mariomac/pipes/pipe"
 
 	attr "github.com/grafana/beyla/pkg/export/attributes/names"
+	"github.com/grafana/beyla/pkg/internal/helpers/maps"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/pkg/internal/svc"
 	kube2 "github.com/grafana/beyla/pkg/internal/transform/kube"
 )
 
+const (
+	ResolverDNS = maps.Bits(1 << iota)
+	ResolverK8s
+)
+
+func resolverSources(str []string) maps.Bits {
+	return maps.MappedBits(str, map[string]maps.Bits{
+		"dns":        ResolverDNS,
+		"k8s":        ResolverK8s,
+		"kube":       ResolverK8s,
+		"kubernetes": ResolverK8s,
+	}, maps.WithTransform(strings.ToLower))
+}
+
 type NameResolverConfig struct {
-	Enable bool `yaml:"enable" env:"BEYLA_NAME_RESOLVER_ENABLE" default:"false"`
+	// Sources for name resolving. Accepted values: dns, k8s
+	Sources []string `yaml:"sources" env:"BEYLA_NAME_RESOLVER_SOURCES" envSeparator:","`
 	// CacheLen specifies the max size of the LRU cache that is checked before
 	// performing the name lookup. Default: 256
 	CacheLen int `yaml:"cache_len" env:"BEYLA_NAME_RESOLVER_CACHE_LEN"`
@@ -31,11 +47,13 @@ type NameResolver struct {
 	cache *expirable.LRU[string, string]
 	cfg   *NameResolverConfig
 	db    *kube2.Database
+
+	sources maps.Bits
 }
 
 func NameResolutionProvider(ctxInfo *global.ContextInfo, cfg *NameResolverConfig) pipe.MiddleProvider[[]request.Span, []request.Span] {
 	return func() (pipe.MiddleFunc[[]request.Span, []request.Span], error) {
-		if cfg == nil || !cfg.Enable {
+		if cfg == nil || len(cfg.Sources) == 0 {
 			return pipe.Bypass[[]request.Span](), nil
 		}
 		return nameResolver(ctxInfo, cfg)
@@ -44,9 +62,10 @@ func NameResolutionProvider(ctxInfo *global.ContextInfo, cfg *NameResolverConfig
 
 func nameResolver(ctxInfo *global.ContextInfo, cfg *NameResolverConfig) (pipe.MiddleFunc[[]request.Span, []request.Span], error) {
 	nr := NameResolver{
-		cfg:   cfg,
-		db:    ctxInfo.AppO11y.K8sDatabase,
-		cache: expirable.NewLRU[string, string](cfg.CacheLen, nil, cfg.CacheTTL),
+		cfg:     cfg,
+		db:      ctxInfo.AppO11y.K8sDatabase,
+		cache:   expirable.NewLRU[string, string](cfg.CacheLen, nil, cfg.CacheTTL),
+		sources: resolverSources(cfg.Sources),
 	}
 
 	return func(in <-chan []request.Span, out chan<- []request.Span) {
@@ -130,7 +149,7 @@ func (nr *NameResolver) dnsResolve(svc *svc.ID, ip string) (string, string) {
 		return "", ""
 	}
 
-	if nr.db != nil {
+	if nr.sources.Has(ResolverK8s) && nr.db != nil {
 		ipAddr := net.ParseIP(ip)
 
 		if ipAddr != nil && !ipAddr.IsLoopback() {
@@ -142,14 +161,15 @@ func (nr *NameResolver) dnsResolve(svc *svc.ID, ip string) (string, string) {
 		}
 	}
 
-	n := nr.resolveIP(ip)
-	if n == ip {
+	if nr.sources.Has(ResolverDNS) {
+		n := nr.resolveIP(ip)
+		if n == ip {
+			return n, svc.Namespace
+		}
+		n = nr.cleanName(svc, ip, n)
 		return n, svc.Namespace
 	}
-
-	n = nr.cleanName(svc, ip, n)
-
-	return n, svc.Namespace
+	return "", ""
 }
 
 func (nr *NameResolver) resolveFromK8s(ip string) (string, string) {

--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -17,6 +17,7 @@ import (
 )
 
 type NameResolverConfig struct {
+	Enable bool `yaml:"enable" env:"BEYLA_NAME_RESOLVER_ENABLE" default:"false"`
 	// CacheLen specifies the max size of the LRU cache that is checked before
 	// performing the name lookup. Default: 256
 	CacheLen int `yaml:"cache_len" env:"BEYLA_NAME_RESOLVER_CACHE_LEN"`
@@ -34,7 +35,7 @@ type NameResolver struct {
 
 func NameResolutionProvider(ctxInfo *global.ContextInfo, cfg *NameResolverConfig) pipe.MiddleProvider[[]request.Span, []request.Span] {
 	return func() (pipe.MiddleFunc[[]request.Span, []request.Span], error) {
-		if cfg == nil {
+		if cfg == nil || !cfg.Enable {
 			return pipe.Bypass[[]request.Span](), nil
 		}
 		return nameResolver(ctxInfo, cfg)

--- a/pkg/transform/name_resolver_test.go
+++ b/pkg/transform/name_resolver_test.go
@@ -62,8 +62,9 @@ func TestResolvePodsFromK8s(t *testing.T) {
 	assert.Nil(t, db.PodInfoForIP("10.1.0.3"))
 
 	nr := NameResolver{
-		db:    &db,
-		cache: expirable.NewLRU[string, string](10, nil, 5*time.Hour),
+		db:      &db,
+		cache:   expirable.NewLRU[string, string](10, nil, 5*time.Hour),
+		sources: resolverSources([]string{"dns", "k8s"}),
 	}
 
 	name, namespace := nr.resolveFromK8s("10.0.0.1")
@@ -144,8 +145,9 @@ func TestResolveServiceFromK8s(t *testing.T) {
 	assert.Nil(t, db.PodInfoForIP("10.1.0.3"))
 
 	nr := NameResolver{
-		db:    &db,
-		cache: expirable.NewLRU[string, string](10, nil, 5*time.Hour),
+		db:      &db,
+		cache:   expirable.NewLRU[string, string](10, nil, 5*time.Hour),
+		sources: resolverSources([]string{"dns", "k8s"}),
 	}
 
 	name, namespace := nr.resolveFromK8s("10.0.0.1")

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -118,4 +118,5 @@ spec:
               value: "application,application_span,application_service_graph,application_process"
             - name: BEYLA_KUBE_CLUSTER_NAME
               value: "beyla"
-
+            - name: BEYLA_NAME_RESOLVER_SOURCES
+              value: "dns,k8s"

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -130,6 +130,8 @@ spec:
               value: "30m0s"
             - name: BEYLA_KUBE_CLUSTER_NAME
               value: "beyla"
+            - name: BEYLA_NAME_RESOLVER_SOURCES
+              value: "dns,k8s"
           ports:
             - containerPort: 8999
               hostPort: 8999

--- a/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
@@ -86,3 +86,5 @@ spec:
               value: "30m0s"
             - name: BEYLA_OTEL_METRICS_FEATURES
               value: "application,application_process"
+            - name: BEYLA_NAME_RESOLVER_SOURCES
+              value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -72,3 +72,5 @@ spec:
               value: "true"
             - name: BEYLA_METRICS_REPORT_PEER
               value: "true"
+            - name: BEYLA_NAME_RESOLVER_SOURCES
+              value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -88,3 +88,5 @@ spec:
               value: "30m0s"
             - name: BEYLA_OTEL_METRICS_FEATURES
               value: "application,application_process"
+            - name: BEYLA_NAME_RESOLVER_SOURCES
+              value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -78,3 +78,5 @@ spec:
           value: "true"
         - name: BEYLA_KUBE_METADATA_ENABLE
           value: "true"
+        - name: BEYLA_NAME_RESOLVER_SOURCES
+          value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -78,3 +78,5 @@ spec:
           value: "true"
         - name: BEYLA_KUBE_METADATA_ENABLE
           value: "true"
+        - name: BEYLA_NAME_RESOLVER_SOURCES
+          value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
@@ -79,3 +79,5 @@ spec:
           value: "true"
         - name: BEYLA_KUBE_METADATA_ENABLE
           value: "true"
+        - name: BEYLA_NAME_RESOLVER_SOURCES
+          value: "dns,k8s"

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -79,3 +79,5 @@ spec:
           value: "true"
         - name: BEYLA_KUBE_METADATA_ENABLE
           value: "true"
+        - name: BEYLA_NAME_RESOLVER_SOURCES
+          value: "dns,k8s"

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -123,3 +123,5 @@ spec:
           value: "8999"
         - name: BEYLA_KUBE_METADATA_ENABLE
           value: "autodetect"
+        - name: BEYLA_NAME_RESOLVER_SOURCES
+          value: "dns,k8s"


### PR DESCRIPTION
We realized that the name resolver component could overload the DNS on scenarios where Beyla instruments many spans whose IPs don't have a known hostname.

We will disable it by default.