### PR TITLE
Renaming process.cpu.state attribute to cpu.mode

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -180,7 +180,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	var processAttributes = AttrReportGroup{
 		SubGroups: []*AttrReportGroup{&appKubeAttributes, &hostAttributes, &promProcessAttributes},
 		Attributes: map[attr.Name]Default{
-			attr.ProcCPUState:  true,
+			attr.ProcCPUMode:   true,
 			attr.ProcDiskIODir: true,
 			attr.ProcNetIODir:  true,
 		},

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -111,7 +111,7 @@ const (
 const (
 	ProcCommand     = Name(semconv.ProcessCommandKey)
 	ProcCommandLine = Name(semconv.ProcessCommandLineKey)
-	ProcCPUState    = Name("process.cpu.state")
+	ProcCPUMode     = Name("cpu.mode")
 	ProcDiskIODir   = Name(semconv2.DiskIoDirectionKey)
 	ProcNetIODir    = Name(semconv2.NetworkIoDirectionKey)
 	ProcOwner       = Name(semconv.ProcessOwnerKey)

--- a/pkg/export/otel/expirer.go
+++ b/pkg/export/otel/expirer.go
@@ -72,7 +72,7 @@ func NewExpirer[Record any, Metric removableMetric[ValType], ValType any](
 // ForRecord returns the data point for the given eBPF record. If that record
 // is accessed for the first time, a new data point is created.
 // If not, a cached copy is returned and the "last access" cache time is updated.
-// Extra attributes can be explicitly added (e.g. process_cpu_state="wait")
+// Extra attributes can be explicitly added (e.g. cpu_mode="wait")
 func (ex *Expirer[Record, Metric, ValType]) ForRecord(r Record, extraAttrs ...attribute.KeyValue) (Metric, attribute.Set) {
 	// to save resources, metrics expiration is triggered each TTL. This means that an expired
 	// metric might stay visible after 2*TTL time after not being updated

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	stateWaitAttr   = attr2.ProcCPUState.OTEL().String("wait")
-	stateUserAttr   = attr2.ProcCPUState.OTEL().String("user")
-	stateSystemAttr = attr2.ProcCPUState.OTEL().String("system")
+	stateWaitAttr   = attr2.ProcCPUMode.OTEL().String("wait")
+	stateUserAttr   = attr2.ProcCPUMode.OTEL().String("user")
+	stateSystemAttr = attr2.ProcCPUMode.OTEL().String("system")
 
 	diskIODirRead  = attr2.ProcDiskIODir.OTEL().String("read")
 	diskIODirWrite = attr2.ProcDiskIODir.OTEL().String("write")
@@ -69,7 +69,7 @@ type procMetricsExporter struct {
 	attrNet           []attributes.Field[*process.Status, attribute.KeyValue]
 
 	// the observation code for CPU metrics will be different depending on
-	// the "process.cpu.state" attribute being selected or not
+	// the "cpu.mode" attribute being selected or not
 	cpuTimeObserver        func(context.Context, *procMetrics, *process.Status)
 	cpuUtilisationObserver func(context.Context, *procMetrics, *process.Status)
 
@@ -149,12 +149,12 @@ func newProcMetricsExporter(
 		attrDisk: attrDisk,
 		attrNet:  attrNet,
 	}
-	if slices.Contains(cpuTimeNames, attr2.ProcCPUState) {
+	if slices.Contains(cpuTimeNames, attr2.ProcCPUMode) {
 		mr.cpuTimeObserver = cpuTimeDisaggregatedObserver
 	} else {
 		mr.cpuTimeObserver = cpuTimeAggregatedObserver
 	}
-	if slices.Contains(cpuUtilNames, attr2.ProcCPUState) {
+	if slices.Contains(cpuUtilNames, attr2.ProcCPUMode) {
 		mr.cpuUtilisationObserver = cpuUtilisationDisaggregatedObserver
 	} else {
 		mr.cpuUtilisationObserver = cpuUtilisationAggregatedObserver
@@ -329,7 +329,7 @@ func (me *procMetricsExporter) observeMetric(reporter *procMetrics, s *process.S
 }
 
 // aggregated observers report all the CPU metrics in a single data point
-// to be triggered when the user disables the "process_cpu_state" metric
+// to be triggered when the user disables the "cpu_mode" metric
 func cpuTimeAggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
 	cpu, attrs := reporter.cpuTime.ForRecord(record)
 	cpu.Add(ctx, record.CPUTimeUserDelta+record.CPUTimeSystemDelta+record.CPUTimeWaitDelta,
@@ -343,7 +343,7 @@ func cpuUtilisationAggregatedObserver(ctx context.Context, reporter *procMetrics
 }
 
 // disaggregated observers report three CPU metrics: system, user and wait time
-// to be triggered when the user enables the "process_cpu_state" metric
+// to be triggered when the user enables the "cpu_mode" metric
 func cpuTimeDisaggregatedObserver(ctx context.Context, reporter *procMetrics, record *process.Status) {
 	cpu, attrs := reporter.cpuTime.ForRecord(record, stateWaitAttr)
 	cpu.Add(ctx, record.CPUTimeWaitDelta, metric2.WithAttributeSet(attrs))

--- a/pkg/export/otel/metrics_proc_test.go
+++ b/pkg/export/otel/metrics_proc_test.go
@@ -26,7 +26,7 @@ func TestProcMetrics_Aggregated(t *testing.T) {
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	// GIVEN an OTEL Metrics Exporter whose process CPU metrics do not consider the process.cpu.state
+	// GIVEN an OTEL Metrics Exporter whose process CPU metrics do not consider the cpu.mode
 	includedAttributes := attributes.InclusionLists{
 		Exclude: []string{"*"},
 	}
@@ -191,9 +191,9 @@ func TestProcMetrics_Disaggregated(t *testing.T) {
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	// GIVEN an OTEL Metrics Exporter whose process CPU metrics consider the process.cpu.state
+	// GIVEN an OTEL Metrics Exporter whose process CPU metrics consider the cpu.mode
 	includedAttributes := attributes.InclusionLists{
-		Include: []string{"process_command", "process_cpu_state", "disk_io_direction", "network_io_direction"},
+		Include: []string{"process_command", "cpu_mode", "disk_io_direction", "network_io_direction"},
 	}
 	otelExporter, err := ProcMetricsExporterProvider(
 		ctx, &global.ContextInfo{}, &ProcMetricsConfig{
@@ -233,42 +233,42 @@ func TestProcMetrics_Disaggregated(t *testing.T) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "user"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "user"}, metric.Attributes)
 		require.EqualValues(t, 30, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "system"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "system"}, metric.Attributes)
 		require.EqualValues(t, 10, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.time", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "wait"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "wait"}, metric.Attributes)
 		require.EqualValues(t, 20, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "user"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "user"}, metric.Attributes)
 		require.EqualValues(t, 1, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "system"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "system"}, metric.Attributes)
 		require.EqualValues(t, 2, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		metric := readChan(t, otlp.Records(), timeout)
 		require.Equal(t, "process.cpu.utilization", metric.Name)
 		require.Equal(t, "foo", metric.ResourceAttributes["process.command"])
-		require.Equal(t, map[string]string{"process.cpu.state": "wait"}, metric.Attributes)
+		require.Equal(t, map[string]string{"cpu.mode": "wait"}, metric.Attributes)
 		require.EqualValues(t, 3, metric.FloatVal)
 	})
 	test.Eventually(t, timeout, func(t require.TestingT) {

--- a/pkg/export/prom/prom_proc_test.go
+++ b/pkg/export/prom/prom_proc_test.go
@@ -28,7 +28,7 @@ func TestProcPrometheusEndpoint_AggregatedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
 
-	// GIVEN a Prometheus Metrics Exporter whose process CPU metrics do not consider the process_cpu_state
+	// GIVEN a Prometheus Metrics Exporter whose process CPU metrics do not consider the cpu_mode
 	attribs := attributes.InclusionLists{
 		Include: []string{"process_command"},
 	}
@@ -115,9 +115,9 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
 
-	// GIVEN a Prometheus Metrics Exporter whose process CPU metrics consider the process_cpu_state
+	// GIVEN a Prometheus Metrics Exporter whose process CPU metrics consider the cpu_mode
 	attribs := attributes.InclusionLists{
-		Include: []string{"process_command", "process_cpu_state", "disk_io_direction", "network_io_direction"},
+		Include: []string{"process_command", "cpu_mode", "disk_io_direction", "network_io_direction"},
 	}
 	exporter, err := ProcPrometheusEndpoint(
 		ctx, &global.ContextInfo{Prometheus: &connector.PrometheusManager{}},
@@ -152,12 +152,12 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 	// THEN the metrics are exported aggregated by system/user/wait times
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		exported := getMetrics(t, promURL)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="user"} 1`)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="system"} 2`)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="wait"} 3`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="user"} 30`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="system"} 10`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="wait"} 20`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="user",process_command="foo"} 1`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="system",process_command="foo"} 2`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="wait",process_command="foo"} 3`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="user",process_command="foo"} 30`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="system",process_command="foo"} 10`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="wait",process_command="foo"} 20`)
 		assert.Contains(t, exported, `process_disk_io_bytes_total{disk_io_direction="read",process_command="foo"} 123`)
 		assert.Contains(t, exported, `process_disk_io_bytes_total{disk_io_direction="write",process_command="foo"} 456`)
 		assert.Contains(t, exported, `process_network_io_bytes_total{network_io_direction="transmit",process_command="foo"} 3`)
@@ -177,12 +177,12 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 	// THEN the counter is updated by adding values and the gauges change their values
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		exported := getMetrics(t, promURL)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="user"} 2`)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="system"} 1`)
-		assert.Contains(t, exported, `process_cpu_utilization_ratio{process_command="foo",process_cpu_state="wait"} 4`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="user"} 33`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="system"} 11`)
-		assert.Contains(t, exported, `process_cpu_time_seconds_total{process_command="foo",process_cpu_state="wait"} 22`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="user",process_command="foo"} 2`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="system",process_command="foo"} 1`)
+		assert.Contains(t, exported, `process_cpu_utilization_ratio{cpu_mode="wait",process_command="foo"} 4`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="user",process_command="foo"} 33`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="system",process_command="foo"} 11`)
+		assert.Contains(t, exported, `process_cpu_time_seconds_total{cpu_mode="wait",process_command="foo"} 22`)
 		assert.Contains(t, exported, `process_disk_io_bytes_total{disk_io_direction="read",process_command="foo"} 126`)
 		assert.Contains(t, exported, `process_disk_io_bytes_total{disk_io_direction="write",process_command="foo"} 458`)
 		assert.Contains(t, exported, `process_network_io_bytes_total{network_io_direction="transmit",process_command="foo"} 33`)

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -87,7 +87,7 @@ func NewStatus(pid int32, svcID *svc.ID) *Status {
 func OTELGetters(name attr.Name) (attributes.Getter[*Status, attribute.KeyValue], bool) {
 	var g attributes.Getter[*Status, attribute.KeyValue]
 	switch name {
-	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
+	case attr.ProcCPUMode, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the OTEL exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
 	}
@@ -116,7 +116,7 @@ func PromGetters(name attr.Name) (attributes.Getter[*Status, string], bool) {
 		g = func(s *Status) string { return strconv.Itoa(int(s.ID.ParentProcessID)) }
 	case attr.ProcPid:
 		g = func(s *Status) string { return strconv.Itoa(int(s.ID.ProcessID)) }
-	case attr.ProcCPUState, attr.ProcDiskIODir, attr.ProcNetIODir:
+	case attr.ProcCPUMode, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the prometheus exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
 	default:

--- a/test/integration/configs/instrumenter-config-java.yml
+++ b/test/integration/configs/instrumenter-config-java.yml
@@ -9,4 +9,4 @@ attributes:
     process_*:
       include: ["*"]
     process_cpu_*:
-      exclude: ["process_cpu_state"]
+      exclude: ["cpu_mode"]

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -11,10 +11,10 @@ attributes:
   select:
     process_cpu_utilization:
       include: ["*"]
-      exclude: ["process_cpu_state"]
+      exclude: ["cpu_mode"]
     process_cpu_time:
       include: ["*"]
-      exclude: ["process_cpu_state"]
+      exclude: ["cpu_mode"]
     process_memory_usage:
       include: ["*"]
     process_memory_virtual:


### PR DESCRIPTION
The latest OTEL specification renamed process.cpu.state to cpu.mode
https://opentelemetry.io/docs/specs/semconv/system/process-metrics/