### PR TITLE
Link directly to resource in GitHub

### DIFF
--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -58,7 +58,7 @@ Configure the [Alloy](/docs/alloy/) pipeline and specify the following nodes:
 
 ![Beyla nodes](https://grafana.com/media/docs/grafana-cloud/beyla/nodes-2.png)
 
-Download the [example River configuration file](/docs/beyla/latest/configure/resources/alloy-config.river) used in this article.
+Download the [example River configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/alloy-config.river) used in this article.
 
 Alloy needs to expose an **OpenTelemetry receiver** endpoint, such that the auto-instrumentation tool can forward both metrics and traces.
 The Alloy configuration file needs to include the following entry:
@@ -158,7 +158,7 @@ a configuration YAML file, which is what we will use in this example.
 Please refer to the complete [Configuration documentation]({{< relref "./options.md" >}}) for
 more detailed description of each configuration option.
 
-You can download the whole [example configuration file](/docs/beyla/latest/configure/resources/instrumenter-config.yml),
+You can download the whole [example configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/instrumenter-config.yml),
 which we will explain in the rest of this section.
 
 First, you will need to specify the executable to instrument. If, for example,

--- a/docs/sources/tutorial/getting-started.md
+++ b/docs/sources/tutorial/getting-started.md
@@ -94,7 +94,7 @@ The code implements an HTTP service that accepts request on port 8080. The HTTP 
 - `status` will override the returned HTTP status code (which defaults to 200). For example `curl -v "http://localhost:8080/foo?status=404"` will return a 404 status code.
 - `delay` will artificially increase the service response time. For example `curl "http://localhost:8080/bar?delay=3s"` will take at least 3 seconds to complete.
 
-Download the [server.go](/docs/beyla/latest/tutorial/resources/server.go) file from this tutorial.
+Download the [server.go](https://github.com/grafana/beyla/blob/main/docs/sources/tutorial/resources/server.go) file from this tutorial.
 
 Run the test HTTP service with the following command:
 


### PR DESCRIPTION
The resources 404 on the website, we have two options, Hugo page bundles or link to GitHub. We have a public repo for Beyla and can link directly to the source.