### PR TITLE
Add exclusion lists to discovery section

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -216,6 +216,9 @@ func (c *Config) Validate() error {
 	if err := c.Discovery.Services.Validate(); err != nil {
 		return ConfigError(fmt.Sprintf("error in services YAML property: %s", err.Error()))
 	}
+	if err := c.Discovery.ExcludeServices.Validate(); err != nil {
+		return ConfigError(fmt.Sprintf("error in exclude_services YAML property: %s", err.Error()))
+	}
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) {
 		return ConfigError("missing at least one of BEYLA_NETWORK_METRICS, BEYLA_EXECUTABLE_NAME or BEYLA_OPEN_PORT property")
 	}

--- a/pkg/internal/discover/matcher_test.go
+++ b/pkg/internal/discover/matcher_test.go
@@ -73,6 +73,103 @@ func TestCriteriaMatcher(t *testing.T) {
 	assert.Equal(t, services.ProcessInfo{Pid: 6, ExePath: "/bin/clientweird99"}, *m.Obj.Process)
 }
 
+func TestCriteriaMatcher_Exclude(t *testing.T) {
+	pipeConfig := beyla.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  services:
+  - name: port-only
+    namespace: foo
+    open_ports: 80,8080-8089
+  - name: exec-only
+    exe_path: weird\d
+  - name: both
+    open_ports: 443
+    exe_path_regexp: "server"
+  exclude_services:
+  - exe_path: s
+`), &pipeConfig))
+
+	matcherFunc, err := CriteriaMatcherProvider(&pipeConfig)()
+	require.NoError(t, err)
+	discoveredProcesses := make(chan []Event[processAttrs], 10)
+	filteredProcesses := make(chan []Event[ProcessMatch], 10)
+	go matcherFunc(discoveredProcesses, filteredProcesses)
+	defer close(discoveredProcesses)
+
+	// it will filter unmatching processes and return a ProcessMatch for these that match
+	processInfo = func(pp processAttrs) (*services.ProcessInfo, error) {
+		exePath := map[PID]string{
+			1: "/bin/weird33", 2: "/bin/weird33", 3: "server",
+			4: "/bin/something", 5: "server", 6: "/bin/clientweird99"}[pp.pid]
+		return &services.ProcessInfo{Pid: int32(pp.pid), ExePath: exePath, OpenPorts: pp.openPorts}, nil
+	}
+	discoveredProcesses <- []Event[processAttrs]{
+		{Type: EventCreated, Obj: processAttrs{pid: 1, openPorts: []uint32{1, 2, 3}}}, // pass
+		{Type: EventDeleted, Obj: processAttrs{pid: 2, openPorts: []uint32{4}}},       // filter
+		{Type: EventCreated, Obj: processAttrs{pid: 3, openPorts: []uint32{8433}}},    // filter
+		{Type: EventCreated, Obj: processAttrs{pid: 4, openPorts: []uint32{8083}}},    // filter (in exclude)
+		{Type: EventCreated, Obj: processAttrs{pid: 5, openPorts: []uint32{443}}},     // filter (in exclude)
+		{Type: EventCreated, Obj: processAttrs{pid: 6}},                               // pass
+	}
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 2)
+	m := matches[0]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, "exec-only", m.Obj.Criteria.Name)
+	assert.Equal(t, "", m.Obj.Criteria.Namespace)
+	assert.Equal(t, services.ProcessInfo{Pid: 1, ExePath: "/bin/weird33", OpenPorts: []uint32{1, 2, 3}}, *m.Obj.Process)
+	m = matches[1]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, "exec-only", m.Obj.Criteria.Name)
+	assert.Equal(t, "", m.Obj.Criteria.Namespace)
+	assert.Equal(t, services.ProcessInfo{Pid: 6, ExePath: "/bin/clientweird99"}, *m.Obj.Process)
+}
+
+func TestCriteriaMatcher_Exclude_Metadata(t *testing.T) {
+	pipeConfig := beyla.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  services:
+  - k8s_node_name: .
+  exclude_services:
+  - k8s_node_name: bar
+`), &pipeConfig))
+
+	matcherFunc, err := CriteriaMatcherProvider(&pipeConfig)()
+	require.NoError(t, err)
+	discoveredProcesses := make(chan []Event[processAttrs], 10)
+	filteredProcesses := make(chan []Event[ProcessMatch], 10)
+	go matcherFunc(discoveredProcesses, filteredProcesses)
+	defer close(discoveredProcesses)
+
+	// it will filter unmatching processes and return a ProcessMatch for these that match
+	processInfo = func(pp processAttrs) (*services.ProcessInfo, error) {
+		exePath := map[PID]string{
+			1: "/bin/weird33", 2: "/bin/weird33", 3: "server",
+			4: "/bin/something", 5: "server", 6: "/bin/clientweird99"}[pp.pid]
+		return &services.ProcessInfo{Pid: int32(pp.pid), ExePath: exePath, OpenPorts: pp.openPorts}, nil
+	}
+	nodeFoo := map[string]string{"k8s_node_name": "foo"}
+	nodeBar := map[string]string{"k8s_node_name": "bar"}
+	discoveredProcesses <- []Event[processAttrs]{
+		{Type: EventCreated, Obj: processAttrs{pid: 1, metadata: nodeFoo}}, // pass
+		{Type: EventDeleted, Obj: processAttrs{pid: 2, metadata: nodeFoo}}, // filter
+		{Type: EventCreated, Obj: processAttrs{pid: 3, metadata: nodeFoo}}, // pass
+		{Type: EventCreated, Obj: processAttrs{pid: 4, metadata: nodeBar}}, // filter (in exclude)
+		{Type: EventDeleted, Obj: processAttrs{pid: 5, metadata: nodeFoo}}, // filter
+		{Type: EventCreated, Obj: processAttrs{pid: 6, metadata: nodeBar}}, // filter (in exclude)
+	}
+
+	matches := testutil.ReadChannel(t, filteredProcesses, 1000*testTimeout)
+	require.Len(t, matches, 2)
+	m := matches[0]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, services.ProcessInfo{Pid: 1, ExePath: "/bin/weird33"}, *m.Obj.Process)
+	m = matches[1]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, services.ProcessInfo{Pid: 3, ExePath: "server"}, *m.Obj.Process)
+}
+
 func TestCriteriaMatcher_MustMatchAllAttributes(t *testing.T) {
 	pipeConfig := beyla.Config{}
 	require.NoError(t, yaml.Unmarshal([]byte(`discovery:

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -47,6 +47,10 @@ type DiscoveryConfig struct {
 	// added to the services definition criteria, with the lowest preference.
 	Services DefinitionCriteria `yaml:"services"`
 
+	// ExcludeServices works analogously to Services, but the applications matching this section won't be instrumented
+	// even if they match the Services selection.
+	ExcludeServices DefinitionCriteria `yaml:"exclude_services"`
+
 	// PollInterval specifies, for the poll service watcher, the interval time between
 	// process inspections
 	PollInterval time.Duration `yaml:"poll_interval" env:"BEYLA_DISCOVERY_POLL_INTERVAL"`

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -15,13 +15,15 @@ data:
     log_level: debug
     discovery:
       services:
-        # testing that K8s discovery only picks the "otherinstance"
-        # deployment (ignoring the "testserver" in the other pod)
         # name and namespace will be automatically set from the K8s metadata
-        - k8s_deployment_name: otherinstance
+        - k8s_deployment_name: (otherinstance|testserver)
         # used in the k8s_owners_*_test.go
         - k8s_statefulset_name: statefulservice
         - k8s_daemonset_name: dsservice
+      exclude_services:
+        # testing service exclusion, by expecting that K8s discovery only picks the "otherinstance"
+        # deployment (ignoring the "testserver" in the other pod)
+        - k8s_deployment_name: testserver        
     routes:
       patterns:
         - /pingpong


### PR DESCRIPTION
Adds a `exclude_services` section to the `discovery` configuration. This will exclude from instrumentation any service matching both the `services` section and the `exclude_services` section.