### PR TITLE
Fix slog errors

### DIFF
--- a/test/integration/components/testserver/gin/gin.go
+++ b/test/integration/components/testserver/gin/gin.go
@@ -38,5 +38,5 @@ func Setup(port int) {
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server", "address", address)
 	err := r.Run(address)
-	log.Error("HTTP server has unexpectedly stopped", err)
+	log.Error("HTTP server has unexpectedly stopped", "error", err)
 }

--- a/test/integration/components/testserver/gorilla/gorilla.go
+++ b/test/integration/components/testserver/gorilla/gorilla.go
@@ -18,5 +18,5 @@ func Setup(port, stdPort int) {
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server", "address", address)
 	err := http.ListenAndServe(address, r)
-	log.Error("HTTP server has unexpectedly stopped", err)
+	log.Error("HTTP server has unexpectedly stopped", "error", err)
 }

--- a/test/integration/components/testserver/gorillamid/gorilla.go
+++ b/test/integration/components/testserver/gorillamid/gorilla.go
@@ -24,5 +24,5 @@ func Setup(port, stdPort int) {
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server with middleware", "address", address)
 	err := http.ListenAndServe(address, h)
-	log.Error("HTTP server has unexpectedly stopped", err)
+	log.Error("HTTP server has unexpectedly stopped", "error", err)
 }

--- a/test/integration/components/testserver/gorillamid2/gorilla.go
+++ b/test/integration/components/testserver/gorillamid2/gorilla.go
@@ -36,5 +36,5 @@ func Setup(port, stdPort int) {
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server with middleware", "address", address)
 	err := http.ListenAndServe(address, handler)
-	log.Error("HTTP server has unexpectedly stopped", err)
+	log.Error("HTTP server has unexpectedly stopped", "error", err)
 }

