### PR TITLE
Update Go version to 1.23

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.23' ]
     steps:
       - uses: actions/checkout@v3
 # TODO:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.23' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.23' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.23' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         arch: ['amd64','arm64']
-        go: [ '1.22' ]
+        go: [ '1.23' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -12,7 +12,7 @@ jobs:
     - name: "Update Go"
       uses: actions/setup-go@v4
       with:
-        go-version: '>=1.22'
+        go-version: '>=1.23'
         check-latest: true
     - name: "Update offsets"
       run: make update-offsets

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ issues:
         - revive
       text: indent-error-flow
 run:
-  go: "1.22"
+  go: "1.23"
   build-tags:
     - integration
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the autoinstrumenter binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # TODO: embed software version in executable
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ endef
 prereqs:
 	@echo "### Check if prerequisites are met, and installing missing dependencies"
 	mkdir -p $(TEST_OUTPUT)/run
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,v1.57.2)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,v1.60.3)
 	$(call go-install-tool,$(BPF2GO),github.com/cilium/ebpf/cmd/bpf2go,$(call gomod-version,cilium/ebpf))
 	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker,$(call gomod-version,grafana/go-offsets-tracker))
 	$(call go-install-tool,$(GOIMPORTS_REVISER),github.com/incu6us/goimports-reviser/v3,v3.6.4)

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	if err := lvl.UnmarshalText([]byte(config.LogLevel)); err != nil {
-		slog.Error("unknown log level specified, choices are [DEBUG, INFO, WARN, ERROR]", err)
+		slog.Error("unknown log level specified, choices are [DEBUG, INFO, WARN, ERROR]", "error", err)
 		os.Exit(-1)
 	}
 
@@ -65,7 +65,7 @@ func main() {
 		go func() {
 			slog.Info("starting PProf HTTP listener", "port", config.ProfilePort)
 			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), nil)
-			slog.Error("PProf HTTP listener stopped working", err)
+			slog.Error("PProf HTTP listener stopped working", "error", err)
 		}()
 	}
 
@@ -90,14 +90,14 @@ func loadConfig(configPath *string) *beyla.Config {
 	if configPath != nil && *configPath != "" {
 		var err error
 		if configReader, err = os.Open(*configPath); err != nil {
-			slog.Error("can't open "+*configPath, err)
+			slog.Error("can't open "+*configPath, "error", err)
 			os.Exit(-1)
 		}
 		defer configReader.Close()
 	}
 	config, err := beyla.LoadConfig(configReader)
 	if err != nil {
-		slog.Error("wrong configuration", err)
+		slog.Error("wrong configuration", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}

--- a/configs/offsets/kafkago/go.mod
+++ b/configs/offsets/kafkago/go.mod
@@ -1,6 +1,6 @@
 module kafkago_off
 
-go 1.22.2
+go 1.23
 
 require github.com/segmentio/kafka-go v0.4.47
 

--- a/configs/offsets/redis/go.mod
+++ b/configs/offsets/redis/go.mod
@@ -1,6 +1,6 @@
 module grafana.com/goredis
 
-go 1.22.2
+go 1.23
 
 require github.com/redis/go-redis/v9 v9.5.1
 

--- a/configs/offsets/sarama/go.mod
+++ b/configs/offsets/sarama/go.mod
@@ -1,6 +1,6 @@
 module sarama_off
 
-go 1.22.2
+go 1.23
 
 require github.com/IBM/sarama v1.43.2
 

--- a/configs/offsets/shopify/go.mod
+++ b/configs/offsets/shopify/go.mod
@@ -1,6 +1,6 @@
 module shopify_sarama_off
 
-go 1.22.2
+go 1.23
 
 require github.com/Shopify/sarama v1.37.1
 

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-ARG GOVERSION="1.22.2"
+ARG GOVERSION="1.23.0"
 
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla
 
-go 1.22
+go 1.23
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -112,7 +112,7 @@ func jsonPrinter(input <-chan []request.Span, indent bool) {
 		data, err := serializeSpansJSON(spans, indent)
 
 		if err != nil {
-			mlog().Error("Error serializing span to json")
+			mlog().Error("Error serializing span to json", "error", err)
 			continue
 		}
 

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -848,7 +848,7 @@ func (mr *MetricsReporter) reportMetrics(input <-chan []request.Span) {
 			reporter, err := mr.reporters.For(&s.ServiceID)
 			if err != nil {
 				mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
-					err, "service", s.ServiceID)
+					"error", err, "service", s.ServiceID)
 				continue
 			}
 			reporter.record(s, mr)

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -306,7 +306,7 @@ func (me *procMetricsExporter) Do(in <-chan []*process.Status) {
 			reporter, err := me.reporters.For(&s.ID)
 			if err != nil {
 				me.log.Error("unexpected error creating OTEL resource. Ignoring metric",
-					err, "service", s.ID.Service)
+					"error", err, "service", s.ID.Service)
 				continue
 			}
 			me.observeMetric(reporter, s)

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -225,7 +225,7 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig, ctxInfo *global.Co
 			return nil, err
 		}
 		if t, err = httpTracer(ctx, opts); err != nil {
-			slog.Error("can't instantiate OTEL HTTP traces exporter", err)
+			slog.Error("can't instantiate OTEL HTTP traces exporter", "error", err)
 			return nil, err
 		}
 		factory := otlphttpexporter.NewFactory()
@@ -253,7 +253,7 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig, ctxInfo *global.Co
 			return nil, err
 		}
 		if t, err = grpcTracer(ctx, opts); err != nil {
-			slog.Error("can't instantiate OTEL GRPC traces exporter: %w", err)
+			slog.Error("can't instantiate OTEL GRPC traces exporter", "error", err)
 			return nil, err
 		}
 		endpoint, _, err := parseTracesEndpoint(&cfg)

