### PR TITLE
Introduce JSON span printer

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -199,7 +199,7 @@ config:
 # -- extra environment variables
 env: {}
   # BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT: 9090
-  # BEYLA_PRINT_TRACES: "true"
+  # BEYLA_TRACE_PRINTER: "text"
 
 # -- extra environment variables to be set from resources such as k8s configMaps/secrets
 envValueFrom: {}

--- a/contrib/example-service.yaml
+++ b/contrib/example-service.yaml
@@ -1,6 +1,6 @@
 open_port: 8000
 service_name: my-django-app
-print_traces: true
+trace_printer: text
 
 ebpf:
   wakeup_len: 100

--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -68,8 +68,8 @@ spec:
               value: "/config/beyla-config.yml"
             - name: BEYLA_SERVICE_NAME
               value: "goblog"
-            - name: BEYLA_PRINT_TRACES
-              value: "true"
+            - name: BEYLA_TRACE_PRINTER
+              value: "text"
             - name: BEYLA_OPEN_PORT
               value: "8443"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -171,11 +171,29 @@ Sets the verbosity level of the process standard output logger.
 Valid log level values are: `DEBUG`, `INFO`, `WARN` and `ERROR`.
 `DEBUG` being the most verbose and `ERROR` the least verbose.
 
+| YAML            | Environment variable  | Type    | Default    |
+| --------------  | --------------------- | ------- | ---------- |
+| `trace_printer` | `BEYLA_TRACE_PRINTER` | string  | `disabled` |
+
+<a id="printer"></a>
+
+Prints any instrumented trace on the standard output (stdout). The value of
+this option specify the format to be used when printing the trace. Valid
+formats are:
+
+| Value         | Description                    |
+|---------------|--------------------------------|
+| `disabled`    | disables the printer           |
+| `text`        | prints a concise line of text  |
+| `json`        | prints a compact JSON object   |
+| `json_indent` | prints an indented JSON object |
+
+
+**The following option has been DEPRECATED.** *Use `trace_printer` instead.*
+
 | YAML           | Environment variable              | Type    | Default |
 | -------------- | -------------------- | ------- | ------- |
 | `print_traces` | `BEYLA_PRINT_TRACES` | boolean | `false` |
-
-<a id="printer"></a>
 
 If `true`, prints any instrumented trace on the standard output (stdout).
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -177,7 +177,7 @@ Valid log level values are: `DEBUG`, `INFO`, `WARN` and `ERROR`.
 
 <a id="printer"></a>
 
-Prints any instrumented trace on the standard output (stdout). The value of
+Prints any instrumented trace on the standard output. The value of
 this option specify the format to be used when printing the trace. Valid
 formats are:
 
@@ -188,14 +188,6 @@ formats are:
 | `json`        | prints a compact JSON object   |
 | `json_indent` | prints an indented JSON object |
 
-
-**The following option has been DEPRECATED.** *Use `trace_printer` instead.*
-
-| YAML           | Environment variable              | Type    | Default |
-| -------------- | -------------------- | ------- | ------- |
-| `print_traces` | `BEYLA_PRINT_TRACES` | boolean | `false` |
-
-If `true`, prints any instrumented trace on the standard output (stdout).
 
 ## Service discovery
 

--- a/docs/sources/network/quickstart.md
+++ b/docs/sources/network/quickstart.md
@@ -145,7 +145,7 @@ Note the following requirements for this deployment configuration:
 - To listen to network packets on the host, Beyla requires the `hostNetwork: true` permission
 - To decorate the network metrics with Kubernetes metadata, create a `ClusterRole` and `ClusterRoleBinding` with `list` and `watch` permissions for ReplicaSets, Pods, Services and Nodes
 
-The configuration does not set an endpoint to export metrics. Instead, the `print_traces: true` option outputs the captured network flows to standard output.
+The configuration does not set an endpoint to export metrics. Instead, the `trace_printer: text` option outputs the captured network flows to standard output.
 
 Use `kubectl logs` to see network flow entries, for example:
 

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -51,7 +51,7 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -51,13 +51,13 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -59,13 +59,13 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -59,7 +59,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 

--- a/docs/sources/quickstart/java.md
+++ b/docs/sources/quickstart/java.md
@@ -47,7 +47,7 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This causes Beyla to print traces to the standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 

--- a/docs/sources/quickstart/java.md
+++ b/docs/sources/quickstart/java.md
@@ -47,13 +47,13 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This causes Beyla to print traces to the standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This causes Beyla to print traces to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -53,7 +53,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically
@@ -64,7 +64,7 @@ Notice: Beyla requires administrative (sudo) privileges, or at least it needs to
 ```sh
 export BEYLA_SERVICE_NAME=quickstart
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -53,7 +53,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -51,7 +51,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -51,7 +51,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically
@@ -62,7 +62,7 @@ Notice: Beyla requires administrative (sudo) privileges, or at least it needs to
 ```sh
 export BEYLA_SERVICE_NAME=quickstart
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -51,7 +51,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -51,7 +51,7 @@ To run Beyla, first set the following environment variables:
   (for example, `80` or `443`). If using the example service in the
   first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This will cause Beyla to print traces to standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This will cause Beyla to print traces to standard output.
 
 Also set the `BEYLA_SERVICE_NAME=quickstart` to override the reported service
 name in the traces and metrics. If it is not set, Beyla would automatically
@@ -62,7 +62,7 @@ Notice: Beyla requires administrative (sudo) privileges, or at least it needs to
 ```sh
 export BEYLA_SERVICE_NAME=quickstart
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -47,7 +47,7 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This causes Beyla to print traces to the standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -47,13 +47,13 @@ To run Beyla, first set the following environment variables:
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
 - `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
-To facilitate local testing, set the `BEYLA_PRINT_TRACES=true` environment variable. This causes Beyla to print traces to the standard output.
+To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. This causes Beyla to print traces to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
 export BEYLA_OPEN_PORT=8080
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."

--- a/docs/sources/setup/docker.md
+++ b/docs/sources/setup/docker.md
@@ -40,7 +40,7 @@ The above command runs a simple HTTPS application. The process opens the contain
 Set environment variables to configure Beyla to print to stdout and listen to a port (container) to inspect the executable:
 
 ```sh
-export BEYLA_PRINT_TRACES=true
+export BEYLA_TRACE_PRINTER=text
 export BEYLA_OPEN_PORT=8443
 ```
 
@@ -53,7 +53,7 @@ Beyla needs to be run with the following settings:
 ```sh
 docker run --rm \
   -e BEYLA_OPEN_PORT=8443 \
-  -e BEYLA_PRINT_TRACES=true \
+  -e BEYLA_TRACE_PRINTER=text \
   --pid="container:goblog" \
   --privileged \
   grafana/beyla:latest
@@ -96,7 +96,7 @@ services:
     pid: "service:goblog"
     privileged: true
     environment:
-      BEYLA_PRINT_TRACES: true
+      BEYLA_TRACE_PRINTER: text
       BEYLA_OPEN_PORT: 8443
 ```
 

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -336,8 +336,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         image: grafana/beyla:latest
         env:
-          - name: BEYLA_PRINT_TRACES
-            value: "true"
+          - name: BEYLA_TRACE_PRINTER
+            value: "text"
           - name: BEYLA_KUBE_METADATA_ENABLE
             value: "autodetect"
           - name: KUBE_NAMESPACE
