### PR TITLE
Fix k8 namespace cache in database

### DIFF
--- a/pkg/internal/discover/container_updater.go
+++ b/pkg/internal/discover/container_updater.go
@@ -28,7 +28,9 @@ func updateLoop(db *kube.Database) pipe.MiddleFunc[[]Event[Instrumentable], []Ev
 					db.AddProcess(uint32(ev.Obj.FileInfo.Pid))
 				case EventDeleted:
 					// we don't need to handle process deletion from here, as the Kubernetes informer will
-					// remove the process from the database when the Pod that contains it is deleted
+					// remove the process from the database when the Pod that contains it is deleted.
+					// However we clean-up the performance related caches, in case we miss pod removal event
+					db.CleanProcessCaches(ev.Obj.FileInfo.Ns)
 				}
 			}
 			out <- instrumentables

--- a/pkg/internal/transform/kube/db.go
+++ b/pkg/internal/transform/kube/db.go
@@ -108,6 +108,18 @@ func (id *Database) OnDeletion(containerID []string) {
 	}
 }
 
+func (id *Database) addProcess(ifp *container.Info) {
+	id.podsCacheMut.Lock()
+	delete(id.fetchedPodsCache, ifp.PIDNamespace)
+	id.podsCacheMut.Unlock()
+	id.nsMut.Lock()
+	id.namespaces[ifp.PIDNamespace] = ifp
+	id.nsMut.Unlock()
+	id.cntMut.Lock()
+	id.containerIDs[ifp.ContainerID] = ifp
+	id.cntMut.Unlock()
+}
+
 // AddProcess also searches for the container.Info of the passed PID
 func (id *Database) AddProcess(pid uint32) {
 	ifp, err := container.InfoForPID(pid)
@@ -115,12 +127,16 @@ func (id *Database) AddProcess(pid uint32) {
 		dblog().Debug("failing to get container information", "pid", pid, "error", err)
 		return
 	}
-	id.nsMut.Lock()
-	id.namespaces[ifp.PIDNamespace] = &ifp
-	id.nsMut.Unlock()
-	id.cntMut.Lock()
-	id.containerIDs[ifp.ContainerID] = &ifp
-	id.cntMut.Unlock()
+
+	id.addProcess(&ifp)
+}
+
+func (id *Database) CleanProcessCaches(ns uint32) {
+	// Don't delete the id.namespaces, we can't tell if Add/Delete events
+	// are in order. Deleting from the cache is safe, since it will be rebuilt.
+	id.podsCacheMut.Lock()
+	delete(id.fetchedPodsCache, ns)
+	id.podsCacheMut.Unlock()
 }
 
 // OwnerPodInfo returns the information of the pod owning the passed namespace

--- a/pkg/internal/transform/kube/db_test.go
+++ b/pkg/internal/transform/kube/db_test.go
@@ -3,9 +3,10 @@ package kube
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/beyla/pkg/internal/helpers/container"
 	"github.com/grafana/beyla/pkg/internal/kube"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_NamespaceReuse(t *testing.T) {

--- a/pkg/internal/transform/kube/db_test.go
+++ b/pkg/internal/transform/kube/db_test.go
@@ -1,0 +1,60 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/grafana/beyla/pkg/internal/helpers/container"
+	"github.com/grafana/beyla/pkg/internal/kube"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NamespaceReuse(t *testing.T) {
+	db := CreateDatabase(&kube.Metadata{})
+	ifp := container.Info{
+		ContainerID:  "a",
+		PIDNamespace: 111,
+	}
+	db.addProcess(&ifp)
+	// pretend we resolved some pod info earlier
+	db.fetchedPodsCache[ifp.PIDNamespace] = &kube.PodInfo{NodeName: "a"}
+	info, err := db.OwnerPodInfo(111)
+	assert.True(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "a", info.NodeName)
+
+	_, ok := db.fetchedPodsCache[ifp.PIDNamespace]
+	assert.True(t, ok)
+
+	ifp1 := container.Info{
+		ContainerID:  "b",
+		PIDNamespace: ifp.PIDNamespace,
+	}
+
+	// We overwrite the container info with new namespace
+	db.addProcess(&ifp1)
+	_, ok = db.fetchedPodsCache[ifp.PIDNamespace]
+	assert.False(t, ok)
+}
+
+func Test_NamespaceCacheCleanup(t *testing.T) {
+	db := CreateDatabase(&kube.Metadata{})
+	ifp := container.Info{
+		ContainerID:  "a",
+		PIDNamespace: 111,
+	}
+	db.addProcess(&ifp)
+	// pretend we resolved some pod info earlier
+	db.fetchedPodsCache[ifp.PIDNamespace] = &kube.PodInfo{NodeName: "a"}
+	info, err := db.OwnerPodInfo(111)
+	assert.True(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "a", info.NodeName)
+
+	_, ok := db.fetchedPodsCache[ifp.PIDNamespace]
+	assert.True(t, ok)
+
+	// We overwrite the container info with new namespace
+	db.CleanProcessCaches(ifp.PIDNamespace)
+	_, ok = db.fetchedPodsCache[ifp.PIDNamespace]
+	assert.False(t, ok)
+}


### PR DESCRIPTION
I think this fixes a bug that was very hard to track. Essentially, we saw a wrong service name used for events in a cluster, where there were a few subsequent launches and deaths of containers.

A container namespace was reused between two services on the new launch and the k8s decorator resolved the wrong name for the service, even though we had the correct destination name in the IP to name resolution. This means that the service IP caches were correct, but the name info was stale.

I made two changes to ensure we cleanup the namespace cache:
1. When we overwrite the namespaces map, we clean up the cache for the namespace. I believe this is sufficient for the fix.
2. I added a secondary cleanup of the cache when we run process deletion.