### PR TITLE
Add 'watch services' permission to unprivileged example

### DIFF
--- a/examples/k8s/unprivileged.yaml
+++ b/examples/k8s/unprivileged.yaml
@@ -43,8 +43,8 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["services"]
-  # list services is needed by network-policy beyla.
-  verbs: ["list"]
+  # list and watch services are needed by network-policy beyla.
+  verbs: ["list", "watch"]
 - apiGroups: ["*"]
   resources: ["deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "replicationcontrollers"]
   # Required to retrieve the owner references used by the seccomp beyla.


### PR DESCRIPTION
The unprivileged Kubernetes example is missing the 'watch services' permission which is causing the following error to appear in the logs of all pods:

`E0903 10:21:26.617356 2510180 reflector.go:147] k8s.io/client-go/informers/factory.go:159: Failed to watch *v1.Service: unknown (get services)`

This PR adds the missing permission to the Cluster Role.