@@ -418,7 +418,7 @@ metadata:
   name: beyla-config
 data:
   beyla-config.yml: |
-    print_traces: true
+    trace_printer: text
     grafana:
       otlp:
         submit: ["metrics","traces"]

--- a/docs/sources/tutorial/getting-started.md
+++ b/docs/sources/tutorial/getting-started.md
@@ -112,10 +112,10 @@ after configuring it to print the traces to the standard output.
 Set environment variables and run Beyla:
 
 ```sh
-BEYLA_PRINT_TRACES=true BEYLA_OPEN_PORT=8080 sudo -E beyla
+BEYLA_TRACE_PRINTER=text BEYLA_OPEN_PORT=8080 sudo -E beyla
 ```
 
-The `BEYLA_PRINT_TRACES=true` configuration option tells Beyla to log any trace to the standard output.
+The `BEYLA_TRACE_PRINTER=text` configuration option tells Beyla to log any trace to the standard output.
 The `BEYLA_OPEN_PORT=8080` option tells Beyla to instrument the service that owns the port 8080.
 Since Beyla requires administrator rights to load eBPF programs, the `beyla` command
 must run with `sudo -E` (or as a `root` user).

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     pid: "service:nginx"
     environment:
       BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "3330"
       BEYLA_SERVICE_NAMESPACE: "demo"
       OTEL_SERVICE_NAME: "demo-nginx"
@@ -58,7 +58,7 @@ services:
     pid: "service:gotestserver"
     environment:
       BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "8080"
       BEYLA_SERVICE_NAMESPACE: "demo"
       OTEL_SERVICE_NAME: "demo-go-service"
@@ -88,7 +88,7 @@ services:
     pid: "service:javatestserver"
     environment:
       BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "8085"
       BEYLA_SERVICE_NAMESPACE: "demo"
       OTEL_SERVICE_NAME: "demo-graalvm-native-service"
@@ -118,7 +118,7 @@ services:
     pid: "service:rusttestserver"
     environment:
       BEYLA_CONFIG_PATH: "/configs/beyla-config.yml"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "8090"
       BEYLA_SERVICE_NAMESPACE: "demo"
       OTEL_SERVICE_NAME: "demo-rust-service"

--- a/examples/k8s/unprivileged.yaml
+++ b/examples/k8s/unprivileged.yaml
@@ -127,8 +127,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         image: grafana/beyla:latest
         env:
-          - name: BEYLA_PRINT_TRACES
-            value: "true"
+          - name: BEYLA_TRACE_PRINTER
+            value: "text"
           - name: BEYLA_EXECUTABLE_NAME
             value: "greetings"
           - name: BEYLA_SERVICE_NAMESPACE

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -94,7 +94,6 @@ var DefaultConfig = Config{
 		SpanMetricsServiceCacheSize: 10000,
 	},
 	Printer: false,
