### PR TITLE
Helm Chart 1.3.0 with Beyla 1.7.0

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.2.1
-appVersion: 1.6.2
+version: 1.3.0
+appVersion: 1.7.0
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.2](https://img.shields.io/badge/AppVersion-1.6.2-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -186,8 +186,6 @@ config:
     attributes:
       kubernetes:
         enable: true
-    ## internal metrics reporting. Refer: https://grafana.com/docs/beyla/latest/configure/options/#internal-metrics-reporter
-    ## If set, user can expose the metrics endpoint via k8s service by configuring .Values.service section
     prometheus_export:
       port: 9090
       path: /metrics

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -188,10 +188,9 @@ config:
         enable: true
     ## internal metrics reporting. Refer: https://grafana.com/docs/beyla/latest/configure/options/#internal-metrics-reporter
     ## If set, user can expose the metrics endpoint via k8s service by configuring .Values.service section
-    internal_metrics:
-      prometheus:
-        port: 9090
-        path: /metrics
+    prometheus_export:
+      port: 9090
+      path: /metrics
 
 ## Env variables that will override configmap values
 ## For example:


### PR DESCRIPTION
This PR also reverts this PR https://github.com/grafana/beyla/pull/961

The idea behind having a default open Prometheus port was to allow a real single-command installation of Beyla without any kind of configuration. Just having a Beyla working with defaults.

You can have without problem this:
```yaml
    prometheus_export:
      port: 9090
      path: /metrics
    internal_metrics:
      prometheus:
        port: 9090
        path: /metrics
```
or even:
```yaml
    prometheus_export:
      port: 9090
      path: /metrics
    internal_metrics:
      prometheus:
        port: 9090
        path: /internal/metrics
```
As the [Beyla prometheus manager](https://github.com/grafana/beyla/blob/main/pkg/internal/connector/prommgr.go#L42-L59) is smart enough to detect when both exporters go to the same port and path, and redirect there all the metrics.

I'm not sure if we really want to enable internal metrics by default to our users. It seems that, in the original code, what was wrong was the comment saying this was internal metrics, but not the fact of being exporting prometheus metrics by default.