### PR TITLE
Remove self references from service graphs

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -901,7 +901,7 @@ of Beyla: application-level metrics or network metrics.
 This option affects the behaviour of the generation of application-level service graph metrics, which can be enabled 
 by adding `application_service_graph` to the list of OpenTelemetry metric export features. By default, Beyla does not
 report application-level service graph metrics which are considered to be self-referencing. For example, self-references
-can be calls from local node metric scrape tools, or a service making an HTTP call to itself. We consider self-references
+can be calls from local node metric scrape tools, or a service making an HTTP call to itself. Self-references
 not useful for the purpose of showing service graphs, while at the same time they increase the cardinality and the
 overall metric storage cost. To allow generation of application-level service graph metrics which also include 
 self-references, change this option value to `true`.
@@ -1290,7 +1290,7 @@ of Beyla: application-level metrics or network metrics.
 This option affects the behaviour of the generation of application-level service graph metrics, which can be enabled 
 by adding `application_service_graph` to the list of Prometheus metric export features. By default, Beyla does not
 report application-level service graph metrics which are considered to be self-referencing. For example, self-references
-can be calls from local node metric scrape tools, or a service making an HTTP call to itself. We consider self-references
+can be calls from local node metric scrape tools, or a service making an HTTP call to itself. Self-references
 not useful for the purpose of showing service graphs, while at the same time they increase the cardinality and the
 overall metric storage cost. To allow generation of application-level service graph metrics which also include 
 self-references, change this option value to `true`.

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -894,6 +894,17 @@ of Beyla: application-level metrics or network metrics.
   metrics; but only if there is an OpenTelemetry endpoint defined. For network-level metrics options visit the
   [network metrics]({{< relref "../network" >}}) configuration documentation.
 
+| YAML                                  | Environment variable                        | Type     | Default |
+|---------------------------------------|---------------------------------------------|----------|---------|
+| `allow_service_graph_self_references` | `BEYLA_ALLOW_SERVICE_GRAPH_SELF_REFERENCES` | boolean  | `false` |
+
+This option affects the behaviour of the generation of application-level service graph metrics, which can be enabled 
+by adding `application_service_graph` to the list of OpenTelemetry metric export features. By default, Beyla does not
+report application-level service graph metrics which are considered to be self-referencing. For example, self-references
+can be calls from local node metric scrape tools, or a service making an HTTP call to itself. We consider self-references
+not useful for the purpose of showing service graphs, while at the same time they increase the cardinality and the
+overall metric storage cost. To allow generation of application-level service graph metrics which also include 
+self-references, change this option value to `true`.
 
 | YAML               | Environment variable                  | Type            | Default                      |
 |--------------------|---------------------------------------|-----------------|------------------------------|
@@ -1271,6 +1282,18 @@ of Beyla: application-level metrics or network metrics.
 - If the list contains `network`, the Beyla Prometheus exporter exports network-level
   metrics; but only if the Prometheus `port` property is defined. For network-level metrics options visit the
   [network metrics]({{< relref "../network" >}}) configuration documentation.
+
+| YAML                                  | Environment variable                                   | Type     | Default |
+|---------------------------------------|--------------------------------------------------------|----------|---------|
+| `allow_service_graph_self_references` | `BEYLA_PROMETHEUS_ALLOW_SERVICE_GRAPH_SELF_REFERENCES` | boolean  | `false` |
+
+This option affects the behaviour of the generation of application-level service graph metrics, which can be enabled 
+by adding `application_service_graph` to the list of Prometheus metric export features. By default, Beyla does not
+report application-level service graph metrics which are considered to be self-referencing. For example, self-references
+can be calls from local node metric scrape tools, or a service making an HTTP call to itself. We consider self-references
+not useful for the purpose of showing service graphs, while at the same time they increase the cardinality and the
+overall metric storage cost. To allow generation of application-level service graph metrics which also include 
+self-references, change this option value to `true`.
 
 
 | YAML               | Environment variable                  | Type            | Default                      |

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -894,9 +894,9 @@ of Beyla: application-level metrics or network metrics.
   metrics; but only if there is an OpenTelemetry endpoint defined. For network-level metrics options visit the
   [network metrics]({{< relref "../network" >}}) configuration documentation.
 
-| YAML                                  | Environment variable                        | Type     | Default |
-|---------------------------------------|---------------------------------------------|----------|---------|
-| `allow_service_graph_self_references` | `BEYLA_ALLOW_SERVICE_GRAPH_SELF_REFERENCES` | boolean  | `false` |
+| YAML                                  | Environment variable                             | Type     | Default |
+|---------------------------------------|--------------------------------------------------|----------|---------|
+| `allow_service_graph_self_references` | `BEYLA_OTEL_ALLOW_SERVICE_GRAPH_SELF_REFERENCES` | boolean  | `false` |
 
 This option affects the behaviour of the generation of application-level service graph metrics, which can be enabled 
 by adding `application_service_graph` to the list of OpenTelemetry metric export features. By default, Beyla does not

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -101,7 +101,7 @@ type MetricsConfig struct {
 	// removed from the metrics set.
 	TTL time.Duration `yaml:"ttl" env:"BEYLA_OTEL_METRICS_TTL"`
 
-	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"BEYLA_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
+	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"BEYLA_OTEL_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
 
 	// Grafana configuration needs to be explicitly set up before building the graph
 	Grafana *GrafanaOTLP `yaml:"-"`

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -483,3 +483,7 @@ func (s *Span) IsExportTracesSpan() bool {
 
 	return s.isTracesExportURL()
 }
+
+func (s *Span) IsSelfReferenceSpan() bool {
+	return s.Peer == s.Host && (s.ServiceID.Namespace == s.OtherNamespace || s.OtherNamespace == "")
+}

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	trace2 "go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func TestSpanClientServer(t *testing.T) {

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	trace2 "go.opentelemetry.io/otel/trace"
@@ -346,6 +347,37 @@ func TestDetectsOTelExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.exports, tt.span.IsExportTracesSpan())
 			assert.Equal(t, false, tt.span.IsExportMetricsSpan())
