### PR TITLE
Add some default settings for beyla network metrics

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -186,6 +186,21 @@ config:
     attributes:
       kubernetes:
         enable: true
+      select:
+        beyla_network_flow_bytes:
+          include:
+            - 'k8s.src.owner.type'
+            - 'k8s.dst.owner.type'
+            - 'direction'
+    filter:
+      network:
+        k8s_dst_owner_name:
+          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+        k8s_src_owner_name:
+          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    # to enable network metrics
+#    network:
+#      enable: true
     prometheus_export:
       port: 9090
       path: /metrics


### PR DESCRIPTION
Open this PR to start a discussion on some of the default settings we suggest Beyla to ship with. These settings are mostly from Asserts' perspective on managing the cardinality of beyla network metrics. It's likely I might be missing some big picture, but let's have something to start with.