### PR TITLE
Terminate Beyla if we can't open a configured Prometheus port

### DIFF
--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -366,7 +366,8 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 			time.Sleep(5 * time.Second)
 			serverUp <- true
 		}()
-		server.ListenAndServe()
+		err := server.ListenAndServe()
+		fmt.Printf("Terminating server %v\n", err)
 	}()
 
 	sigChan := make(chan os.Signal, 1)

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -5,13 +5,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"os/signal"
 	"regexp"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/mariomac/pipes/pipe"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -339,6 +343,55 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 			assert.Equal(t, tt.discarded, !mr.otelSpanObserved(&tt.span), tt.name)
 		})
 	}
+}
+
+func TestTerminatesOnBadPromPort(t *testing.T) {
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+	openPort, err := test.FreeTCPPort()
+	require.NoError(t, err)
+
+	// Grab the port we just allocated for something else
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %v, http: %v\n", r.URL.Path, r.TLS == nil)
+	})
+	server := http.Server{Addr: fmt.Sprintf(":%d", openPort), Handler: handler}
+	serverUp := make(chan bool, 1)
+
+	go func() {
+		go func() {
+			time.Sleep(5 * time.Second)
+			serverUp <- true
+		}()
+		server.ListenAndServe()
+	}()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT)
+
+	pm := connector.PrometheusManager{}
+
+	c := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: TracesTargetInfo,
+		Help: "target service information in trace span metric format",
+	}, []string{"a"}).MetricVec
+
+	pm.Register(openPort, "/metrics", c)
+	go pm.StartHTTP(ctx)
+
+	ok := false
+	select {
+	case sig := <-sigChan:
+		assert.Equal(t, sig, syscall.SIGINT)
+		ok = true
+	case <-time.After(5 * time.Second):
+		ok = false
+	}
+
+	assert.True(t, ok)
 }
 
 var mmux = sync.Mutex{}

--- a/pkg/internal/connector/prommgr.go
+++ b/pkg/internal/connector/prommgr.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -109,9 +111,10 @@ func (pm *PrometheusManager) listenAndServe(ctx context.Context, port int, handl
 	go func() {
 		err := server.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
-			log.Debug("HTTP server was closed", "error", err)
+			log.Debug("Prometheus endpoint server was closed", "error", err)
 		} else {
-			log.Error("HTTP service ended unexpectedly", "error", err)
+			log.Error("Prometheus endpoint service ended unexpectedly", "error", err)
+			syscall.Kill(os.Getpid(), syscall.SIGINT) // interrupt for graceful shutdown, instead of os.Exit
 		}
 	}()
 	go func() {

--- a/pkg/internal/connector/prommgr.go
+++ b/pkg/internal/connector/prommgr.go
@@ -114,7 +114,10 @@ func (pm *PrometheusManager) listenAndServe(ctx context.Context, port int, handl
 			log.Debug("Prometheus endpoint server was closed", "error", err)
 		} else {
 			log.Error("Prometheus endpoint service ended unexpectedly", "error", err)
-			syscall.Kill(os.Getpid(), syscall.SIGINT) // interrupt for graceful shutdown, instead of os.Exit
+			err = syscall.Kill(os.Getpid(), syscall.SIGINT) // interrupt for graceful shutdown, instead of os.Exit
+			if err != nil {
+				log.Error("unable to terminate Beyla", "error", err)
+			}
 		}
 	}()
 	go func() {


### PR DESCRIPTION
Beyla can fail to register the HTTP Prometheus metrics endpoint because of number of reasons. It can be that the port is already opened or we don't have permission to listen on a specific port.

Currently, when we fail to open the Prometheus port the Beyla process prints an error message, but then successfully runs. Successful run can be misleading, since for the end users there is no indication that the process is unhealthy and the error message is buried in the very first few lines of the logs. The symptom is metrics are not scraped, but Beyla is up and running.

This PR causes Beyla to terminate as soon as we fail to register the port. We can't add early validation for this error scenario, because we can't predict all of the possible reasons we may not be able to open the Prometheus port.