### PR TITLE
Prevent beyla self-instrumentation

### DIFF
--- a/pkg/internal/discover/attacher_test.go
+++ b/pkg/internal/discover/attacher_test.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/internal/exec"
 	"github.com/grafana/beyla/pkg/services"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSkipSelfInstrumentation(t *testing.T) {

--- a/pkg/internal/discover/attacher_test.go
+++ b/pkg/internal/discover/attacher_test.go
@@ -1,0 +1,56 @@
+package discover
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/grafana/beyla/pkg/beyla"
+	"github.com/grafana/beyla/pkg/internal/exec"
+	"github.com/grafana/beyla/pkg/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipSelfInstrumentation(t *testing.T) {
+	pid := os.Getpid()
+
+	for _, tt := range []struct {
+		ta     *TraceAttacher
+		isSelf bool
+		test   string
+	}{
+		{
+			ta: &TraceAttacher{
+				log:      slog.With("component", "discover.TraceAttacher"),
+				Cfg:      &beyla.DefaultConfig,
+				beylaPID: pid,
+			},
+			isSelf: true,
+			test:   "Default config",
+		},
+		{
+			ta: &TraceAttacher{
+				log:      slog.With("component", "discover.TraceAttacher"),
+				Cfg:      &beyla.DefaultConfig,
+				beylaPID: 0,
+			},
+			isSelf: false,
+			test:   "Default config, non-beyla pid",
+		},
+		{
+			ta: &TraceAttacher{
+				log:      slog.With("component", "discover.TraceAttacher"),
+				Cfg:      &beyla.Config{Discovery: services.DiscoveryConfig{AllowSelfInstrumentation: true}},
+				beylaPID: pid,
+			},
+			isSelf: false,
+			test:   "Beyla pid, allow self instrumentation",
+		},
+	} {
+		t.Run(tt.test, func(t *testing.T) {
+			i := Instrumentable{FileInfo: &exec.FileInfo{Pid: int32(pid)}}
+
+			assert.Equal(t, tt.isSelf, tt.ta.skipSelfInstrumentation(&i))
+		})
+	}
+}

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -56,6 +56,8 @@ type DiscoveryConfig struct {
 	// gathered for certain languages, such as Golang.
 	SystemWide bool `yaml:"system_wide" env:"BEYLA_SYSTEM_WIDE"`
 
+	AllowSelfInstrumentation bool `yaml:"allow_self_instrumentation" env:"BEYLA_ALLOW_SELF_INSTRUMENTATION"`
+
 	// This can be enabled to use generic HTTP tracers only, no Go-specifics will be used:
 	SkipGoSpecificTracers bool `yaml:"skip_go_specific_tracers" env:"BEYLA_SKIP_GO_SPECIFIC_TRACERS"`
 

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -685,3 +685,14 @@ func testPrometheusBeylaBuildInfo(t *testing.T) {
 		require.NotEmpty(t, results)
 	})
 }
+
+func testPrometheusNoBeylaEvents(t *testing.T) {
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`http_server_request_duration_seconds_count{service_name="beyla"}`)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(results))
+	})
+}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -219,6 +219,8 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 	compose.Env = append(compose.Env,
 		`INSTRUMENTER_CONFIG_SUFFIX=-promscrape`,
 		`PROM_CONFIG_SUFFIX=-promscrape`,
+		`BEYLA_EXECUTABLE_NAME=`,
+		`BEYLA_OPEN_PORT=8082,8999`, // force Beyla self-instrumentation to ensure we don't do it
 	)
 
 	require.NoError(t, err)
@@ -227,6 +229,7 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
 	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
+	t.Run("Testing for no Beyla self metrics", testPrometheusNoBeylaEvents)
 	t.Run("Testing process-level metrics", testProcesses(map[string]string{
 		"process_executable_name": "testserver",
 		"process_executable_path": "/testserver",


### PR DESCRIPTION
Depending on how customers choose to deploy beyla, we can easily end up in a situation where Beyla is self-instrumenting itself. One example would be setting "all" for an executable name or a kubernetes pod/service/namespace. This is particularly common actually, because our default helm configuration instruments all namespaces, so Beyla will self-instrument even when it's installed in its own namespace.

Self-instrumentation comes with serious consequences, mainly because of self-perpetuating instrumentation of calls to /v1/metrics and /v1/traces. This creates unnecessary load on all components in the system and drowns the collection pipeline.

I've added an option to purposefully enable Beyla self-instrumentation, however I think we shouldn't even document it. It should be purely internal option we may choose to enable in some special circumstances.