### PR TITLE
Helm chart: allow unprivileged deployment of Beyla

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.3.0
-appVersion: 1.7.0
+version: 1.4.0
+appVersion: 1.8.0
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -24,7 +24,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 |-----|------|---------|-------------|
 | affinity | object | `{}` | used for scheduling of pods based on affinity rules |
 | config.create | bool | `true` | set to true, to use the below default configurations |
-| config.data | object | `{"attributes":{"kubernetes":{"enable":true}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
+| config.data | object | `{"attributes":{"kubernetes":{"enable":true},"select":{"beyla_network_flow_bytes":{"include":["k8s.src.owner.type","k8s.dst.owner.type","direction"]}}},"filter":{"network":{"k8s_dst_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"},"k8s_src_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"}}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
 | config.name | string | `""` |  |
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` | Determines how DNS resolution is handled for that pod. If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Beyla requires `hostNetwork` access, causing cluster service DNS resolution to fail. It is recommended not to change this if Beyla sends traces and metrics to Grafana components via k8s service. |
 | env | object | `{}` | extra environment variables |
@@ -49,7 +49,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | rbac.create | bool | `true` | Whether to create RBAC resources for Belya |
 | rbac.extraClusterRoleRules | list | `[]` | Extra custer roles to be created for Belya |
 | resources | object | `{}` |  |
-| securityContext.privileged | bool | `true` |  |
+| securityContext.privileged | bool | `true` | For an unprivileged / less privileged setup, use privileged: false and uncomment the required capabilities in the values file. |
 | service.annotations | object | `{}` | Service annotations. |
 | service.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
 | service.clusterIP | string | `""` | cluster IP |

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -29,6 +29,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` | Determines how DNS resolution is handled for that pod. If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Beyla requires `hostNetwork` access, causing cluster service DNS resolution to fail. It is recommended not to change this if Beyla sends traces and metrics to Grafana components via k8s service. |
 | env | object | `{}` | extra environment variables |
 | envValueFrom | object | `{}` | extra environment variables to be set from resources such as k8s configMaps/secrets |
+| extraCapabilities | list | `[]` | Extra capabilities for unprivileged / less privileged setup. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname. |
 | global.image.pullSecrets | list | `[]` | Optional set of global image pull secrets. |
 | global.image.registry | string | `""` | Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...) |
@@ -46,10 +47,11 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | podSecurityContext | object | `{}` |  |
 | preset | string | `"application"` | Preconfigures some default properties for network or application observability. Accepted values are "network" or "application". |
 | priorityClassName | string | `""` |  |
+| privileged | bool | `true` | If set to false, deploys an unprivileged / less privileged setup. |
 | rbac.create | bool | `true` | Whether to create RBAC resources for Belya |
 | rbac.extraClusterRoleRules | list | `[]` | Extra custer roles to be created for Belya |
 | resources | object | `{}` |  |
-| securityContext.privileged | bool | `true` | For an unprivileged / less privileged setup, use privileged: false and uncomment the required capabilities in the values file. |
+| securityContext | object | `{"privileged":true}` | Security context for privileged setup. |
 | service.annotations | object | `{}` | Service annotations. |
 | service.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
 | service.clusterIP | string | `""` | cluster IP |

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -25,7 +25,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if ne .Values.securityContext.privileged }}
+        {{- if not (.Values.securityContext.privileged) }}
         container.apparmor.security.beta.kubernetes.io/beyla: "unconfined"
         {{- end }}
       labels:
@@ -45,7 +45,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- if ne .Values.securityContext.privileged }}
+      {{- if not (.Values.securityContext.privileged) }}
       initContainers:
         - name: mount-bpf-fs
           image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "beyla.imageId" . }}
@@ -89,7 +89,7 @@ spec:
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"
-          {{- if ne .Values.securityContext.privileged }}
+          {{- if not (.Values.securityContext.privileged) }}
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -111,7 +111,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/beyla/config
               name: beyla-config
-          {{- if ne .Values.securityContext.privileged }}
+          {{- if not (.Values.securityContext.privileged) }}
             - name: bpffs
               mountPath: /sys/fs/bpf
               mountPropagation: HostToContainer
@@ -140,7 +140,7 @@ spec:
         - name: beyla-config
           configMap:
             name: {{ default (include "beyla.fullname" .) .Values.config.name }}
-      {{- if ne .Values.securityContext.privileged }}
+      {{- if not (.Values.securityContext.privileged) }}
         - name: bpffs
           hostPath:
             path: /sys/fs/bpf

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -25,7 +25,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if not (.Values.securityContext.privileged) }}
+        {{- if not (.Values.privileged) }}
         container.apparmor.security.beta.kubernetes.io/beyla: "unconfined"
         {{- end }}
       labels:
@@ -45,7 +45,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- if not (.Values.securityContext.privileged) }}
+      {{- if not (.Values.privileged) }}
       initContainers:
         - name: mount-bpf-fs
           image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "beyla.imageId" . }}
@@ -74,9 +74,27 @@ spec:
         - name: beyla
           image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "beyla.imageId" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
           securityContext:
