### PR TITLE
Fix `wildcard` regex in rout matcher

### DIFF
--- a/pkg/internal/transform/route/matcher.go
+++ b/pkg/internal/transform/route/matcher.go
@@ -9,7 +9,7 @@ import (
 // - /user/:userId/details (Gin)
 // - /user/{userId}/details (Gorilla)
 // More formats will be appended at some point
-var wildcard = regexp.MustCompile(`^((:\w*)|(\{\w*}))$`)
+var wildcard = regexp.MustCompile(`^((:\w*)|(\{\w*\}))$`)
 
 // Matcher allows matching a given URL path towards a set of framework-like provided
 // patterns.


### PR DESCRIPTION
Hi, I am interested in the route matcher implementation in Beyla, and I noticed that there is a tiny error in the matcher.