### PR TITLE
Export k8s flags

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -19,8 +19,8 @@ import (
 	"github.com/grafana/beyla/pkg/internal/filter"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/infraolly/process"
-	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/traces"
+	"github.com/grafana/beyla/pkg/kubeflags"
 	"github.com/grafana/beyla/pkg/services"
 	"github.com/grafana/beyla/pkg/transform"
 )
@@ -105,7 +105,7 @@ var DefaultConfig = Config{
 			HostnameDNSResolution: true,
 		},
 		Kubernetes: transform.KubernetesDecorator{
-			Enable:               kube.EnabledDefault,
+			Enable:               kubeflags.EnabledDefault,
 			InformersSyncTimeout: 30 * time.Second,
 		},
 	},

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -18,9 +18,9 @@ import (
 	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/infraolly/process"
-	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/netolly/transform/cidr"
 	"github.com/grafana/beyla/pkg/internal/traces"
+	"github.com/grafana/beyla/pkg/kubeflags"
 	"github.com/grafana/beyla/pkg/transform"
 )
 
@@ -162,7 +162,7 @@ network:
 			},
 			Kubernetes: transform.KubernetesDecorator{
 				KubeconfigPath:       "/foo/bar",
-				Enable:               kube.EnabledTrue,
+				Enable:               kubeflags.EnabledTrue,
 				InformersSyncTimeout: 30 * time.Second,
 			},
 			Select: attributes.Selection{

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -8,8 +8,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/grafana/beyla/pkg/kubeflags"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/beyla/pkg/kubeflags"
 )
 
 type MetadataProvider struct {

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -8,16 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/grafana/beyla/pkg/kubeflags"
 	"k8s.io/client-go/kubernetes"
-)
-
-type EnableFlag string
-
-const (
-	EnabledTrue       = EnableFlag("true")
-	EnabledFalse      = EnableFlag("false")
-	EnabledAutodetect = EnableFlag("autodetect")
-	EnabledDefault    = EnabledFalse
 )
 
 type MetadataProvider struct {
@@ -32,7 +24,7 @@ type MetadataProvider struct {
 }
 
 func NewMetadataProvider(
-	enable EnableFlag,
+	enable kubeflags.EnableFlag,
 	disabledInformers []string,
 	kubeConfigPath string,
 	syncTimeout time.Duration,
@@ -50,20 +42,20 @@ func (mp *MetadataProvider) IsKubeEnabled() bool {
 	if mp == nil {
 		return false
 	}
-	switch strings.ToLower(string(mp.enable.Load().(EnableFlag))) {
-	case string(EnabledTrue):
+	switch strings.ToLower(string(mp.enable.Load().(kubeflags.EnableFlag))) {
+	case string(kubeflags.EnabledTrue):
 		return true
-	case string(EnabledFalse), "": // empty value is disabled
+	case string(kubeflags.EnabledFalse), "": // empty value is disabled
 		return false
-	case string(EnabledAutodetect):
+	case string(kubeflags.EnabledAutodetect):
 		// We autodetect that we are in a kubernetes if we can properly load a K8s configuration file
 		_, err := LoadConfig(mp.kubeConfigPath)
 		if err != nil {
 			klog().Debug("kubeconfig can't be detected. Assuming we are not in Kubernetes", "error", err)
-			mp.enable.Store(EnabledFalse)
+			mp.enable.Store(kubeflags.EnabledFalse)
 			return false
 		}
-		mp.enable.Store(EnabledTrue)
+		mp.enable.Store(kubeflags.EnabledTrue)
 		return true
 	default:
 		klog().Warn("invalid value for Enable value. Ignoring stage", "value", mp.enable.Load())
@@ -72,7 +64,7 @@ func (mp *MetadataProvider) IsKubeEnabled() bool {
 }
 
 func (mp *MetadataProvider) ForceDisable() {
-	mp.enable.Store(EnabledFalse)
+	mp.enable.Store(kubeflags.EnabledFalse)
 }
 
 func (mp *MetadataProvider) Get(ctx context.Context) (*Metadata, error) {

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/grafana/beyla/pkg/internal/testutil"
 	"github.com/grafana/beyla/pkg/internal/traces"
+	"github.com/grafana/beyla/pkg/kubeflags"
 	"github.com/grafana/beyla/pkg/transform"
 	"github.com/grafana/beyla/test/collector"
 	"github.com/grafana/beyla/test/consumer"
@@ -39,7 +40,7 @@ func gctx(groups attributes.AttrGroups) *global.ContextInfo {
 	return &global.ContextInfo{
 		Metrics:               imetrics.NoopReporter{},
 		MetricAttributeGroups: groups,
-		K8sInformer:           kube.NewMetadataProvider(kube.EnabledFalse, nil, "", 0),
+		K8sInformer:           kube.NewMetadataProvider(kubeflags.EnabledFalse, nil, "", 0),
 	}
 }
 

--- a/pkg/kubeflags/kubeflags.go
+++ b/pkg/kubeflags/kubeflags.go
@@ -1,0 +1,10 @@
+package kubeflags
+
+type EnableFlag string
+
+const (
+	EnabledTrue       = EnableFlag("true")
+	EnabledFalse      = EnableFlag("false")
+	EnabledAutodetect = EnableFlag("autodetect")
+	EnabledDefault    = EnabledFalse
+)

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/pkg/internal/svc"
+	"github.com/grafana/beyla/pkg/kubeflags"
 )
 
 func klog() *slog.Logger {
@@ -19,7 +20,7 @@ func klog() *slog.Logger {
 }
 
 type KubernetesDecorator struct {
-	Enable kube.EnableFlag `yaml:"enable" env:"BEYLA_KUBE_METADATA_ENABLE"`
+	Enable kubeflags.EnableFlag `yaml:"enable" env:"BEYLA_KUBE_METADATA_ENABLE"`
 
 	// ClusterName overrides cluster name. If empty, the NetO11y module will try to retrieve
 	// it from the Cloud Provider Metadata (EC2, GCP and Azure), and leave it empty if it fails to.


### PR DESCRIPTION
This PR moves kubernetes flags to its own exported package.
This is necessary for alloy to enable or disable k8s monitoring.