### PR TITLE
Validate timeout greater than 0s for InformersSyncTimeout

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -237,6 +237,9 @@ func (c *Config) Validate() error {
 	if c.EBPF.BatchLength == 0 {
 		return ConfigError("BEYLA_BPF_BATCH_LENGTH must be at least 1")
 	}
+	if c.Attributes.Kubernetes.InformersSyncTimeout == 0 {
+		return ConfigError("BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT duration must be greater than 0s")
+	}
 
 	if c.Enabled(FeatureNetO11y) && !c.Grafana.OTLP.MetricsEnabled() && !c.Metrics.Enabled() &&
 		!c.Prometheus.Enabled() && !c.NetworkFlows.Print {


### PR DESCRIPTION
In early stages of Beyla Alloy integration this flag was set to 0 and Beyla was crashing.
This PR adds a validation (tho i wasn't able to replicate the error this time, so just in case).

Fixes #739