### PR TITLE
Count testing in OTEL histogram export

### DIFF
--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -175,6 +175,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		assert.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 		assert.EqualValues(t, 100/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 
 	test.Eventually(t, timeout, func(t require.TestingT) {
@@ -182,6 +183,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
 		assert.EqualValues(t, 25/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 
 	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
@@ -196,6 +198,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 		assert.EqualValues(t, 130/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 2, metric.Count)
 	})
 
 	now.Advance(2 * time.Minute)
@@ -222,6 +225,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		}
 		require.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 		require.EqualValues(t, 140/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 3, metric.Count)
 	}
 
 	// AND WHEN the metrics labels that disappeared are received again
@@ -236,6 +240,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
 		assert.EqualValues(t, 70/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 }
 
@@ -289,6 +294,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		assert.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 		assert.EqualValues(t, 100/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 
 	test.Eventually(t, timeout, func(t require.TestingT) {
@@ -296,6 +302,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
 		assert.EqualValues(t, 25/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 
 	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
@@ -310,6 +317,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		require.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 		assert.EqualValues(t, 130/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 2, metric.Count)
 	})
 
 	now.Advance(2 * time.Minute)
@@ -337,6 +345,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 			}
 			require.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
 			require.EqualValues(t, 140/float64(time.Second), metric.FloatVal)
+			assert.Equal(t, 3, metric.Count)
 		}
 	})
 	// AND WHEN the metrics labels that disappeared are received again
@@ -351,6 +360,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		require.Equal(t, "http.server.request.duration", metric.Name)
 		assert.Equal(t, map[string]string{"url.path": "/bar"}, metric.Attributes)
 		assert.EqualValues(t, 70/float64(time.Second), metric.FloatVal)
+		assert.Equal(t, 1, metric.Count)
 	})
 }
 

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -118,6 +118,7 @@ func TestBasicPipeline(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 2 / float64(time.Second),
+		Count:    1,
 	}, event)
 
 }
@@ -325,6 +326,7 @@ func TestRouteConsolidation(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 2 / float64(time.Second),
+		Count:    1,
 	}, events["/user/{id}"])
 
 	assert.Equal(t, collector.MetricRecord{
@@ -349,6 +351,7 @@ func TestRouteConsolidation(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 2 / float64(time.Second),
+		Count:    1,
 	}, events["/products/{id}/push"])
 
 	assert.Equal(t, collector.MetricRecord{
@@ -373,6 +376,7 @@ func TestRouteConsolidation(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 2 / float64(time.Second),
+		Count:    1,
 	}, events["/**"])
 }
 
@@ -433,6 +437,7 @@ func TestGRPCPipeline(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 2 / float64(time.Second),
+		Count:    1,
 	}, event)
 }
 
@@ -526,6 +531,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 		},
 		Type:     pmetric.MetricTypeHistogram,
 		FloatVal: 1 / float64(time.Second),
+		Count:    1,
 	}, event)
 }
 

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -184,6 +184,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							Unit:               m.Unit(),
 							Type:               m.Type(),
 							FloatVal:           hdp.Sum(),
+							Count:              int(hdp.Count()),
 							Attributes:         map[string]string{},
 							ResourceAttributes: resourceAttrs,
 						}
@@ -227,6 +228,7 @@ type MetricRecord struct {
 	Type               pmetric.MetricType
 	IntVal             int64
 	FloatVal           float64
+	Count              int
 }
 
 type TraceRecord struct {


### PR DESCRIPTION
Doesn't really fix anything, just provides extra safety to histogram unit tests.