--- a/pkg/internal/connector/prommgr.go
+++ b/pkg/internal/connector/prommgr.go
@@ -109,9 +109,9 @@ func (pm *PrometheusManager) listenAndServe(ctx context.Context, port int, handl
 	go func() {
 		err := server.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
-			log.Debug("HTTP server was closed", "err", err)
+			log.Debug("HTTP server was closed", "error", err)
 		} else {
-			log.Error("HTTP service ended unexpectedly", err)
+			log.Error("HTTP service ended unexpectedly", "error", err)
 		}
 	}()
 	go func() {

--- a/pkg/internal/discover/attacher_linux.go
+++ b/pkg/internal/discover/attacher_linux.go
@@ -31,12 +31,12 @@ func (ta *TraceAttacher) mountBpfPinPath() error {
 
 func (ta *TraceAttacher) unmountBpfPinPath() {
 	if err := unix.Unmount(ta.pinPath, unix.MNT_FORCE); err != nil {
-		ta.log.Warn("can't unmount pinned root. Try unmounting and removing it manually", err)
+		ta.log.Warn("can't unmount pinned root. Try unmounting and removing it manually", "error", err)
 		return
 	}
 	ta.log.Debug("unmounted bpf file system")
 	if err := os.RemoveAll(ta.pinPath); err != nil {
-		ta.log.Warn("can't remove pinned root. Try removing it manually", err)
+		ta.log.Warn("can't remove pinned root. Try removing it manually", "error", err)
 	} else {
 		ta.log.Debug("removed pin path")
 	}

--- a/pkg/internal/ebpf/common/ringbuf.go
+++ b/pkg/internal/ebpf/common/ringbuf.go
@@ -96,7 +96,7 @@ func (rbf *ringBufForwarder) sharedReadAndForward(ctx context.Context, closers [
 	// user space.
 	eventsReader, err := readerFactory(rbf.ringbuffer)
 	if err != nil {
-		rbf.logger.Error("creating perf reader. Exiting", err)
+		rbf.logger.Error("creating perf reader. Exiting", "error", err)
 		return
 	}
 	rbf.spans = make([]request.Span, rbf.cfg.BatchLength)
@@ -113,7 +113,7 @@ func (rbf *ringBufForwarder) readAndForward(ctx context.Context, spansChan chan<
 	// user space.
 	eventsReader, err := readerFactory(rbf.ringbuffer)
 	if err != nil {
-		rbf.logger.Error("creating perf reader. Exiting", err)
+		rbf.logger.Error("creating perf reader. Exiting", "error", err)
 		return
 	}
 	rbf.closers = append(rbf.closers, eventsReader)
@@ -153,7 +153,7 @@ func (rbf *ringBufForwarder) readAndForwardInner(eventsReader ringBufReader, spa
 				rbf.logger.Debug("ring buffer is closed")
 				return
 			}
-			rbf.logger.Error("error reading from perf reader", err)
+			rbf.logger.Error("error reading from perf reader", "error", err)
 			continue
 		}
 		rbf.processAndForward(record, spansChan)
@@ -172,7 +172,7 @@ func (rbf *ringBufForwarder) processAndForward(record ringbuf.Record, spansChan 
 	defer rbf.access.Unlock()
 	s, ignore, err := rbf.reader(&record, rbf.filter)
 	if err != nil {
-		rbf.logger.Error("error parsing perf event", err)
+		rbf.logger.Error("error parsing perf event", "error", err)
 		return
 	}
 	if ignore {

--- a/test/cmd/grpc/client/client.go
+++ b/test/cmd/grpc/client/client.go
@@ -55,7 +55,7 @@ func printFeatureWithClient(point *pb.Point, counter int) {
 
 	conn, err := grpc.NewClient(*serverAddr, opts...)
 	if err != nil {
-		slog.Error("fail to dial", err)
+		slog.Error("fail to dial", "error", err)
 		os.Exit(-1)
 	}
 	defer conn.Close()
@@ -84,7 +84,7 @@ func printFeature(client pb.RouteGuideClient, point *pb.Point, counter int) {
 
 	feature, err := client.GetFeature(ctx, point)
 	if err != nil {
-		slog.Error("client.GetFeature failed", err)
+		slog.Error("client.GetFeature failed", "error", err)
 		os.Exit(-1)
 	}
 	if slog.Default().Enabled(context.TODO(), slog.LevelDebug) {
@@ -99,7 +99,7 @@ func printFeatureWrapper(client pb.RouteGuideClient, point *pb.Point) {
 	defer cancel()
 	feature, err := client.GetFeatureWrapper(ctx, point)
 	if err != nil {
-		slog.Error("client.GetFeature failed", err)
+		slog.Error("client.GetFeature failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -115,7 +115,7 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 	defer cancel()
 	stream, err := client.ListFeatures(ctx, rect)
 	if err != nil {
-		slog.Error("client.ListFeatures failed", err)
+		slog.Error("client.ListFeatures failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -125,7 +125,7 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 			break
 		}
 		if err != nil {
-			slog.Error("client.ListFeatures failed", err)
+			slog.Error("client.ListFeatures failed", "error", err)
 			os.Exit(-1)
 		}
 		slog.Info("Feature: ", "name", feature.GetName(),
@@ -147,20 +147,20 @@ func runRecordRoute(client pb.RouteGuideClient) {
 	defer cancel()
 	stream, err := client.RecordRoute(ctx)
 	if err != nil {
-		slog.Error("client.RecordRoute failed", err)
+		slog.Error("client.RecordRoute failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
 	for _, point := range points {
 		if err := stream.Send(point); err != nil {
-			slog.Error("client.RecordRoute: stream.Send failed", err, "point", point)
+			slog.Error("client.RecordRoute: stream.Send failed", "error", err, "point", point)
 			// nolint:gocritic
 			os.Exit(-1)
 		}
 	}
 	reply, err := stream.CloseAndRecv()
 	if err != nil {
-		slog.Error("client.RecordRoute failed", err)
+		slog.Error("client.RecordRoute failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -181,7 +181,7 @@ func runRouteChat(client pb.RouteGuideClient) {
 	defer cancel()
 	stream, err := client.RouteChat(ctx)
 	if err != nil {
-		slog.Error("client.RouteChat failed", err)
+		slog.Error("client.RouteChat failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -195,7 +195,7 @@ func runRouteChat(client pb.RouteGuideClient) {
 				return
 			}
 			if err != nil {
-				slog.Error("client.RouteChat failed", err)
+				slog.Error("client.RouteChat failed", "error", err)
 				// nolint:gocritic
 				os.Exit(-1)
 			}
@@ -204,13 +204,13 @@ func runRouteChat(client pb.RouteGuideClient) {
 	}()
 	for _, note := range notes {
 		if err := stream.Send(note); err != nil {
-			slog.Error("client.RouteChat:", err, "stream.Send", note)
+			slog.Error("client.RouteChat:", "error", err, "stream.Send", note)
 			os.Exit(-1)
 		}
 	}
 	err = stream.CloseSend()
 	if err != nil {
-		slog.Error("client.CloseSend", err)
+		slog.Error("client.CloseSend", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -232,7 +232,7 @@ func main() {
 	if ok {
 		err := lvl.UnmarshalText([]byte(lvlEnv))
 		if err != nil {
-			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", errors.New(lvlEnv))
+			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", "error", errors.New(lvlEnv))
 			os.Exit(-1)
 		}
 	}
@@ -254,7 +254,7 @@ func main() {
 
 	conn, err := grpc.NewClient(*serverAddr, opts...)
 	if err != nil {
-		slog.Error("fail to dial", err)
+		slog.Error("fail to dial", "error", err)
 		os.Exit(-1)
 	}
 	defer conn.Close()

--- a/test/cmd/grpc/client/client.go
+++ b/test/cmd/grpc/client/client.go
@@ -274,7 +274,7 @@ func main() {
 		fmt.Printf("Sleeping, press any key\n")
 
 		var input string
-		fmt.Scanln(&input)
+		_, _ = fmt.Scanln(&input)
 
 		counter++
 		// Feature missing.
@@ -308,7 +308,7 @@ func main() {
 			fmt.Printf("tp_buf: %x\n", tpBuf)
 
 			var input string
-			fmt.Scanln(&input)
+			_, _ = fmt.Scanln(&input)
 			counter++
 			printFeatureWithClient(&pb.Point{Latitude: 409146138, Longitude: -746188906}, counter)
 		}

--- a/test/cmd/grpc/server/server.go
+++ b/test/cmd/grpc/server/server.go
@@ -182,14 +182,14 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 		var err error
 		data, err = os.ReadFile(filePath)
 		if err != nil {
-			slog.Error("Failed to load default features", err)
+			slog.Error("Failed to load default features", "error", err)
 			os.Exit(-1)
 		}
 	} else {
 		data = exampleData
 	}
 	if err := json.Unmarshal(data, &s.savedFeatures); err != nil {
-		slog.Error("Failed to load default features", err)
+		slog.Error("Failed to load default features", "error", err)
 		os.Exit(-1)
 	}
 }
@@ -253,7 +253,7 @@ func main() {
 	if ok {
 		err := lvl.UnmarshalText([]byte(lvlEnv))
 		if err != nil {
-			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", errors.New(lvlEnv))
+			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", "error", errors.New(lvlEnv))
 			os.Exit(-1)
 		}
 	}
@@ -265,7 +265,7 @@ func main() {
 	flag.Parse()
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
 	if err != nil {
-		slog.Error("failed to listen", err)
+		slog.Error("failed to listen", "error", err)
 		os.Exit(-1)
 	}
 	var opts []grpc.ServerOption
@@ -278,7 +278,7 @@ func main() {
 		}
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			slog.Error("Failed to generate credentials", err)
+			slog.Error("Failed to generate credentials", "error", err)
 			os.Exit(-1)
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
@@ -288,7 +288,7 @@ func main() {
 	slog.Info("listening and serving", "port", *port)
 	err = grpcServer.Serve(lis)
 	if err != nil {
-		slog.Error("failed to serve", err)
+		slog.Error("failed to serve", "error", err)
 		os.Exit(-1)
 	}
 }

--- a/test/cmd/pingserver/server.go
+++ b/test/cmd/pingserver/server.go
@@ -39,7 +39,7 @@ func pingHandler(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 	b, err := rw.Write([]byte(ret))
 	if err != nil {
-		slog.Error("writing response", err, "url", req.URL)
+		slog.Error("writing response", "error", err, "url", req.URL)
 		return
 	}
 	slog.Debug(fmt.Sprintf("%T", rw))
@@ -56,7 +56,7 @@ func main() {
 	if ok {
 		err := lvl.UnmarshalText([]byte(lvlEnv))
 		if err != nil {
-			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", errors.New(lvlEnv))
+			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", "error", errors.New(lvlEnv))
 			os.Exit(-1)
 		}
 	}
@@ -69,7 +69,7 @@ func main() {
 	if ps, ok := os.LookupEnv(envPort); ok {
 		var err error
 		if port, err = strconv.Atoi(ps); err != nil {
-			slog.Error("parsing port", err, "value", ps)
+			slog.Error("parsing port", "error", err, "value", ps)
 			os.Exit(-1)
 		}
 	}

--- a/test/cmd/pingwrapper/wrapper.go
+++ b/test/cmd/pingwrapper/wrapper.go
@@ -45,7 +45,7 @@ func pingAsync(rw http.ResponseWriter, req *http.Request) {
 	duration, err := time.ParseDuration("10s")
 
 	if err != nil {
-		slog.Error("can't parse duration", err)
+		slog.Error("can't parse duration", "error", err)
 		os.Exit(-1)
 	}
 
@@ -96,11 +96,11 @@ func pingHandler(rw http.ResponseWriter, req *http.Request) {
 	if res.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
-			slog.Error("reading response", err, "url", req.URL)
+			slog.Error("reading response", "error", err, "url", req.URL)
 		}
 		b, err := rw.Write(bodyBytes)
 		if err != nil {
-			slog.Error("writing response", err, "url", req.URL)
+			slog.Error("writing response", "error", err, "url", req.URL)
 			return
 		}
 		slog.Debug(fmt.Sprintf("%T", rw))
@@ -112,7 +112,7 @@ func gpingHandler(rw http.ResponseWriter, _ *http.Request) {
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	conn, err := grpc.NewClient("localhost:5051", opts...)
 	if err != nil {
-		slog.Error("fail to dial", err)
+		slog.Error("fail to dial", "error", err)
 		os.Exit(-1)
 	}
 	defer conn.Close()
@@ -125,7 +125,7 @@ func gpingHandler(rw http.ResponseWriter, _ *http.Request) {
 	defer cancel()
 	feature, err := client.GetFeature(ctx, point)
 	if err != nil {
-		slog.Error("client.GetFeature failed", err)
+		slog.Error("client.GetFeature failed", "error", err)
 		// nolint:gocritic
 		os.Exit(-1)
 	}
@@ -144,7 +144,7 @@ func main() {
 	if ok {
 		err := lvl.UnmarshalText([]byte(lvlEnv))
 		if err != nil {
-			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", errors.New(lvlEnv))
+			slog.Error("unknown log level specified, choises are [DEBUG, INFO, WARN, ERROR]", "error", errors.New(lvlEnv))
 			os.Exit(-1)
 		}
 	}
@@ -157,7 +157,7 @@ func main() {
 	if ps, ok := os.LookupEnv(envPort); ok {
 		var err error
 		if port, err = strconv.Atoi(ps); err != nil {
-			slog.Error("parsing port", err, "value", ps)
+			slog.Error("parsing port", "error", err, "value", ps)
 			os.Exit(-1)
 		}
 	}

--- a/test/collector/collector.go
+++ b/test/collector/collector.go
@@ -45,7 +45,7 @@ func Start(ctx context.Context) (*TestCollector, error) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		body, err := io.ReadAll(request.Body)
 		if err != nil {
-			log.Error("reading request body", err)
+			log.Error("reading request body", "error", err)
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -79,7 +79,7 @@ func Start(ctx context.Context) (*TestCollector, error) {
 func (tc *TestCollector) traceEvent(writer http.ResponseWriter, body []byte) {
 	req := ptraceotlp.NewExportRequest()
 	if err := req.UnmarshalProto(body); err != nil {
-		log.Error("unmarshalling protobuf event", err)
+		log.Error("unmarshalling protobuf event", "error", err)
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -138,7 +138,7 @@ func (tc *TestCollector) TraceRecords() chan TraceRecord {
 func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 	req := pmetricotlp.NewExportRequest()
 	if err := req.UnmarshalProto(body); err != nil {
-		log.Error("unmarshalling protobuf event", err)
+		log.Error("unmarshalling protobuf event", "error", err)
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/test/integration/components/beyla/Dockerfile
+++ b/test/integration/components/beyla/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/beyla/Dockerfile_dbg
+++ b/test/integration/components/beyla/Dockerfile_dbg
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/go_grpc_server_mux/Dockerfile
+++ b/test/integration/components/go_grpc_server_mux/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/go_grpc_server_mux/Dockerfile_tls
+++ b/test/integration/components/go_grpc_server_mux/Dockerfile_tls
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/go_grpc_server_mux/go.mod
+++ b/test/integration/components/go_grpc_server_mux/go.mod
@@ -1,6 +1,6 @@
 module grpc_mux
 
-go 1.22.5
+go 1.23
 
 require (
 	golang.org/x/net v0.27.0

--- a/test/integration/components/gohttp2/client/Dockerfile
+++ b/test/integration/components/gohttp2/client/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gohttp2/client/go.mod
+++ b/test/integration/components/gohttp2/client/go.mod
@@ -1,6 +1,6 @@
 module http2client
 
-go 1.22
+go 1.23
 
 require (
 	golang.org/x/net v0.20.0 // indirect

--- a/test/integration/components/gohttp2/server/Dockerfile
+++ b/test/integration/components/gohttp2/server/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gohttp2/server/go.mod
+++ b/test/integration/components/gohttp2/server/go.mod
@@ -1,6 +1,6 @@
 module http2srv
 
-go 1.22
+go 1.23
 
 require (
 	golang.org/x/net v0.20.0 // indirect

--- a/test/integration/components/gokafka-seg/Dockerfile
+++ b/test/integration/components/gokafka-seg/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gokafka-seg/go.mod
+++ b/test/integration/components/gokafka-seg/go.mod
@@ -1,6 +1,6 @@
 module grafana.com/gokafka-seg
 
-go 1.22.2
+go 1.23
 
 require github.com/segmentio/kafka-go v0.4.47
 

--- a/test/integration/components/gokafka/Dockerfile
+++ b/test/integration/components/gokafka/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gokafka/go.mod
+++ b/test/integration/components/gokafka/go.mod
@@ -1,6 +1,6 @@
 module grafana.com/gokafka
 
-go 1.22.2
+go 1.23
 
 require (
 	github.com/IBM/sarama v1.43.2 // indirect

--- a/test/integration/components/goredis/Dockerfile
+++ b/test/integration/components/goredis/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/goredis/go.mod
+++ b/test/integration/components/goredis/go.mod
@@ -1,6 +1,6 @@
 module grafana.com/goredis
 
-go 1.22.2
+go 1.23
 
 require github.com/redis/go-redis/v9 v9.5.1
 

--- a/test/integration/components/grpcpinger/Dockerfile
+++ b/test/integration/components/grpcpinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/httppinger/Dockerfile
+++ b/test/integration/components/httppinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/old_grpc/backend/Dockerfile
+++ b/test/integration/components/old_grpc/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /src
 

--- a/test/integration/components/old_grpc/worker/Dockerfile
+++ b/test/integration/components/old_grpc/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /src
 

--- a/test/integration/components/pingclient/Dockerfile
+++ b/test/integration/components/pingclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/sqlclient/Dockerfile
+++ b/test/integration/components/sqlclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile
+++ b/test/integration/components/testserver/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_duplicate
+++ b/test/integration/components/testserver/Dockerfile_duplicate
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_nodebug
+++ b/test/integration/components/testserver/Dockerfile_nodebug
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_rename1
+++ b/test/integration/components/testserver/Dockerfile_rename1
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_static
+++ b/test/integration/components/testserver/Dockerfile_static
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 ARG TARGETARCH
 

--- a/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
+++ b/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/otel/k8s_main_test.go
+++ b/test/integration/k8s/otel/k8s_main_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/integration/k8s/prom/k8s_prom_main_test.go
+++ b/test/integration/k8s/prom/k8s_prom_main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 	); err != nil {
-		slog.Error("can't build docker images", err)
+		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
 	}
 

--- a/test/oats/kafka/go.mod
+++ b/test/oats/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla/test/oats
 
-go 1.22
+go 1.23
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/test/oats/redis/go.mod
+++ b/test/oats/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla/test/oats
 
-go 1.22
+go 1.23
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/test/oats/sql/go.mod
+++ b/test/oats/sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla/test/oats
 
-go 1.22
+go 1.23
 
 require (
 	github.com/grafana/oats v0.0.3


### PR DESCRIPTION
Just checking that no breaking changes are introduced in this version. The merge of this PR can be deferred after all the other PRs are merged, to avoid conflicts.

This PR also fixes some `slog.Error` invocations that were wrong. In Go 1.22 it caused some wrong-format output but in Go 1.23 they are treated as compile errors.