+          {{- if .Values.privileged }}
+          {{- with .Values.securityContext }}
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - BPF
+                - SYS_PTRACE
+                - NET_RAW
+                - CHECKPOINT_RESTORE
+                - DAC_READ_SEARCH
+                - PERFMON
+              {{- with .Values.extraCapabilities }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              drop:
+                - ALL
           {{- end }}
           ports:
           - name: {{ .Values.service.portName }}
@@ -89,7 +107,7 @@ spec:
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"
-          {{- if not (.Values.securityContext.privileged) }}
+          {{- if not (.Values.privileged) }}
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -111,7 +129,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/beyla/config
               name: beyla-config
-          {{- if not (.Values.securityContext.privileged) }}
+          {{- if not (.Values.privileged) }}
             - name: bpffs
               mountPath: /sys/fs/bpf
               mountPropagation: HostToContainer
@@ -140,7 +158,7 @@ spec:
         - name: beyla-config
           configMap:
             name: {{ default (include "beyla.fullname" .) .Values.config.name }}
-      {{- if not (.Values.securityContext.privileged) }}
+      {{- if not (.Values.privileged) }}
         - name: bpffs
           hostPath:
             path: /sys/fs/bpf

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -25,6 +25,9 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if ne .Values.securityContext.privileged }}
+        container.apparmor.security.beta.kubernetes.io/beyla: "unconfined"
+        {{- end }}
       labels:
         {{- include "beyla.labels" . | nindent 8 }}
         app.kubernetes.io/component: workload
@@ -41,6 +44,31 @@ spec:
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if ne .Values.securityContext.privileged }}
+      initContainers:
+        - name: mount-bpf-fs
+          image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "beyla.imageId" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - 'mkdir -p /sys/fs/bpf/$BEYLA_BPF_FS_PATH && mount -t bpf bpf /sys/fs/bpf/$BEYLA_BPF_FS_PATH'
+          command:
+          - /bin/bash
+          - -c
+          - --
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: bpffs
+            mountPath: /sys/fs/bpf
+            mountPropagation: Bidirectional
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: BEYLA_BPF_FS_PATH
+              value: beyla-$(KUBE_NAMESPACE)
       {{- end }}
       containers:
         - name: beyla
@@ -61,6 +89,16 @@ spec:
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"
+          {{- if ne .Values.securityContext.privileged }}
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: BEYLA_BPF_FS_PATH
+              value: beyla-$(KUBE_NAMESPACE)
+            - name: BEYLA_BPF_FS_BASE_DIR
+              value: /sys/fs/bpf
+          {{- end }}
           {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: "{{ $value }}"
@@ -73,6 +111,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/beyla/config
               name: beyla-config
+          {{- if ne .Values.securityContext.privileged }}
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+              mountPropagation: HostToContainer
+          {{- end }}
       {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.global.image.pullSecrets }}
@@ -97,3 +140,8 @@ spec:
         - name: beyla-config
           configMap:
             name: {{ default (include "beyla.fullname" .) .Values.config.name }}
+      {{- if ne .Values.securityContext.privileged }}
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+      {{- end }}

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -59,7 +59,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # -- For an unprivileged / less privileged setup, use privileged: false and uncomment the settings below
+  # -- For an unprivileged / less privileged setup, use privileged: false and uncomment the required capabilities in the values file.
   privileged: true
   # runAsUser: 0
   # readOnlyRootFilesystem: true

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -58,23 +58,23 @@ serviceAccount:
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- If set to false, deploys an unprivileged / less privileged setup.
+privileged: true
+
+# -- Extra capabilities for unprivileged / less privileged setup.
+extraCapabilities: []
+  #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
+  #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+
+# -- Security context for privileged setup.
 securityContext:
-  # -- For an unprivileged / less privileged setup, use privileged: false and uncomment the required capabilities in the values file.
   privileged: true
-  # runAsUser: 0
-  # readOnlyRootFilesystem: true
   # capabilities:
-  #   add:
-  #     - BPF                 # <-- Important. Required for most eBPF probes to function correctly.
-  #     - SYS_PTRACE          # <-- Important. Allows Beyla to access the container namespaces and inspect executables.
-  #     - NET_RAW             # <-- Important. Allows Beyla to use socket filters for http requests.
-  #     - CHECKPOINT_RESTORE  # <-- Important. Allows Beyla to open ELF files.
-  #     - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
-  #     - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
-  #     #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
-  #     #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
   #   drop:
-  #     - ALL
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 priorityClassName: ""
   # system-node-critical

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -59,13 +59,22 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  # -- For an unprivileged / less privileged setup, use privileged: false and uncomment the settings below
   privileged: true
-  # capabilities:
-  #   drop:
-  #   - ALL
+  # runAsUser: 0
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  # capabilities:
+  #   add:
+  #     - BPF                 # <-- Important. Required for most eBPF probes to function correctly.
+  #     - SYS_PTRACE          # <-- Important. Allows Beyla to access the container namespaces and inspect executables.
+  #     - NET_RAW             # <-- Important. Allows Beyla to use socket filters for http requests.
+  #     - CHECKPOINT_RESTORE  # <-- Important. Allows Beyla to open ELF files.
+  #     - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
+  #     - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
+  #     #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
+  #     #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+  #   drop:
+  #     - ALL
 
 priorityClassName: ""
   # system-node-critical

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -63,8 +63,8 @@ privileged: true
 
 # -- Extra capabilities for unprivileged / less privileged setup.
 extraCapabilities: []
-  #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
-  #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+  # - SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
+  # - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
 
 # -- Security context for privileged setup.
 securityContext:


### PR DESCRIPTION
Closes #1075 

This PR adds a new property `privileged` which can be set to `false` to add the required configurations to the DaemonSet (based on the unprivileged example).

Chart version is increased to 1.4.0 and app version to 1.8.0.