### PR TITLE
Cleans up some stray fmt and dead code

### DIFF
--- a/pkg/internal/ebpf/common/go_kafka_transform.go
+++ b/pkg/internal/ebpf/common/go_kafka_transform.go
@@ -3,7 +3,6 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"unsafe"
 
 	"github.com/cilium/ebpf/ringbuf"
@@ -19,8 +18,6 @@ func ReadGoSaramaRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, er
 	if err != nil {
 		return request.Span{}, true, err
 	}
-
-	fmt.Printf("Event %v\n", event)
 
 	info, err := ProcessKafkaRequest(event.Buf[:])
 

--- a/pkg/internal/ebpf/httpfltr/httpfltr.go
+++ b/pkg/internal/ebpf/httpfltr/httpfltr.go
@@ -31,7 +31,6 @@ type Tracer struct {
 	bpfObjects bpfObjects
 	closers    []io.Closer
 	log        *slog.Logger
-	Service    *svc.ID
 }
 
 func New(cfg *beyla.Config, metrics imetrics.Reporter) *Tracer {

--- a/pkg/internal/ebpf/httpssl/httpssl.go
+++ b/pkg/internal/ebpf/httpssl/httpssl.go
@@ -33,7 +33,6 @@ type Tracer struct {
 	bpfObjects bpfObjects
 	closers    []io.Closer
 	log        *slog.Logger
-	Service    *svc.ID
 }
 
 func New(cfg *beyla.Config, metrics imetrics.Reporter) *Tracer {

--- a/pkg/internal/ebpf/nodejs/nodejs.go
+++ b/pkg/internal/ebpf/nodejs/nodejs.go
@@ -26,7 +26,6 @@ type Tracer struct {
 	bpfObjects bpfObjects
 	closers    []io.Closer
 	log        *slog.Logger
-	Service    *svc.ID
 }
 
 func New(cfg *beyla.Config, metrics imetrics.Reporter) *Tracer {


### PR DESCRIPTION
While investigating an issue with wrong service id picked for some server spans, I noticed some debug print information that was not removed and some extra service IDs we weren't using.