### PR TITLE
Add SetDebugMode function in config.go

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -257,6 +257,9 @@ func (c *Config) SetDebugMode() {
 	c.Printer = true
 	c.LogLevel = "DEBUG"
 	c.EBPF.BpfDebug = true
+	if c.NetworkFlows.Enable {
+		c.NetworkFlows.Print = true
+	}
 }
 
 // LoadConfig overrides configuration in the following order (from less to most priority)

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -252,6 +252,13 @@ func (c *Config) Enabled(feature Feature) bool {
 	return false
 }
 
+// SetDebugMode sets the debug mode for Beyla
+func (c *Config) SetDebugMode() {
+	c.Printer = true
+	c.LogLevel = "DEBUG"
+	c.EBPF.BpfDebug = true
+}
+
 // LoadConfig overrides configuration in the following order (from less to most priority)
 // 1 - Default configuration (defaultConfig variable)
 // 2 - Contents of the provided file reader (nillable)


### PR DESCRIPTION
If we want to configure all debug capabilities for Beyla in places like
Alloy we would need to expose the whole eBPF config block to be public.
For now that seems not very necessary so this public method will allow
Alloy receive all debugging logs from Beyla.