-	Noop:    false,
 	InternalMetrics: imetrics.Config{
 		Prometheus: imetrics.PrometheusConfig{
 			Port: 0, // disabled by default
@@ -165,7 +164,6 @@ type Config struct {
 	// are useful for development purposes. They might be helpful for customer support.
 
 	ChannelBufferLen int               `yaml:"channel_buffer_len" env:"BEYLA_CHANNEL_BUFFER_LEN"`
-	Noop             debug.NoopEnabled `yaml:"noop" env:"BEYLA_NOOP_TRACES"`
 	ProfilePort      int               `yaml:"profile_port" env:"BEYLA_PROFILE_PORT"`
 	InternalMetrics  imetrics.Config   `yaml:"internal_metrics"`
 
@@ -237,7 +235,7 @@ func (c *Config) Validate() error {
 			" purposes, you can also set BEYLA_NETWORK_PRINT_FLOWS=true")
 	}
 
-	if c.Enabled(FeatureAppO11y) && !c.Noop.Enabled() && !c.Printer.Enabled() &&
+	if c.Enabled(FeatureAppO11y) && !c.Printer.Enabled() &&
 		!c.Grafana.OTLP.MetricsEnabled() && !c.Grafana.OTLP.TracesEnabled() &&
 		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
 		!c.Prometheus.Enabled() {

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -3,6 +3,7 @@ package beyla
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"time"
 
@@ -93,7 +94,8 @@ var DefaultConfig = Config{
 		TTL:                         defaultMetricsTTL,
 		SpanMetricsServiceCacheSize: 10000,
 	},
-	Printer: false,
+	Printer:      false, // Deprecated: use TracePrinter instead
+	TracePrinter: debug.TracePrinterDisabled,
 	InternalMetrics: imetrics.Config{
 		Prometheus: imetrics.PrometheusConfig{
 			Port: 0, // disabled by default
@@ -140,6 +142,7 @@ type Config struct {
 	Traces       otel.TracesConfig             `yaml:"otel_traces_export"`
 	Prometheus   prom.PrometheusConfig         `yaml:"prometheus_export"`
 	Printer      debug.PrintEnabled            `yaml:"print_traces" env:"BEYLA_PRINT_TRACES"`
+	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"BEYLA_TRACE_PRINTER"`
 
 	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
 	Exec       services.RegexpAttr `yaml:"executable_name" env:"BEYLA_EXECUTABLE_NAME"`
@@ -163,9 +166,9 @@ type Config struct {
 	// From this comment, the properties below will remain undocumented, as they
 	// are useful for development purposes. They might be helpful for customer support.
 
-	ChannelBufferLen int               `yaml:"channel_buffer_len" env:"BEYLA_CHANNEL_BUFFER_LEN"`
-	ProfilePort      int               `yaml:"profile_port" env:"BEYLA_PROFILE_PORT"`
-	InternalMetrics  imetrics.Config   `yaml:"internal_metrics"`
+	ChannelBufferLen int             `yaml:"channel_buffer_len" env:"BEYLA_CHANNEL_BUFFER_LEN"`
+	ProfilePort      int             `yaml:"profile_port" env:"BEYLA_PROFILE_PORT"`
+	InternalMetrics  imetrics.Config `yaml:"internal_metrics"`
 
 	// Processes metrics for application. They will be only enabled if there is a metrics exporter enabled,
 	// and both the "application" and "application_process" features are enabled
@@ -235,11 +238,26 @@ func (c *Config) Validate() error {
 			" purposes, you can also set BEYLA_NETWORK_PRINT_FLOWS=true")
 	}
 
+	if !c.TracePrinter.Valid() {
+		return ConfigError(fmt.Sprintf("invalid value for trace_printer: '%s'", c.TracePrinter))
+	}
+
+	if c.Printer.Enabled() && c.TracePrinter.Enabled() {
+		return ConfigError("print_traces and trace_printer are mutually exclusive, use trace_printer instead")
+	}
+
+	// TODO Printer is deprecated, remove
+	if c.Printer.Enabled() {
+		slog.Warn("'print_traces' configuration option has been deprecated and will be removed" +
+			" in the future - use 'trace_printer' instead")
+		c.TracePrinter = debug.TracePrinterText
+	}
+
 	if c.Enabled(FeatureAppO11y) && !c.Printer.Enabled() &&
 		!c.Grafana.OTLP.MetricsEnabled() && !c.Grafana.OTLP.TracesEnabled() &&
 		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
-		!c.Prometheus.Enabled() {
-		return ConfigError("you need to define at least one exporter: print_traces," +
+		!c.Prometheus.Enabled() && !c.TracePrinter.Enabled() {
+		return ConfigError("you need to define at least one exporter: trace_printer," +
 			" grafana, otel_metrics_export, otel_traces_export or prometheus_export")
 	}
 
@@ -267,7 +285,7 @@ func (c *Config) Enabled(feature Feature) bool {
 
 // SetDebugMode sets the debug mode for Beyla
 func (c *Config) SetDebugMode() {
-	c.Printer = true
+	c.TracePrinter = debug.TracePrinterText
 	c.LogLevel = "DEBUG"
 	c.EBPF.BpfDebug = true
 	if c.NetworkFlows.Enable {

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -62,7 +62,6 @@ network:
 	require.NoError(t, os.Setenv("BEYLA_NETWORK_AGENT_IP", "1.2.3.4"))
 	require.NoError(t, os.Setenv("BEYLA_OPEN_PORT", "8080-8089"))
 	require.NoError(t, os.Setenv("OTEL_SERVICE_NAME", "svc-name"))
-	require.NoError(t, os.Setenv("BEYLA_NOOP_TRACES", "true"))
 	require.NoError(t, os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:3131"))
 	require.NoError(t, os.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "localhost:3232"))
 	require.NoError(t, os.Setenv("BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT", "3210"))
@@ -71,7 +70,7 @@ network:
 	require.NoError(t, os.Setenv("BEYLA_NAME_RESOLVER_SOURCES", "k8s,dns"))
 	defer unsetEnv(t, map[string]string{
 		"KUBECONFIG":      "",
-		"BEYLA_OPEN_PORT": "", "BEYLA_EXECUTABLE_NAME": "", "OTEL_SERVICE_NAME": "", "BEYLA_NOOP_TRACES": "",
+		"BEYLA_OPEN_PORT": "", "BEYLA_EXECUTABLE_NAME": "", "OTEL_SERVICE_NAME": "",
 		"OTEL_EXPORTER_OTLP_ENDPOINT": "", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "", "GRAFANA_CLOUD_SUBMIT": "",
 	})
 
@@ -100,7 +99,6 @@ network:
 		ChannelBufferLen: 33,
 		LogLevel:         "INFO",
 		Printer:          false,
-		Noop:             true,
 		EBPF: ebpfcommon.TracerConfig{
 			BatchLength:        100,
 			BatchTimeout:       time.Second,

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -84,22 +84,6 @@ func spanType(span *request.Span) string {
 	return ""
 }
 
-type NoopEnabled bool
-
-func (n NoopEnabled) Enabled() bool {
-	return bool(n)
-}
-func NoopNode(n NoopEnabled) pipe.FinalProvider[[]request.Span] {
-	return func() (pipe.FinalFunc[[]request.Span], error) {
-		if !n {
-			return pipe.IgnoreFinal[[]request.Span](), nil
 		}
-		counter := 0
-		return func(spans <-chan []request.Span) {
-			for range spans {
-				counter += len(spans)
-			}
-			fmt.Printf("Processed %d requests\n", counter)
-		}, nil
 	}
 }

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -2,7 +2,9 @@
 package debug
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/mariomac/pipes/pipe"
 	"go.opentelemetry.io/otel/trace"
@@ -10,46 +12,112 @@ import (
 	"github.com/grafana/beyla/pkg/internal/request"
 )
 
+// TODO deprecated (REMOVE) - use TracePrinter instead
 type PrintEnabled bool
 
 func (p PrintEnabled) Enabled() bool {
 	return bool(p)
 }
 
-func PrinterNode(e PrintEnabled) pipe.FinalProvider[[]request.Span] {
+type TracePrinter string
+
+const (
+	TracePrinterDisabled   = TracePrinter("disabled")
+	TracePrinterCounter    = TracePrinter("counter")
+	TracePrinterText       = TracePrinter("text")
+	TracePrinterJSON       = TracePrinter("json")
+	TracePrinterJSONIndent = TracePrinter("json_indent")
+)
+
+func mlog() *slog.Logger {
+	return slog.With("component", "debug.TracePrinter")
+}
+
+func (t TracePrinter) Valid() bool {
+	switch t {
+	case TracePrinterDisabled, TracePrinterText, TracePrinterJSON, TracePrinterJSONIndent, TracePrinterCounter:
+		return true
+	}
+
+	return false
+}
+
+func (t TracePrinter) Enabled() bool {
+	return t.Valid() && t != TracePrinterDisabled
+}
+
+func resolvePrinterFunc(p TracePrinter) pipe.FinalFunc[[]request.Span] {
+	const (
+		jsonIndent   = true
+		jsonNoIndent = false
+	)
+
+	switch p {
+	case TracePrinterText:
+		return textPrinter
+	case TracePrinterJSON:
+		return func(input <-chan []request.Span) { jsonPrinter(input, jsonNoIndent) }
+	case TracePrinterJSONIndent:
+		return func(input <-chan []request.Span) { jsonPrinter(input, jsonIndent) }
+	case TracePrinterCounter:
+		return makeCounterPrinter()
+	}
+
+	return pipe.IgnoreFinal[[]request.Span]()
+}
+
+func PrinterNode(p TracePrinter) pipe.FinalProvider[[]request.Span] {
+	printerFunc := resolvePrinterFunc(p)
+
 	return func() (pipe.FinalFunc[[]request.Span], error) {
-		if !e {
-			return pipe.IgnoreFinal[[]request.Span](), nil
-		}
-		return printFunc()
+		return printerFunc, nil
 	}
 }
 
-func printFunc() (pipe.FinalFunc[[]request.Span], error) {
-	return func(input <-chan []request.Span) {
-		for spans := range input {
-			for i := range spans {
-				t := spans[i].Timings()
-				fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] size:%dB svc=[%s %s] traceparent=[%s]\n",
-					t.Start.Format("2006-01-02 15:04:05.12345"),
-					t.End.Sub(t.RequestStart),
-					t.End.Sub(t.Start),
-					spanType(&spans[i]),
-					spans[i].Status,
-					spans[i].Method,
-					spans[i].Path,
-					spans[i].Peer+" as "+spans[i].PeerName,
-					spans[i].PeerPort,
-					spans[i].Host+" as "+spans[i].HostName,
-					spans[i].HostPort,
-					spans[i].ContentLength,
-					&spans[i].ServiceID,
-					spans[i].ServiceID.SDKLanguage.String(),
-					traceparent(&spans[i]),
-				)
-			}
+func textPrinter(input <-chan []request.Span) {
+	for spans := range input {
+		for i := range spans {
+			t := spans[i].Timings()
+			fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] size:%dB svc=[%s %s] traceparent=[%s]\n",
+				t.Start.Format("2006-01-02 15:04:05.12345"),
+				t.End.Sub(t.RequestStart),
+				t.End.Sub(t.Start),
+				spans[i].Type,
+				spans[i].Status,
+				spans[i].Method,
+				spans[i].Path,
+				spans[i].Peer+" as "+spans[i].PeerName,
+				spans[i].PeerPort,
+				spans[i].Host+" as "+spans[i].HostName,
+				spans[i].HostPort,
+				spans[i].ContentLength,
+				&spans[i].ServiceID,
+				spans[i].ServiceID.SDKLanguage.String(),
+				traceparent(&spans[i]),
+			)
 		}
-	}, nil
+	}
+}
+
+func serializeSpansJSON(spans []request.Span, indent bool) ([]byte, error) {
+	if indent {
+		return json.MarshalIndent(spans, "", " ")
+	}
+
+	return json.Marshal(spans)
+}
+
+func jsonPrinter(input <-chan []request.Span, indent bool) {
+	for spans := range input {
+		data, err := serializeSpansJSON(spans, indent)
+
+		if err != nil {
+			mlog().Error("Error serializing span to json")
+			continue
+		}
+
+		fmt.Printf("%s\n", data)
+	}
 }
 
 func traceparent(span *request.Span) string {
@@ -59,31 +127,14 @@ func traceparent(span *request.Span) string {
 	return fmt.Sprintf("00-%s-%s-%02x", trace.TraceID(span.TraceID).String(), trace.SpanID(span.ParentSpanID).String(), span.Flags)
 }
 
-func spanType(span *request.Span) string {
-	switch span.Type {
-	case request.EventTypeHTTP:
-		return "SRV"
-	case request.EventTypeHTTPClient:
-		return "CLNT"
-	case request.EventTypeGRPC:
-		return "GRPC_SRV"
-	case request.EventTypeGRPCClient:
-		return "GRPC_CLNT"
-	case request.EventTypeSQLClient:
-		return "SQL"
-	case request.EventTypeRedisClient:
-		return "REDIS"
-	case request.EventTypeKafkaClient:
-		return "KAFKA"
-	case request.EventTypeRedisServer:
-		return "REDIS_SRV"
-	case request.EventTypeKafkaServer:
-		return "KAFKA_SRV"
-	}
+func makeCounterPrinter() pipe.FinalFunc[[]request.Span] {
+	counter := 0
 
-	return ""
-}
-
+	return func(input <-chan []request.Span) {
+		for spans := range input {
+			counter += len(spans)
 		}
+
+		fmt.Printf("Processed %d requests\n", counter)
 	}
 }

--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -1,0 +1,168 @@
+package debug
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	trace2 "go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/beyla/pkg/internal/request"
+)
+
+func TestTracePrinterValidEnabled(t *testing.T) {
+	type testData struct {
+		printer TracePrinter
+		valid   bool
+		enabled bool
+	}
+
+	printers := []testData{
+		{"disabled", true, false},
+		{"counter", true, true},
+		{"text", true, true},
+		{"json", true, true},
+		{"json_indent", true, true},
+		{"invalid", false, false},
+		{"", false, false},
+	}
+
+	for i := range printers {
+		p := &printers[i]
+		assert.Equal(t, p.printer.Valid(), p.valid)
+		assert.Equal(t, p.printer.Enabled(), p.enabled)
+	}
+}
+
+func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
+	fakeSpan := request.Span{
+		Type:           request.EventTypeHTTP,
+		IgnoreSpan:     request.IgnoreMetrics,
+		Method:         "method",
+		Path:           "path",
+		Route:          "route",
+		Peer:           "peer",
+		PeerPort:       1234,
+		Host:           "host",
+		HostPort:       5678,
+		Status:         200,
+		ContentLength:  1024,
+		RequestStart:   10000,
+		Start:          15000,
+		End:            35000,
+		TraceID:        trace2.TraceID{0x1, 0x2, 0x3},
+		SpanID:         trace2.SpanID{0x1, 0x2, 0x3},
+		ParentSpanID:   trace2.SpanID{0x1, 0x2, 0x3},
+		Flags:          1,
+		PeerName:       "peername",
+		HostName:       "hostname",
+		OtherNamespace: "otherns",
+		Statement:      "statement",
+	}
+
+	// redirect the TracePrinter function stdout to a pipe so that we can
+	// capture and return its output
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	stdout := os.Stdout
+	os.Stdout = w
+
+	spanCh := make(chan []request.Span)
+
+	go func() {
+		f := resolvePrinterFunc(tracePrinter)
+		f(spanCh)
+		w.Close()
+	}()
+
+	spanCh <- []request.Span{fakeSpan}
+	close(spanCh)
+
+	funcOutput, err := io.ReadAll(r)
+	r.Close()
+
+	require.NoError(t, err)
+
+	os.Stdout = stdout
+
+	return string(funcOutput)
+}
+
+func TestTracePrinterResolve_PrinterText(t *testing.T) {
+	expected := "2024-07-20 13:31:54.72013154 (25µs[20µs]) HTTP 200 method path" +
+		" [peer as peername:1234]->[host as hostname:5678] size:1024B svc=[ go]" +
+		" traceparent=[00-01020300000000000000000000000000-0102030000000000-01]\n"
+
+	actual := traceFuncHelper(t, TracePrinterText)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTracePrinterResolve_PrinterCounter(t *testing.T) {
+	expected := "Processed 1 requests\n"
+	actual := traceFuncHelper(t, TracePrinterCounter)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTracePrinterResolve_PrinterJSON(t *testing.T) {
+	expected := `[{"type":"HTTP","ignoreSpan":"Metrics","peer":"peer","peerPort":"1234",` +
+		`"host":"host","hostPort":"5678","traceID":"01020300000000000000000000000000",` +
+		`"spanID":"0102030000000000","parentSpanID":"0102030000000000","flags":"1",` +
+		`"peerName":"peername","hostName":"hostname","kind":"SERVER","start":"1721503914233133",` +
+		`"handlerStart":"1721503914233138","end":"1721503914233158","duration":"25µs",` +
+		`"durationUSec":"25","handlerDuration":"20µs","handlerDurationUSec":"20","attributes":` +
+		`{"clientAddr":"peername","contentLen":"1024","method":"method","route":"route",` +
+		`"serverAddr":"hostname","serverPort":"5678","status":"200","url":"path"}}]` + "\n"
+
+	actual := traceFuncHelper(t, TracePrinterJSON)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTracePrinterResolve_PrinterJSONIndent(t *testing.T) {
+	expected := `[
+ {
+  "type": "HTTP",
+  "ignoreSpan": "Metrics",
+  "peer": "peer",
+  "peerPort": "1234",
+  "host": "host",
+  "hostPort": "5678",
+  "traceID": "01020300000000000000000000000000",
+  "spanID": "0102030000000000",
+  "parentSpanID": "0102030000000000",
+  "flags": "1",
+  "peerName": "peername",
+  "hostName": "hostname",
+  "kind": "SERVER",
+  "start": "1721503914233133",
+  "handlerStart": "1721503914233138",
+  "end": "1721503914233158",
+  "duration": "25µs",
+  "durationUSec": "25",
+  "handlerDuration": "20µs",
+  "handlerDurationUSec": "20",
+  "attributes": {
+   "clientAddr": "peername",
+   "contentLen": "1024",
+   "method": "method",
+   "route": "route",
+   "serverAddr": "hostname",
+   "serverPort": "5678",
+   "status": "200",
+   "url": "path"
+  }
+ }
+]
+`
+
+	actual := traceFuncHelper(t, TracePrinterJSONIndent)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTracePrinterResolve_PrinterDisabledInvalid(t *testing.T) {
+	assert.Nil(t, resolvePrinterFunc(TracePrinterDisabled))
+	assert.Nil(t, resolvePrinterFunc(TracePrinter("")))
+	assert.Nil(t, resolvePrinterFunc(TracePrinter("INVALID")))
+}

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -117,7 +117,7 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 	pipe.AddFinalProvider(gnb, prometheus, prom.PrometheusEndpoint(ctx, gb.ctxInfo, &config.Prometheus, config.Attributes.Select))
 	pipe.AddFinalProvider(gnb, alloyTraces, alloy.TracesReceiver(ctx, gb.ctxInfo, &config.TracesReceiver, config.Attributes.Select))
 
-	pipe.AddFinalProvider(gnb, printer, debug.PrinterNode(config.Printer))
+	pipe.AddFinalProvider(gnb, printer, debug.PrinterNode(config.TracePrinter))
 
 	// process subpipeline will start another pipeline only to collect and export data
 	// about the processes of an instrumented application

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -40,7 +40,6 @@ type nodesMap struct {
 	Traces      pipe.Final[[]request.Span]
 	Prometheus  pipe.Final[[]request.Span]
 	Printer     pipe.Final[[]request.Span]
-	Noop        pipe.Final[[]request.Span]
 
 	ProcessReport pipe.Final[[]request.Span]
 }
@@ -53,7 +52,7 @@ func (n *nodesMap) Connect() {
 	n.Routes.SendTo(n.Kubernetes)
 	n.Kubernetes.SendTo(n.NameResolver)
 	n.NameResolver.SendTo(n.AttributeFilter)
-	n.AttributeFilter.SendTo(n.AlloyTraces, n.Metrics, n.Traces, n.Prometheus, n.Printer, n.Noop, n.ProcessReport)
+	n.AttributeFilter.SendTo(n.AlloyTraces, n.Metrics, n.Traces, n.Prometheus, n.Printer, n.ProcessReport)
 }
 
 // accessor functions to each field. Grouped here for code brevity during the pipeline build
@@ -67,7 +66,6 @@ func otelMetrics(n *nodesMap) *pipe.Final[[]request.Span]                   { re
 func otelTraces(n *nodesMap) *pipe.Final[[]request.Span]                    { return &n.Traces }
 func printer(n *nodesMap) *pipe.Final[[]request.Span]                       { return &n.Printer }
 func prometheus(n *nodesMap) *pipe.Final[[]request.Span]                    { return &n.Prometheus }
-func noop(n *nodesMap) *pipe.Final[[]request.Span]                          { return &n.Noop }
 func processReport(n *nodesMap) *pipe.Final[[]request.Span]                 { return &n.ProcessReport }
 
 // builder with injectable instantiators for unit testing
@@ -119,7 +117,6 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 	pipe.AddFinalProvider(gnb, prometheus, prom.PrometheusEndpoint(ctx, gb.ctxInfo, &config.Prometheus, config.Attributes.Select))
 	pipe.AddFinalProvider(gnb, alloyTraces, alloy.TracesReceiver(ctx, gb.ctxInfo, &config.TracesReceiver, config.Attributes.Select))
 
-	pipe.AddFinalProvider(gnb, noop, debug.NoopNode(config.Noop))
 	pipe.AddFinalProvider(gnb, printer, debug.PrinterNode(config.Printer))
 
 	// process subpipeline will start another pipeline only to collect and export data

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -1,6 +1,9 @@
 package request
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -28,12 +31,58 @@ const (
 	EventTypeKafkaServer
 )
 
+func (t EventType) String() string {
+	switch t {
+	case EventTypeHTTP:
+		return "HTTP"
+	case EventTypeGRPC:
+		return "GRPC"
+	case EventTypeHTTPClient:
+		return "HTTPClient"
+	case EventTypeGRPCClient:
+		return "GRPCClient"
+	case EventTypeSQLClient:
+		return "SQLClient"
+	case EventTypeRedisClient:
+		return "RedisClient"
+	case EventTypeKafkaClient:
+		return "KafkaClient"
+	case EventTypeRedisServer:
+		return "RedisServer"
+	case EventTypeKafkaServer:
+		return "KafkaServer"
+	default:
+		return fmt.Sprintf("UNKNOWN (%d)", t)
+	}
+}
+
+func (t EventType) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
 type IgnoreMode uint8
 
 const (
 	IgnoreMetrics IgnoreMode = iota + 1
 	IgnoreTraces
 )
+
+func (m IgnoreMode) String() string {
+	switch m {
+	case IgnoreMetrics:
+		return "Metrics"
+	case IgnoreTraces:
+		return "Traces"
+	case 0:
+		return "(none)"
+	default:
+		return fmt.Sprintf("UNKNOWN (%d)", m)
+	}
+}
+
+func (m IgnoreMode) MarshalText() ([]byte, error) {
+	return []byte(m.String()), nil
+}
 
 const (
 	MessagingPublish = "publish"
@@ -63,34 +112,164 @@ type PidInfo struct {
 // REMINDER: any attribute here must be also added to the functions SpanOTELGetters,
 // SpanPromGetters and getDefinitions in pkg/internal/export/metric/definitions.go
 type Span struct {
-	Type           EventType
-	IgnoreSpan     IgnoreMode
-	Method         string
-	Path           string
-	Route          string
-	Peer           string
-	PeerPort       int
-	Host           string
-	HostPort       int
-	Status         int
-	ContentLength  int64
-	RequestStart   int64
-	Start          int64
-	End            int64
-	ServiceID      svc.ID // TODO: rename to Service or ResourceAttrs
-	TraceID        trace2.TraceID
-	SpanID         trace2.SpanID
-	ParentSpanID   trace2.SpanID
-	Flags          uint8
-	Pid            PidInfo
-	PeerName       string
-	HostName       string
-	OtherNamespace string
-	Statement      string
+	Type           EventType      `json:"type"`
+	IgnoreSpan     IgnoreMode     `json:"ignoreSpan"`
+	Method         string         `json:"-"`
+	Path           string         `json:"-"`
+	Route          string         `json:"-"`
+	Peer           string         `json:"peer"`
+	PeerPort       int            `json:"peerPort,string"`
+	Host           string         `json:"host"`
+	HostPort       int            `json:"hostPort,string"`
+	Status         int            `json:"-"`
+	ContentLength  int64          `json:"-"`
+	RequestStart   int64          `json:"-"`
+	Start          int64          `json:"-"`
+	End            int64          `json:"-"`
+	ServiceID      svc.ID         `json:"-"` // TODO: rename to Service or ResourceAttrs
+	TraceID        trace2.TraceID `json:"traceID"`
+	SpanID         trace2.SpanID  `json:"spanID"`
+	ParentSpanID   trace2.SpanID  `json:"parentSpanID"`
+	Flags          uint8          `json:"flags,string"`
+	Pid            PidInfo        `json:"-"`
+	PeerName       string         `json:"peerName"`
+	HostName       string         `json:"hostName"`
+	OtherNamespace string         `json:"-"`
+	Statement      string         `json:"-"`
 }
 
 func (s *Span) Inside(parent *Span) bool {
 	return s.RequestStart >= parent.RequestStart && s.End <= parent.End
+}
+
+const (
+	kClient   = "CLIENT"
+	kServer   = "SERVER"
+	kProducer = "PRODUCER"
+	kConsumer = "CONSUMER"
+	kInternal = "INTERNAL"
+)
+
+func kindString(span *Span) string {
+	switch span.Type {
+	case EventTypeHTTP, EventTypeGRPC, EventTypeKafkaServer, EventTypeRedisServer:
+		return kServer
+	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient:
+		return kClient
+	case EventTypeKafkaClient:
+		switch span.Method {
+		case MessagingPublish:
+			return kProducer
+		case MessagingProcess:
+			return kConsumer
+		}
+	}
+	return kInternal
+}
+
+// helper attribute functions used by JSON serialization
+type SpanAttributes map[string]string
+
+func spanAttributes(s *Span) SpanAttributes {
+	switch s.Type {
+	case EventTypeHTTP:
+		return SpanAttributes{
+			"method":     s.Method,
+			"status":     strconv.Itoa(s.Status),
+			"url":        s.Path,
+			"contentLen": strconv.FormatInt(s.ContentLength, 10),
+			"route":      s.Route,
+			"clientAddr": SpanPeer(s),
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+		}
+	case EventTypeHTTPClient:
+		return SpanAttributes{
+			"method":     s.Method,
+			"status":     strconv.Itoa(s.Status),
+			"url":        s.Path,
+			"clientAddr": SpanPeer(s),
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+		}
+	case EventTypeGRPC:
+		return SpanAttributes{
+			"method":     s.Path,
+			"status":     strconv.Itoa(s.Status),
+			"clientAddr": SpanPeer(s),
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+		}
+	case EventTypeGRPCClient:
+		return SpanAttributes{
+			"method":     s.Path,
+			"status":     strconv.Itoa(s.Status),
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+		}
+	case EventTypeSQLClient:
+		return SpanAttributes{
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+			"operation":  s.Method,
+			"table":      s.Path,
+			"statement":  s.Statement,
+		}
+	case EventTypeRedisServer:
+		return SpanAttributes{
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+			"operation":  s.Method,
+			"statement":  s.Statement,
+			"query":      s.Path,
+		}
+	case EventTypeKafkaServer:
+		return SpanAttributes{
+			"serverAddr": SpanHost(s),
+			"serverPort": strconv.Itoa(s.HostPort),
+			"operation":  s.Method,
+			"clientId":   s.OtherNamespace,
+		}
+	}
+
+	return SpanAttributes{}
+}
+
+func (s Span) MarshalJSON() ([]byte, error) {
+	type JSONSpan Span
+
+	t := s.Timings()
+	start := t.RequestStart.UnixMicro()
+	handlerStart := t.Start.UnixMicro()
+	end := t.End.UnixMicro()
+	duration := t.End.Sub(t.RequestStart)
+	handlerDuration := t.End.Sub(t.Start)
+
+	aux := struct {
+		JSONSpan
+		Kind              string         `json:"kind"`
+		Start             int64          `json:"start,string"`
+		HandlerStart      int64          `json:"handlerStart,string"`
+		End               int64          `json:"end,string"`
+		Duration          string         `json:"duration"`
+		DurationUS        int64          `json:"durationUSec,string"`
+		HandlerDuration   string         `json:"handlerDuration"`
+		HandlerDurationUS int64          `json:"handlerDurationUSec,string"`
+		Attributes        SpanAttributes `json:"attributes"`
+	}{
+		JSONSpan:          JSONSpan(s),
+		Kind:              kindString(&s),
+		Start:             start,
+		HandlerStart:      handlerStart,
+		End:               end,
+		Duration:          duration.String(),
+		DurationUS:        duration.Microseconds(),
+		HandlerDuration:   handlerDuration.String(),
+		HandlerDurationUS: handlerDuration.Microseconds(),
+		Attributes:        spanAttributes(&s),
+	}
+
+	return json.Marshal(aux)
 }
 
 type Timings struct {

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -110,7 +110,7 @@ type PidInfo struct {
 // Span contains the information being submitted by the following nodes in the graph.
 // It enables comfortable handling of data from Go.
 // REMINDER: any attribute here must be also added to the functions SpanOTELGetters,
-// SpanPromGetters and getDefinitions in pkg/internal/export/metric/definitions.go
+// SpanPromGetters and getDefinitions in pkg/export/attributes/attr_defs.go
 type Span struct {
 	Type           EventType      `json:"type"`
 	IgnoreSpan     IgnoreMode     `json:"ignoreSpan"`

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -1,9 +1,12 @@
 package request
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	trace2 "go.opentelemetry.io/otel/trace"
 )
 
 func TestSpanClientServer(t *testing.T) {
@@ -19,5 +22,219 @@ func TestSpanClientServer(t *testing.T) {
 			Type: st,
 		}
 		assert.True(t, span.IsClientSpan())
+	}
+}
+
+func TestEventTypeString(t *testing.T) {
+	typeStringMap := map[EventType]string{
+		EventTypeHTTP:        "HTTP",
+		EventTypeGRPC:        "GRPC",
+		EventTypeHTTPClient:  "HTTPClient",
+		EventTypeGRPCClient:  "GRPCClient",
+		EventTypeSQLClient:   "SQLClient",
+		EventTypeRedisClient: "RedisClient",
+		EventTypeKafkaClient: "KafkaClient",
+		EventTypeRedisServer: "RedisServer",
+		EventTypeKafkaServer: "KafkaServer",
+		EventType(99):        "UNKNOWN (99)",
+	}
+
+	for ev, str := range typeStringMap {
+		assert.Equal(t, ev.String(), str)
+	}
+}
+
+func TestIgnoreModeString(t *testing.T) {
+	modeStringMap := map[IgnoreMode]string{
+		IgnoreMetrics:  "Metrics",
+		IgnoreTraces:   "Traces",
+		IgnoreMode(0):  "(none)",
+		IgnoreMode(99): "UNKNOWN (99)",
+	}
+
+	for mode, str := range modeStringMap {
+		assert.Equal(t, mode.String(), str)
+	}
+}
+
+func TestKindString(t *testing.T) {
+	m := map[*Span]string{
+		&Span{Type: EventTypeHTTP}:                                  kServer,
+		&Span{Type: EventTypeGRPC}:                                  kServer,
+		&Span{Type: EventTypeKafkaServer}:                           kServer,
+		&Span{Type: EventTypeRedisServer}:                           kServer,
+		&Span{Type: EventTypeHTTPClient}:                            kClient,
+		&Span{Type: EventTypeGRPCClient}:                            kClient,
+		&Span{Type: EventTypeSQLClient}:                             kClient,
+		&Span{Type: EventTypeRedisClient}:                           kClient,
+		&Span{Type: EventTypeKafkaClient, Method: MessagingPublish}: kProducer,
+		&Span{Type: EventTypeKafkaClient, Method: MessagingProcess}: kConsumer,
+		&Span{}: kInternal,
+	}
+
+	for span, str := range m {
+		assert.Equal(t, kindString(span), str)
+	}
+}
+
+type jsonObject = map[string]interface{}
+
+func deserializeJSONObject(data []byte) (jsonObject, error) {
+	var object jsonObject
+	err := json.Unmarshal(data, &object)
+
+	return object, err
+}
+
+func TestSerializeJSONSpans(t *testing.T) {
+	type testData struct {
+		eventType EventType
+		attribs   map[string]any
+	}
+
+	tData := []testData{
+		testData{
+			eventType: EventTypeHTTP,
+			attribs: map[string]any{
+				"method":     "method",
+				"status":     "200",
+				"url":        "path",
+				"contentLen": "1024",
+				"route":      "route",
+				"clientAddr": "peername",
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+			},
+		},
+		testData{
+			eventType: EventTypeHTTPClient,
+			attribs: map[string]any{
+				"method":     "method",
+				"status":     "200",
+				"url":        "path",
+				"clientAddr": "peername",
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+			},
+		},
+		testData{
+			eventType: EventTypeGRPC,
+			attribs: map[string]any{
+				"method":     "path",
+				"status":     "200",
+				"clientAddr": "peername",
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+			},
+		},
+		testData{
+			eventType: EventTypeGRPCClient,
+			attribs: map[string]any{
+				"method":     "path",
+				"status":     "200",
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+			},
+		},
+		testData{
+			eventType: EventTypeSQLClient,
+			attribs: map[string]any{
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+				"operation":  "method",
+				"table":      "path",
+				"statement":  "statement",
+			},
+		},
+		testData{
+			eventType: EventTypeRedisClient,
+			attribs:   map[string]any{},
+		},
+		testData{
+			eventType: EventTypeKafkaClient,
+			attribs:   map[string]any{},
+		},
+		testData{
+			eventType: EventTypeRedisServer,
+			attribs: map[string]any{
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+				"operation":  "method",
+				"statement":  "statement",
+				"query":      "path",
+			},
+		},
+		testData{
+			eventType: EventTypeKafkaServer,
+			attribs: map[string]any{
+				"serverAddr": "hostname",
+				"serverPort": "5678",
+				"operation":  "method",
+				"clientId":   "otherns",
+			},
+		},
+	}
+
+	test := func(t *testing.T, tData *testData) {
+		span := Span{
+			Type:           tData.eventType,
+			IgnoreSpan:     IgnoreMetrics,
+			Method:         "method",
+			Path:           "path",
+			Route:          "route",
+			Peer:           "peer",
+			PeerPort:       1234,
+			Host:           "host",
+			HostPort:       5678,
+			Status:         200,
+			ContentLength:  1024,
+			RequestStart:   10000,
+			Start:          15000,
+			End:            35000,
+			TraceID:        trace2.TraceID{0x1, 0x2, 0x3},
+			SpanID:         trace2.SpanID{0x1, 0x2, 0x3},
+			ParentSpanID:   trace2.SpanID{0x1, 0x2, 0x3},
+			Flags:          1,
+			PeerName:       "peername",
+			HostName:       "hostname",
+			OtherNamespace: "otherns",
+			Statement:      "statement",
+		}
+
+		data, err := json.MarshalIndent(span, "", " ")
+
+		require.NoError(t, err)
+
+		s, err := deserializeJSONObject(data)
+
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]any{
+			"type":                tData.eventType.String(),
+			"kind":                kindString(&span),
+			"ignoreSpan":          "Metrics",
+			"peer":                "peer",
+			"peerPort":            "1234",
+			"host":                "host",
+			"hostPort":            "5678",
+			"peerName":            "peername",
+			"hostName":            "hostname",
+			"start":               s["start"],
+			"handlerStart":        s["handlerStart"],
+			"end":                 s["end"],
+			"duration":            "25µs",
+			"durationUSec":        "25",
+			"handlerDuration":     "20µs",
+			"handlerDurationUSec": "20",
+			"traceID":             "01020300000000000000000000000000",
+			"spanID":              "0102030000000000",
+			"parentSpanID":        "0102030000000000",
+			"flags":               "1",
+			"attributes":          tData.attribs,
+		}, s)
+	}
+
+	for i := range tData {
+		test(t, &tData[i])
 	}
 }

--- a/test/integration/docker-compose-1.16.yml
+++ b/test/integration/docker-compose-1.16.yml
@@ -28,7 +28,7 @@ services:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
       BEYLA_OTEL_METRICS_FEATURES: "application,application_span"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: 8080
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_SERVICE_NAMESPACE: "integration-test"

--- a/test/integration/docker-compose-1.17.yml
+++ b/test/integration/docker-compose-1.17.yml
@@ -31,7 +31,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OTEL_METRICS_FEATURES: "application,application_span"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms

--- a/test/integration/docker-compose-client.yml
+++ b/test/integration/docker-compose-client.yml
@@ -25,7 +25,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-dotnet.yml
+++ b/test/integration/docker-compose-dotnet.yml
@@ -32,7 +32,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-elixir.yml
+++ b/test/integration/docker-compose-elixir.yml
@@ -29,7 +29,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "4000"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_SERVICE_NAMESPACE: "integration-test"

--- a/test/integration/docker-compose-http2.yml
+++ b/test/integration/docker-compose-http2.yml
@@ -41,7 +41,7 @@ services:
     pid: "host"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_METRICS_INTERVAL: "10ms"
       BEYLA_BPF_BATCH_TIMEOUT: "10ms"
       BEYLA_LOG_LEVEL: "DEBUG"

--- a/test/integration/docker-compose-java-host.yml
+++ b/test/integration/docker-compose-java-host.yml
@@ -24,7 +24,7 @@ services:
     environment:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java-host.yml"
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"
       BEYLA_EXECUTABLE_NAME: "${JAVA_EXECUTABLE_NAME}"
       BEYLA_SYSTEM_WIDE: "${BEYLA_SYSTEM_WIDE}"

--- a/test/integration/docker-compose-java-pid.yml
+++ b/test/integration/docker-compose-java-pid.yml
@@ -24,7 +24,7 @@ services:
     environment:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"
       BEYLA_EXECUTABLE_NAME: "${JAVA_EXECUTABLE_NAME}"
       BEYLA_SYSTEM_WIDE: "${BEYLA_SYSTEM_WIDE}"

--- a/test/integration/docker-compose-java-system-wide.yml
+++ b/test/integration/docker-compose-java-system-wide.yml
@@ -36,7 +36,7 @@ services:
     environment:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"
       BEYLA_EXECUTABLE_NAME: "${JAVA_EXECUTABLE_NAME}"
       BEYLA_SYSTEM_WIDE: "${BEYLA_SYSTEM_WIDE}"

--- a/test/integration/docker-compose-java.yml
+++ b/test/integration/docker-compose-java.yml
@@ -28,7 +28,7 @@ services:
     pid: "host"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${JAVA_OPEN_PORT}"
       BEYLA_EXECUTABLE_NAME: "${JAVA_EXECUTABLE_NAME}"
       BEYLA_SYSTEM_WIDE: "${BEYLA_SYSTEM_WIDE}"

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -131,7 +131,7 @@ services:
     environment:
       GOCOVERDIR: "/coverage"
       BEYLA_OTEL_METRICS_FEATURES: "application,application_span"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_METRICS_INTERVAL: "10ms"
       BEYLA_BPF_BATCH_TIMEOUT: "10ms"
       BEYLA_LOG_LEVEL: "DEBUG"

--- a/test/integration/docker-compose-nodeclient.yml
+++ b/test/integration/docker-compose-nodeclient.yml
@@ -32,7 +32,7 @@ services:
     pid: "service:nodeclient"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms

--- a/test/integration/docker-compose-nodejs.yml
+++ b/test/integration/docker-compose-nodejs.yml
@@ -33,7 +33,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-other-grpc.yml
+++ b/test/integration/docker-compose-other-grpc.yml
@@ -46,7 +46,7 @@ services:
     pid: "host"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OTEL_METRICS_FEATURES: "application,application_span"
       BEYLA_PROMETHEUS_FEATURES: "application,application_span"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms

--- a/test/integration/docker-compose-python-sql.yml
+++ b/test/integration/docker-compose-python-sql.yml
@@ -40,7 +40,7 @@ services:
     environment:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config.yml"
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-python.yml
+++ b/test/integration/docker-compose-python.yml
@@ -28,7 +28,7 @@ services:
     environment:
       BEYLA_CONFIG_PATH: "/configs/instrumenter-config-java.yml"
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-ruby.yml
+++ b/test/integration/docker-compose-ruby.yml
@@ -26,7 +26,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "counter"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose-rust.yml
+++ b/test/integration/docker-compose-rust.yml
@@ -29,7 +29,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "json_indent"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "json"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
       BEYLA_OTEL_METRICS_FEATURES: "application,application_span,application_process"
       BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process"

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -90,8 +90,8 @@ spec:
               value: "/configs/instrumenter-config.yml"
             - name: GOCOVERDIR
               value: "/testoutput"
-            - name: BEYLA_PRINT_TRACES
-              value: "true"
+            - name: BEYLA_TRACE_PRINTER
+              value: "text"
             - name: BEYLA_OPEN_PORT
               value: "8080"
             - name: BEYLA_DISCOVERY_POLL_INTERVAL

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -104,8 +104,8 @@ spec:
               value: "/testoutput"
             - name: BEYLA_DISCOVERY_POLL_INTERVAL
               value: "500ms"
-            - name: BEYLA_PRINT_TRACES
-              value: "true"
+            - name: BEYLA_TRACE_PRINTER
+              value: "text"
             - name: BEYLA_OPEN_PORT
               value: "8080"
             - name: BEYLA_SERVICE_NAMESPACE

--- a/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
@@ -15,7 +15,7 @@ data:
       select:
         "*":
           include: ["*"]
-    print_traces: true
+    trace_printer: text
     log_level: debug
     discovery:
       services:

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -8,7 +8,7 @@ data:
       kubernetes:
         enable: true
         cluster_name: beyla
-    print_traces: true
+    trace_printer: text
     log_level: debug
     discovery:
       services:

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -11,7 +11,7 @@ data:
       select:
         process_*:
           include: ["*"]
-    print_traces: true
+    trace_printer: text
     log_level: debug
     discovery:
       services:

--- a/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -60,8 +60,8 @@ spec:
           value: "/testoutput"
         - name: BEYLA_DISCOVERY_POLL_INTERVAL
           value: "500ms"
-        - name: BEYLA_PRINT_TRACES
-          value: "true"
+        - name: BEYLA_TRACE_PRINTER
+          value: "text"
         - name: BEYLA_EXECUTABLE_NAME
           value: "httppinger"
         - name: BEYLA_METRICS_INTERVAL

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -60,8 +60,8 @@ spec:
           value: "/testoutput"
         - name: BEYLA_DISCOVERY_POLL_INTERVAL
           value: "500ms"
-        - name: BEYLA_PRINT_TRACES
-          value: "true"
+        - name: BEYLA_TRACE_PRINTER
+          value: "text"
         - name: BEYLA_EXECUTABLE_NAME
           value: "httppinger"
         - name: BEYLA_METRICS_INTERVAL

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
@@ -61,8 +61,8 @@ spec:
           value: "/testoutput"
         - name: BEYLA_DISCOVERY_POLL_INTERVAL
           value: "500ms"
-        - name: BEYLA_PRINT_TRACES
-          value: "true"
+        - name: BEYLA_TRACE_PRINTER
+          value: "counter"
         - name: BEYLA_EXECUTABLE_NAME
           value: "grpcpinger"
         - name: BEYLA_METRICS_INTERVAL

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -61,8 +61,8 @@ spec:
           value: "/testoutput"
         - name: BEYLA_DISCOVERY_POLL_INTERVAL
           value: "500ms"
-        - name: BEYLA_PRINT_TRACES
-          value: "true"
+        - name: BEYLA_TRACE_PRINTER
+          value: "json_indent"
         - name: BEYLA_EXECUTABLE_NAME
           value: "grpcpinger"
         - name: BEYLA_METRICS_INTERVAL

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -99,8 +99,8 @@ spec:
       env:
         - name: GOCOVERDIR
           value: "/testoutput"
-        - name: BEYLA_PRINT_TRACES
-          value: "true"
+        - name: BEYLA_TRACE_PRINTER
+          value: "json"
         - name: BEYLA_OPEN_PORT
           value: "8080"
         - name: BEYLA_DISCOVERY_POLL_INTERVAL

--- a/test/oats/kafka/docker-compose-beyla-go-kafka-go.yml
+++ b/test/oats/kafka/docker-compose-beyla-go-kafka-go.yml
@@ -55,7 +55,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/kafka/docker-compose-beyla-go-kafka-sarama.yml
+++ b/test/oats/kafka/docker-compose-beyla-go-kafka-sarama.yml
@@ -55,7 +55,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/kafka/docker-compose-beyla-java-kafka.yml
+++ b/test/oats/kafka/docker-compose-beyla-java-kafka.yml
@@ -47,7 +47,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       #BEYLA_EXECUTABLE_NAME: "java"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"

--- a/test/oats/kafka/docker-compose-beyla-python-kafka.yml
+++ b/test/oats/kafka/docker-compose-beyla-python-kafka.yml
@@ -55,7 +55,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/redis/docker-compose-beyla-go-redis.yml
+++ b/test/oats/redis/docker-compose-beyla-go-redis.yml
@@ -31,7 +31,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/redis/docker-compose-beyla-redis.yml
+++ b/test/oats/redis/docker-compose-beyla-redis.yml
@@ -31,7 +31,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/sql/docker-compose-beyla-gosqlclient-statement.yml
+++ b/test/oats/sql/docker-compose-beyla-gosqlclient-statement.yml
@@ -25,7 +25,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/sql/docker-compose-beyla-gosqlclient.yml
+++ b/test/oats/sql/docker-compose-beyla-gosqlclient.yml
@@ -25,7 +25,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"

--- a/test/oats/sql/docker-compose-beyla-sql.yml
+++ b/test/oats/sql/docker-compose-beyla-sql.yml
@@ -36,7 +36,7 @@ services:
     pid: "service:testserver"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_OPEN_PORT: {{ .ApplicationPort }}
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"


### PR DESCRIPTION
Introduce a new flag called `BEYLA_TRACE_PRINTER`,  *deprecate* `BEYLA_PRINT_TRACES`, and *remove* `BEYLA_NOOP_TRACES`.

The new `BEYLA_TRACE_PRINTER` supersedes both `BEYLA_PRINT_TRACES` and `BEYLA_NOOP_TRACES`. It also adds two new output modes, `json` and `json_indent` as described below.

`BEYLA_TRACE_PRINTER` accepts the following values:
- `text` equivalent to `BEYLA_PRINT_TRACES=true`: prints a text line with the span data
- `counter` equivalent to `BEYLA_TRACES_NOOP=true`: prints the number of processed requests at the end of execution
- `json` prints the span as a compact JSON document
- `json_indent` prints the span as an indented JSON document
- `disabled` - equivalent to `BEYLA_PRINT_TRACES=false`

Closes https://github.com/grafana/beyla/issues/344

TODO

- [x] tests
- [x] latest review comments
- [x] documentation