### PR TITLE
Rename beyla_build_info for internal registry

### DIFF
--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -127,4 +127,4 @@ Beyla can be [configured to report internal metrics]({{< relref "./configure/opt
 | `beyla_otel_trace_export_errors_total` | CounterVec | Error count on each failed OTEL trace export, by error type                              |
 | `beyla_prometheus_http_requests_total` | CounterVec | Number of requests towards the Prometheus Scrape endpoint, faceted by HTTP port and path |
 | `beyla_instrumented_processes`        | GaugeVec    | Instrumented processes by Beyla, with process name                                       |
-| `beyla_build_info`                    | GaugeVec    | Version information of the Beyla binary, including the build time and commit hash        |
+| `beyla_internal_build_info`                    | GaugeVec    | Version information of the Beyla binary, including the build time and commit hash        |

--- a/grafana/beyla.json
+++ b/grafana/beyla.json
@@ -103,7 +103,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "beyla_build_info",
+          "expr": "beyla_internal_build_info",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",

--- a/pkg/internal/imetrics/iprom.go
+++ b/pkg/internal/imetrics/iprom.go
@@ -70,7 +70,7 @@ func NewPrometheusReporter(cfg *PrometheusConfig, manager *connector.PrometheusM
 			Help: "Instrumented processes by Beyla",
 		}, []string{"process_name"}),
 		beylaInfo: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "beyla_build_info",
+			Name: "beyla_internal_build_info",
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
 				"goversion from which Beyla was built, the goos and goarch for the build.",
 			ConstLabels: map[string]string{
@@ -89,10 +89,8 @@ func NewPrometheusReporter(cfg *PrometheusConfig, manager *connector.PrometheusM
 			pr.otelTraceExports,
 			pr.otelTraceExportErrs,
 			pr.prometheusRequests,
-			pr.instrumentedProcesses)
-		// Using the registry here means that the metrics will be registered with the global prometheus registry
-		// Therefore, we won't register beyla_build_info as it's already registered in pkg/export/prom/prom.go
-		pr.beylaInfo = nil
+			pr.instrumentedProcesses,
+			pr.beylaInfo)
 	} else {
 		manager.Register(cfg.Port, cfg.Path,
 			pr.tracerFlushes,
@@ -112,9 +110,7 @@ func (p *PrometheusReporter) Start(ctx context.Context) {
 	if p.connector != nil {
 		p.connector.StartHTTP(ctx)
 	}
-	if p.beylaInfo != nil {
-		p.beylaInfo.Set(1)
-	}
+	p.beylaInfo.Set(1)
 }
 
 func (p *PrometheusReporter) TracerFlush(len int) {


### PR DESCRIPTION
When Beyla is configured to have same port and path for prometheus exporter and internal metrics
means that the same Prometheus registry. This causes a panic because it tries to register `beyla_build_info`.

I tried different approaches to avoid register duplicated metrics but all the implementations are quite hacky,
as there's not a proper way to see if a metric is already register.

The easiest approach is to rename `beyla_build_info` to `beyla_internal_build_info`. So far it would only break
the internal debug dashboard.