### PR TITLE
Short timeout for cloud instance ID fetcher

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -109,6 +109,9 @@ var DefaultConfig = Config{
 			Enable:               kubeflags.EnabledDefault,
 			InformersSyncTimeout: 30 * time.Second,
 		},
+		HostID: HostIDConfig{
+			FetchTimeout: 500 * time.Millisecond,
+		},
 	},
 	Routes:       &transform.RoutesConfig{Unmatch: transform.UnmatchHeuristic},
 	NetworkFlows: defaultNetworkConfig,
@@ -192,6 +195,14 @@ type Attributes struct {
 	Kubernetes transform.KubernetesDecorator `yaml:"kubernetes"`
 	InstanceID traces.InstanceIDConfig       `yaml:"instance_id"`
 	Select     attributes.Selection          `yaml:"select"`
+	HostID     HostIDConfig                  `yaml:"host_id"`
+}
+
+type HostIDConfig struct {
+	// Override allows overriding the reported host.id in Beyla
+	Override string `yaml:"override" env:"BEYLA_HOST_ID"`
+	// HostIDFetchTimeout specifies the timeout for trying to fetch the HostID from diverse Cloud Providers
+	FetchTimeout time.Duration `yaml:"fetch_timeout" env:"BEYLA_HOST_ID_FETCH_TIMEOUT"`
 }
 
 type ConfigError string

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -46,6 +46,9 @@ attributes:
     informers_sync_timeout: 30s
   instance_id:
     dns: true
+  host_id:
+    override: the-host-id
+    fetch_timeout: 4s
   select:
     beyla.network.flow:
       include: ["foo", "bar"]
@@ -165,6 +168,10 @@ network:
 				KubeconfigPath:       "/foo/bar",
 				Enable:               kubeflags.EnabledTrue,
 				InformersSyncTimeout: 30 * time.Second,
+			},
+			HostID: HostIDConfig{
+				Override:     "the-host-id",
+				FetchTimeout: 4 * time.Second,
 			},
 			Select: attributes.Selection{
 				attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -131,7 +131,11 @@ func buildCommonContextInfo(
 
 	attributeGroups(config, ctxInfo)
 
-	ctxInfo.FetchHostID(ctx)
+	if config.Attributes.HostID.Override == "" {
+		ctxInfo.FetchHostID(ctx, config.Attributes.HostID.FetchTimeout)
+	} else {
+		ctxInfo.HostID = config.Attributes.HostID.Override
+	}
 
 	return ctxInfo
 }

--- a/pkg/internal/pipe/global/context.go
+++ b/pkg/internal/pipe/global/context.go
@@ -11,7 +11,8 @@ import (
 // ContextInfo stores some context information that must be shared across some nodes of the
 // processing graph.
 type ContextInfo struct {
-	// HostID of the host running Beyla
+	// HostID of the host running Beyla. Unless testing environments, this value must be
+	// automatically set after invoking FetchHostID
 	HostID string
 	// AppO11y stores context information that is only required for application observability.
 	// Its values must be initialized by the App O11y code and shouldn't be accessed from the

--- a/pkg/internal/pipe/global/host_id_test.go
+++ b/pkg/internal/pipe/global/host_id_test.go
@@ -1,0 +1,18 @@
+package global
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchTimeout(t *testing.T) {
+	ctxInfo := ContextInfo{}
+	start := time.Now()
+	ctxInfo.FetchHostID(context.Background(), time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, time.Second)
+}


### PR DESCRIPTION
The AWS Host ID fetcher was taking too much time to fail when executed on non-AWS resources.

This seems as an internal issue of the used library.

This PR times out the AWS fetcher to 500ms (timeout is configurable by the users).

The timeout should be more than enough to get the Cloud ID on AWS. I've tried it on real AWS and takes around ~4ms