--- a/test/integration/components/testserver/grpc/client/client.go
+++ b/test/integration/components/testserver/grpc/client/client.go
@@ -64,7 +64,7 @@ func printFeature(ctx context.Context, client pb.RouteGuideClient, point *pb.Poi
 	defer cancel()
 	feature, err := client.GetFeature(ctx, point)
 	if err != nil {
-		logs.Error("client.GetFeature failed", err)
+		logs.Error("client.GetFeature failed", "error", err)
 		// nolint:gocritic
 		return err
 	}
@@ -88,7 +88,7 @@ func newClient(po *pingOpts) (pb.RouteGuideClient, io.Closer, error) {
 
 	conn, err := grpc.NewClient(po.serverAddr, opts...)
 	if err != nil {
-		logs.Error("fail to dial", err)
+		logs.Error("fail to dial", "error", err)
 		return nil, conn, err
 	}
 	return pb.NewRouteGuideClient(conn), conn, nil
@@ -151,7 +151,7 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 
 	stream, err := client.ListFeatures(ctx, rect)
 	if err != nil {
-		slog.Error("client.ListFeatures failed", err)
+		slog.Error("client.ListFeatures failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -161,7 +161,7 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 			break
 		}
 		if err != nil {
-			slog.Error("client.ListFeatures failed", err)
+			slog.Error("client.ListFeatures failed", "error", err)
 			os.Exit(-1)
 		}
 		slog.Debug("Feature: ", "name", feature.GetName(),

--- a/test/integration/components/testserver/grpc/server/server.go
+++ b/test/integration/components/testserver/grpc/server/server.go
@@ -154,14 +154,14 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 		var err error
 		data, err = os.ReadFile(filePath)
 		if err != nil {
-			log.Error("Failed to load default features", err)
+			log.Error("Failed to load default features", "error", err)
 			os.Exit(-1)
 		}
 	} else {
 		data = exampleData
 	}
 	if err := json.Unmarshal(data, &s.savedFeatures); err != nil {
-		log.Error("Failed to load default features", err)
+		log.Error("Failed to load default features", "error", err)
 		os.Exit(-1)
 	}
 }
@@ -220,7 +220,7 @@ func Setup(port int) error {
 	flag.Parse()
 	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
-		log.Error("failed to listen", err)
+		log.Error("failed to listen", "error", err)
 		return err
 	}
 	var opts []grpc.ServerOption
@@ -229,7 +229,7 @@ func Setup(port int) error {
 	log.Info("GRPC listening and serving", "port", port)
 	err = grpcServer.Serve(lis)
 	if err != nil {
-		log.Error("failed to serve", err)
+		log.Error("failed to serve", "error", err)
 		return err
 	}
 	return nil
@@ -239,7 +239,7 @@ func SetupTLS(port int) error {
 	flag.Parse()
 	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
-		log.Error("failed to listen", err)
+		log.Error("failed to listen", "error", err)
 		return err
 	}
 	var opts []grpc.ServerOption
@@ -247,7 +247,7 @@ func SetupTLS(port int) error {
 	keyFile := "x509/server_test_key.pem"
 	creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
 	if err != nil {
-		log.Error("Failed to generate credentials", err)
+		log.Error("Failed to generate credentials", "error", err)
 		return err
 	}
 	opts = []grpc.ServerOption{grpc.Creds(creds)}
@@ -256,7 +256,7 @@ func SetupTLS(port int) error {
 	log.Info("GRPC listening and serving", "port", port)
 	err = grpcServer.Serve(lis)
 	if err != nil {
-		log.Error("failed to serve", err)
+		log.Error("failed to serve", "error", err)
 		return err
 	}
 	return nil

--- a/test/integration/components/testserver/std/std.go
+++ b/test/integration/components/testserver/std/std.go
@@ -70,7 +70,7 @@ func echoAsync(rw http.ResponseWriter, port int) {
 	duration, err := time.ParseDuration("10s")
 
 	if err != nil {
-		slog.Error("can't parse duration", err)
+		slog.Error("can't parse duration", "error", err)
 		rw.WriteHeader(500)
 		return
 	}
@@ -104,7 +104,7 @@ func echo(rw http.ResponseWriter, port int) {
 
 	res, err := http.Get(requestURL)
 	if err != nil {
-		slog.Error("error making http request", err)
+		slog.Error("error making http request", "error", err)
 		rw.WriteHeader(500)
 		return
 	}
@@ -130,7 +130,7 @@ func echoLowPort(rw http.ResponseWriter) {
 
 	res, err := httpClient.Get(requestURL)
 	if err != nil {
-		slog.Error("error making http request", err)
+		slog.Error("error making http request", "error", err)
 		rw.WriteHeader(500)
 		return
 	}
@@ -146,7 +146,7 @@ func echoDist(rw http.ResponseWriter) {
 
 	res, err := http.Get(requestURL)
 	if err != nil {
-		slog.Error("error making http request", err)
+		slog.Error("error making http request", "error", err)
 		rw.WriteHeader(500)
 		return
 	}
@@ -159,7 +159,7 @@ func echoCall(rw http.ResponseWriter) {
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	conn, err := grpc.NewClient("localhost:5051", opts...)
 	if err != nil {
-		slog.Error("fail to dial", err)
+		slog.Error("fail to dial", "error", err)
 		rw.WriteHeader(500)
 		return
 	}

--- a/test/integration/components/testserver/testserver.go
+++ b/test/integration/components/testserver/testserver.go
@@ -41,7 +41,7 @@ type config struct {
 func main() {
 	cfg := config{}
 	if err := env.Parse(&cfg); err != nil {
-		slog.Error("can't load configuration from environment", err)
+		slog.Error("can't load configuration from environment", "error", err)
 		os.Exit(-1)
 	}
 	setupLog(&cfg)
@@ -97,7 +97,7 @@ func setupLog(cfg *config) {
 	lvl := slog.LevelInfo
 	err := lvl.UnmarshalText([]byte(cfg.LogLevel))
 	if err != nil {
-		slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", err)
+		slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", "error", err)
 		os.Exit(-1)
 	}
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{


### PR DESCRIPTION
A few tests contained wrong slog statements that led to errors such as

```
 slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)  
```
