### PR TITLE
Expire span metrics and service graph metrics in the OTEL exporter

### DIFF
--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -135,10 +135,13 @@ const (
 	ServiceNamespace = Name(semconv.ServiceNamespaceKey)
 
 	HostName = Name(semconv.HostNameKey)
+	HostID   = Name(semconv.HostIDKey)
+
+	ServiceInstanceID = Name(semconv.ServiceInstanceIDKey)
 )
 
 // traces related attributes
-var (
+const (
 	// SQL
 	DBQueryText = Name("db.query.text")
 )

--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -113,7 +113,7 @@ func TestTracePrinterResolve_PrinterJSON(t *testing.T) {
 	prefix := `[{"type":"HTTP","ignoreSpan":"Metrics","peer":"peer","peerPort":"1234",` +
 		`"host":"host","hostPort":"5678","traceID":"01020300000000000000000000000000",` +
 		`"spanID":"0102030000000000","parentSpanID":"0102030000000000","flags":"1",` +
-		`"peerName":"peername","hostName":"hostname","kind":"SERVER","`
+		`"peerName":"peername","hostName":"hostname","kind":"SPAN_KIND_SERVER","`
 
 	suffix := `duration":"25µs","durationUSec":"25","handlerDuration":"20µs",` +
 		`"handlerDurationUSec":"20","attributes":{"clientAddr":"peername",` +
@@ -142,7 +142,7 @@ func TestTracePrinterResolve_PrinterJSONIndent(t *testing.T) {
   "flags": "1",
   "peerName": "peername",
   "hostName": "hostname",
-  "kind": "SERVER",`
+  "kind": "SPAN_KIND_SERVER",`
 
 	suffix := `"duration": "25µs",
   "durationUSec": "25",

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -388,7 +388,7 @@ func GenerateTraces(span *request.Span, hostID string, userAttrs map[attr.Name]s
 
 	// Create a parent span for the whole request session
 	s := ss.Spans().AppendEmpty()
-	s.SetName(request.TraceName(span))
+	s.SetName(span.TraceName())
 	s.SetKind(ptrace.SpanKind(spanKind(span)))
 	s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
 

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -699,9 +699,9 @@ func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
 	return []string{
 		span.ServiceID.Name,
 		span.ServiceID.Namespace,
-		request.TraceName(span),
+		span.TraceName(),
 		strconv.Itoa(int(request.SpanStatusCode(span))),
-		request.SpanKindString(span),
+		span.ServiceGraphKind(),
 		span.ServiceID.Instance,
 		job,
 		"beyla",

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -699,9 +699,9 @@ func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
 	return []string{
 		span.ServiceID.Name,
 		span.ServiceID.Namespace,
-		otel.TraceName(span),
+		request.TraceName(span),
 		strconv.Itoa(int(request.SpanStatusCode(span))),
-		otel.SpanKindString(span),
+		request.SpanKindString(span),
 		span.ServiceID.Instance,
 		job,
 		"beyla",

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -1,8 +1,6 @@
 package request
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
@@ -119,57 +117,4 @@ func SpanPeer(span *Span) string {
 	}
 
 	return span.Peer
-}
-
-func SpanKindString(span *Span) string {
-	switch span.Type {
-	case EventTypeHTTP, EventTypeGRPC, EventTypeKafkaServer, EventTypeRedisServer:
-		return "SPAN_KIND_SERVER"
-	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient:
-		return "SPAN_KIND_CLIENT"
-	case EventTypeKafkaClient:
-		switch span.Method {
-		case MessagingPublish:
-			return "SPAN_KIND_PRODUCER"
-		case MessagingProcess:
-			return "SPAN_KIND_CONSUMER"
-		}
-	}
-	return "SPAN_KIND_INTERNAL"
-}
-
-func TraceName(span *Span) string {
-	switch span.Type {
-	case EventTypeHTTP:
-		name := span.Method
-		if span.Route != "" {
-			name += " " + span.Route
-		}
-		return name
-	case EventTypeGRPC, EventTypeGRPCClient:
-		return span.Path
-	case EventTypeHTTPClient:
-		return span.Method
-	case EventTypeSQLClient:
-		operation := span.Method
-		if operation == "" {
-			return "SQL"
-		}
-		table := span.Path
-		if table != "" {
-			operation += " " + table
-		}
-		return operation
-	case EventTypeRedisClient, EventTypeRedisServer:
-		if span.Method == "" {
-			return "REDIS"
-		}
-		return span.Method
-	case EventTypeKafkaClient, EventTypeKafkaServer:
-		if span.Path == "" {
-			return span.Method
-		}
-		return fmt.Sprintf("%s %s", span.Path, span.Method)
-	}
-	return ""
 }

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
@@ -117,4 +119,57 @@ func SpanPeer(span *Span) string {
 	}
 
 	return span.Peer
+}
+
+func SpanKindString(span *Span) string {
+	switch span.Type {
+	case EventTypeHTTP, EventTypeGRPC, EventTypeKafkaServer, EventTypeRedisServer:
+		return "SPAN_KIND_SERVER"
+	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient:
+		return "SPAN_KIND_CLIENT"
+	case EventTypeKafkaClient:
+		switch span.Method {
+		case MessagingPublish:
+			return "SPAN_KIND_PRODUCER"
+		case MessagingProcess:
+			return "SPAN_KIND_CONSUMER"
+		}
+	}
+	return "SPAN_KIND_INTERNAL"
+}
+
+func TraceName(span *Span) string {
+	switch span.Type {
+	case EventTypeHTTP:
+		name := span.Method
+		if span.Route != "" {
+			name += " " + span.Route
+		}
+		return name
+	case EventTypeGRPC, EventTypeGRPCClient:
+		return span.Path
+	case EventTypeHTTPClient:
+		return span.Method
+	case EventTypeSQLClient:
+		operation := span.Method
+		if operation == "" {
+			return "SQL"
+		}
+		table := span.Path
+		if table != "" {
+			operation += " " + table
+		}
+		return operation
+	case EventTypeRedisClient, EventTypeRedisServer:
+		if span.Method == "" {
+			return "REDIS"
+		}
+		return span.Method
+	case EventTypeKafkaClient, EventTypeKafkaServer:
+		if span.Path == "" {
+			return span.Method
+		}
+		return fmt.Sprintf("%s %s", span.Path, span.Method)
+	}
+	return ""
 }

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -64,9 +64,9 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.ServiceNamespace:
 		getter = func(s *Span) attribute.KeyValue { return semconv.ServiceNamespace(s.ServiceID.Namespace) }
 	case attr.SpanKind:
-		getter = func(s *Span) attribute.KeyValue { return SpanKindMetric(SpanKindString(s)) }
+		getter = func(s *Span) attribute.KeyValue { return SpanKindMetric(s.ServiceGraphKind()) }
 	case attr.SpanName:
-		getter = func(s *Span) attribute.KeyValue { return SpanNameMetric(TraceName(s)) }
+		getter = func(s *Span) attribute.KeyValue { return SpanNameMetric(s.TraceName()) }
 	case attr.Source:
 		getter = func(_ *Span) attribute.KeyValue { return SourceMetric("beyla") }
 	case attr.StatusCode:

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -59,21 +59,21 @@ func TestIgnoreModeString(t *testing.T) {
 
 func TestKindString(t *testing.T) {
 	m := map[*Span]string{
-		&Span{Type: EventTypeHTTP}:                                  kServer,
-		&Span{Type: EventTypeGRPC}:                                  kServer,
-		&Span{Type: EventTypeKafkaServer}:                           kServer,
-		&Span{Type: EventTypeRedisServer}:                           kServer,
-		&Span{Type: EventTypeHTTPClient}:                            kClient,
-		&Span{Type: EventTypeGRPCClient}:                            kClient,
-		&Span{Type: EventTypeSQLClient}:                             kClient,
-		&Span{Type: EventTypeRedisClient}:                           kClient,
-		&Span{Type: EventTypeKafkaClient, Method: MessagingPublish}: kProducer,
-		&Span{Type: EventTypeKafkaClient, Method: MessagingProcess}: kConsumer,
-		&Span{}: kInternal,
+		&Span{Type: EventTypeHTTP}:                                  "SPAN_KIND_SERVER",
+		&Span{Type: EventTypeGRPC}:                                  "SPAN_KIND_SERVER",
+		&Span{Type: EventTypeKafkaServer}:                           "SPAN_KIND_SERVER",
+		&Span{Type: EventTypeRedisServer}:                           "SPAN_KIND_SERVER",
+		&Span{Type: EventTypeHTTPClient}:                            "SPAN_KIND_CLIENT",
+		&Span{Type: EventTypeGRPCClient}:                            "SPAN_KIND_CLIENT",
+		&Span{Type: EventTypeSQLClient}:                             "SPAN_KIND_CLIENT",
+		&Span{Type: EventTypeRedisClient}:                           "SPAN_KIND_CLIENT",
+		&Span{Type: EventTypeKafkaClient, Method: MessagingPublish}: "SPAN_KIND_PRODUCER",
+		&Span{Type: EventTypeKafkaClient, Method: MessagingProcess}: "SPAN_KIND_CONSUMER",
+		&Span{}: "SPAN_KIND_INTERNAL",
 	}
 
 	for span, str := range m {
-		assert.Equal(t, kindString(span), str)
+		assert.Equal(t, span.ServiceGraphKind(), str)
 	}
 }
 
@@ -211,7 +211,7 @@ func TestSerializeJSONSpans(t *testing.T) {
 
 		assert.Equal(t, map[string]any{
 			"type":                tData.eventType.String(),
-			"kind":                kindString(&span),
+			"kind":                span.ServiceGraphKind(),
 			"ignoreSpan":          "Metrics",
 			"peer":                "peer",
 			"peerPort":            "1234",


### PR DESCRIPTION
The `traces_target_info` case is a bit more complex case and will be expired in another PR, just to keep this PR small.