### PR TITLE
Use Prometheus registry when specified

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -116,10 +116,13 @@ func buildCommonContextInfo(
 	}
 	if config.InternalMetrics.Prometheus.Port != 0 {
 		slog.Debug("reporting internal metrics as Prometheus")
-		ctxInfo.Metrics = imetrics.NewPrometheusReporter(&config.InternalMetrics.Prometheus, promMgr)
+		ctxInfo.Metrics = imetrics.NewPrometheusReporter(&config.InternalMetrics.Prometheus, promMgr, nil)
 		// Prometheus manager also has its own internal metrics, so we need to pass the imetrics reporter
 		// TODO: remove this dependency cycle and let prommgr to create and return the PrometheusReporter
 		promMgr.InstrumentWith(ctxInfo.Metrics)
+	} else if config.Prometheus.Registry != nil {
+		slog.Debug("reporting internal metrics with Prometheus Registry")
+		ctxInfo.Metrics = imetrics.NewPrometheusReporter(&config.InternalMetrics.Prometheus, nil, config.Prometheus.Registry)
 	} else {
 		slog.Debug("not reporting internal metrics")
 		ctxInfo.Metrics = imetrics.NoopReporter{}

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -114,16 +114,17 @@ func buildCommonContextInfo(
 			config.Attributes.Kubernetes.InformersSyncTimeout,
 		),
 	}
-	if config.InternalMetrics.Prometheus.Port != 0 {
+	switch {
+	case config.InternalMetrics.Prometheus.Port != 0:
 		slog.Debug("reporting internal metrics as Prometheus")
 		ctxInfo.Metrics = imetrics.NewPrometheusReporter(&config.InternalMetrics.Prometheus, promMgr, nil)
 		// Prometheus manager also has its own internal metrics, so we need to pass the imetrics reporter
 		// TODO: remove this dependency cycle and let prommgr to create and return the PrometheusReporter
 		promMgr.InstrumentWith(ctxInfo.Metrics)
-	} else if config.Prometheus.Registry != nil {
+	case config.Prometheus.Registry != nil:
 		slog.Debug("reporting internal metrics with Prometheus Registry")
 		ctxInfo.Metrics = imetrics.NewPrometheusReporter(&config.InternalMetrics.Prometheus, nil, config.Prometheus.Registry)
-	} else {
+	default:
 		slog.Debug("not reporting internal metrics")
 		ctxInfo.Metrics = imetrics.NoopReporter{}
 	}

--- a/pkg/export/prom/prom_proc.go
+++ b/pkg/export/prom/prom_proc.go
@@ -46,6 +46,9 @@ func ProcPrometheusEndpoint(
 		if err != nil {
 			return nil, err
 		}
+		if cfg.Metrics.Registry != nil {
+			return reporter.collectMetrics, nil
+		}
 		return reporter.reportMetrics, nil
 	}
 }
@@ -178,17 +181,29 @@ func newProcReporter(
 		mr.netObserver = mr.observeAggregatedNet
 	}
 
-	mr.promConnect.Register(cfg.Metrics.Port, cfg.Metrics.Path,
-		mr.cpuUtilization, mr.cpuTime,
-		mr.memory, mr.memoryVirtual,
-		mr.disk,
-		mr.net)
+	if cfg.Metrics.Registry != nil {
+		cfg.Metrics.Registry.MustRegister(
+			mr.cpuUtilization, mr.cpuTime,
+			mr.memory, mr.memoryVirtual,
+			mr.disk, mr.net,
+		)
+	} else {
+		mr.promConnect.Register(cfg.Metrics.Port, cfg.Metrics.Path,
+			mr.cpuUtilization, mr.cpuTime,
+			mr.memory, mr.memoryVirtual,
+			mr.disk,
+			mr.net)
+	}
 
 	return mr, nil
 }
 
 func (r *procMetricsReporter) reportMetrics(input <-chan []*process.Status) {
 	go r.promConnect.StartHTTP(r.bgCtx)
+	r.collectMetrics(input)
+}
+
+func (r *procMetricsReporter) collectMetrics(input <-chan []*process.Status) {
 	for processes := range input {
 		// clock needs to be updated to let the expirer
 		// remove the old metrics


### PR DESCRIPTION
This PR enables using the Prometheus Registry (for Alloy) for the following metrics:
- Internal metrics
- Network metrics
- Process metrics