+		})
+	}
+}
+
+func TestSelfReferencingSpan(t *testing.T) {
+	// Metrics
+	tests := []struct {
+		name    string
+		span    Span
+		selfref bool
+	}{
+		{
+			name:    "Not a self-reference",
+			span:    Span{Type: EventTypeHTTP, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200, Host: "10.10.10.10", Peer: "10.11.10.11", OtherNamespace: "", ServiceID: svc.ID{Namespace: ""}},
+			selfref: false,
+		},
+		{
+			name:    "Not a self-reference, same IP, different namespace",
+			span:    Span{Type: EventTypeHTTP, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200, Host: "10.10.10.10", Peer: "10.10.10.10", OtherNamespace: "B", ServiceID: svc.ID{Namespace: "A"}},
+			selfref: false,
+		},
+		{
+			name:    "Same IP different namespace, but the other namespace is empty",
+			span:    Span{Type: EventTypeHTTP, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200, Host: "10.10.10.10", Peer: "10.10.10.10", OtherNamespace: "", ServiceID: svc.ID{Namespace: "A"}},
+			selfref: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.selfref, tt.span.IsSelfReferenceSpan())
 		})
 	}
 }

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       GOCOVERDIR: "/coverage"
       BEYLA_TRACE_PRINTER: "json"
       BEYLA_OPEN_PORT: "${BEYLA_OPEN_PORT}"
-      BEYLA_OTEL_METRICS_FEATURES: "application,application_span,application_process"
-      BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process"
+      BEYLA_OTEL_METRICS_FEATURES: "application,application_span,application_process,application_service_graph"
+      BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_EXECUTABLE_NAME: "${BEYLA_EXECUTABLE_NAME}"
       BEYLA_SKIP_GO_SPECIFIC_TRACERS: "${BEYLA_SKIP_GO_SPECIFIC_TRACERS}"

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -56,7 +56,7 @@ func testREDMetricsHTTP(t *testing.T) {
 			waitForTestComponents(t, testCaseURL)
 			testREDMetricsForHTTPLibrary(t, testCaseURL, "testserver", "integration-test")
 			testSpanMetricsForHTTPLibrary(t, "testserver", "integration-test")
-			testServiceGraphMetricsForHTTPLibrary(t, "testserver", "integration-test")
+			testServiceGraphMetricsForHTTPLibrary(t, "integration-test")
 		})
 	}
 }
@@ -143,7 +143,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 }
 
 // **IMPORTANT** Tests must first call -> func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
-func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
+func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcNs string) {
 	pq := prom.Client{HostPort: prometheusHostPort}
 	var results []prom.Result
 
@@ -151,8 +151,7 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
 		results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
-			`service_namespace="` + svcNs + `",` +
-			`service_name="` + svcName + `"` +
+			`service_namespace="` + svcNs + `"` +
 			`}`)
 		require.NoError(t, err)
 		// check span metric latency exists
@@ -165,8 +164,7 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) 
 	results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
 		`service_namespace="` + svcNs + `",` +
 		`client="127.0.0.1",` +
-		`server="127.0.0.1",` +
-		`service_name="` + svcName + `"` +
+		`server="127.0.0.1"` +
 		`}`)
 	require.NoError(t, err)
 	// check calls total to 0, no self references
@@ -176,8 +174,7 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) 
 	results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
 		`service_namespace="` + svcNs + `",` +
 		`client="::1",` +
-		`server="::1",` +
-		`service_name="` + svcName + `"` +
+		`server="::1"` +
 		`}`)
 	require.NoError(t, err)
 	// check calls total to 0, no self references

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -152,7 +152,8 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcNs string) {
 		var err error
 		results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
 			`service_namespace="` + svcNs + `"` +
-			`}`)
+			`} or traces_service_graph_request_server_seconds_count{` +
+			`server_service_namespace="` + svcNs + `"}`)
 		require.NoError(t, err)
 		// check span metric latency exists
 		enoughPromResults(t, results)
@@ -162,7 +163,6 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcNs string) {
 
 	var err error
 	results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
-		`service_namespace="` + svcNs + `",` +
 		`client="127.0.0.1",` +
 		`server="127.0.0.1"` +
 		`}`)
@@ -172,7 +172,6 @@ func testServiceGraphMetricsForHTTPLibrary(t *testing.T, svcNs string) {
 	assert.Equal(t, 0, val)
 
 	results, err = pq.Query(`traces_service_graph_request_server_seconds_count{` +
-		`service_namespace="` + svcNs + `",` +
 		`client="::1",` +
 		`server="::1"` +
 		`}`)


### PR DESCRIPTION
Beyla's direct service graph generation code didn't check for calls which are self-referencing. Self-references are not shown on service graph tools and by generating them we increase the overall cardinality and storage cost. From few customer scenarios we've seen, self-references can be very common. For example, folks often install tools which run beside the service to check its health and liveness. 

With this PR we remove the self reference generation by default, while leaving an option to allow customers to turn that back on.