### PR TITLE
Deduplicate instance ids and restore target_instance in Prometheus

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -170,6 +170,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			attr.ProcOwner:       true,
 			attr.ProcParentPid:   true,
 			attr.ProcPid:         true,
+			attr.TargetInstance:  true,
 			attr.ProcCommandLine: false,
 			attr.ProcCommandArgs: false,
 			attr.ProcExecName:    false,

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -193,7 +193,8 @@ func newProcMetricsExporter(
 
 func getProcessResourceAttrs(hostID string, procID *process.ID) []attribute.KeyValue {
 	return append(
-		getAppResourceAttrs(hostID, procID.Service),
+		getResourceAttrs(hostID, procID.Service),
+		semconv.ServiceInstanceID(string(procID.UID)),
 		attr2.ProcCommand.OTEL().String(procID.Command),
 		attr2.ProcOwner.OTEL().String(procID.User),
 		attr2.ProcParentPid.OTEL().String(strconv.Itoa(int(procID.ParentProcessID))),

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -77,7 +77,7 @@ func NewStatus(pid int32, svcID *svc.ID) *Status {
 	return &Status{ID: ID{
 		ProcessID: pid,
 		Service:   svcID,
-		UID:       svcID.UID + svc.UID("-"+strconv.Itoa(int(pid))),
+		UID:       svcID.UID.AppendUint32(uint32(pid)),
 	}}
 }
 
@@ -119,6 +119,8 @@ func PromGetters(name attr.Name) (attributes.Getter[*Status, string], bool) {
 	case attr.ProcCPUMode, attr.ProcDiskIODir, attr.ProcNetIODir:
 		// the attributes are handled explicitly by the prometheus exporter, but we need to
 		// ignore them to avoid that the default case tries to report them from service metadata
+	case attr.TargetInstance:
+		g = func(s *Status) string { return string(s.ID.UID) }
 	default:
 		g = func(s *Status) string { return s.ID.Service.Metadata[name] }
 	}

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -57,6 +57,8 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		}
 	case attr.Service:
 		getter = func(s *Span) attribute.KeyValue { return ServiceMetric(s.ServiceID.Name) }
+	case attr.ServiceInstanceID:
+		getter = func(s *Span) attribute.KeyValue { return semconv.ServiceInstanceID(string(s.ServiceID.UID)) }
 	case attr.ServiceName:
 		getter = func(s *Span) attribute.KeyValue { return semconv.ServiceName(s.ServiceID.Name) }
 	case attr.ServiceNamespace:
@@ -174,8 +176,12 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 			}
 			return ""
 		}
+	case attr.ServiceInstanceID:
+		getter = func(s *Span) string { return string(s.ServiceID.UID) }
 	// resource metadata values below. Unlike OTEL, they are included here because they
 	// belong to the metric, instead of the Resource
+	case attr.TargetInstance:
+		getter = func(s *Span) string { return string(s.ServiceID.UID) }
 	case attr.ServiceName:
 		getter = func(s *Span) string { return s.ServiceID.Name }
 	case attr.ServiceNamespace:

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -45,9 +45,6 @@ func (it InstrumentableType) String() string {
 	}
 }
 
-// UID uniquely identifies a service instance
-type UID string
-
 type idFlags uint8
 
 const (

--- a/pkg/internal/svc/uid.go
+++ b/pkg/internal/svc/uid.go
@@ -1,0 +1,43 @@
+package svc
+
+import (
+	"bytes"
+	"encoding/base32"
+	"encoding/binary"
+	"hash/fnv"
+)
+
+var encoding = base32.NewEncoding("0123456789abcdefghijklmnopqrstuv").WithPadding('w')
+
+// UID uniquely identifies a service instance.
+// When built through the Append function, it will contain a FNV64 hash string in Base32
+type UID string
+
+// NewUID creates a UID containing the argument hash as a Base32 string
+func NewUID(fromString string) UID {
+	return UID("").Append(fromString)
+}
+
+// Append returns a UID whose contents are the hash concatenating the current UID value
+// (which is already a hash) with the passed string
+func (u UID) Append(str string) UID {
+	return u.append([]byte(str))
+}
+
+// AppendUint32 returns a UID whose contents are the hash concatenating the current UID value
+// (which is already a hash) with the bytes of the passed integer
+func (u UID) AppendUint32(i uint32) UID {
+	return u.append(binary.LittleEndian.AppendUint32(nil, i))
+}
+
+func (u UID) append(content []byte) UID {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(u))
+	_, _ = hasher.Write(content)
+	buf := bytes.Buffer{}
+
+	encoder := base32.NewEncoder(encoding, &buf)
+	_, _ = encoder.Write(hasher.Sum(nil))
+
+	return UID(buf.String())
+}

--- a/pkg/internal/svc/uid_test.go
+++ b/pkg/internal/svc/uid_test.go
@@ -1,0 +1,36 @@
+package svc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUID_Append(t *testing.T) {
+	u := NewUID("test")
+	require.NotEmpty(t, string(u))
+
+	u1 := u.Append("a")
+	u2 := u.Append("a")
+	u3 := u.Append("b")
+
+	// same operations in the same order must provide exact results
+	assert.Equal(t, u1, u2)
+	// different operations must provide different results
+	assert.NotEqual(t, u1, u3)
+}
+
+func TestUID_AppendUint32(t *testing.T) {
+	u := NewUID("test")
+	require.NotEmpty(t, string(u))
+
+	u1 := u.AppendUint32(1)
+	u2 := u.AppendUint32(1)
+	u3 := u.AppendUint32(2)
+
+	// same operations in the same order must provide exact results
+	assert.Equal(t, u1, u2)
+	// different operations must provide different results
+	assert.NotEqual(t, u1, u3)
+}

--- a/pkg/internal/traces/read_decorator.go
+++ b/pkg/internal/traces/read_decorator.go
@@ -3,7 +3,6 @@ package traces
 import (
 	"context"
 	"log/slog"
-	"strconv"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mariomac/pipes/pipe"
@@ -95,7 +94,7 @@ func hostNamePIDDecorator(cfg *InstanceIDConfig) decorator {
 		for i := range spans {
 			uid, ok := uidsCache.Get(spans[i].Pid.HostPID)
 			if !ok {
-				uid = svc.UID(fullHostName + "-" + strconv.Itoa(int(spans[i].Pid.HostPID)))
+				uid = svc.NewUID(fullHostName).AppendUint32(spans[i].Pid.HostPID)
 				uidsCache.Add(spans[i].Pid.HostPID, uid)
 			}
 			spans[i].ServiceID.UID = uid

--- a/pkg/internal/traces/read_decorator_test.go
+++ b/pkg/internal/traces/read_decorator_test.go
@@ -33,16 +33,16 @@ func TestReadDecorator(t *testing.T) {
 	for _, tc := range []testCase{{
 		desc:        "dns",
 		cfg:         ReadDecorator{InstanceID: InstanceIDConfig{HostnameDNSResolution: true}},
-		expectedUID: svc.UID(dnsHostname + "-1234"),
+		expectedUID: svc.NewUID(dnsHostname).AppendUint32(1234),
 		expectedHN:  dnsHostname,
 	}, {
 		desc:        "no-dns",
-		expectedUID: svc.UID(localHostname + "-1234"),
+		expectedUID: svc.NewUID(localHostname).AppendUint32(1234),
 		expectedHN:  localHostname,
 	}, {
 		desc:        "override hostname",
 		cfg:         ReadDecorator{InstanceID: InstanceIDConfig{OverrideHostname: "foooo"}},
-		expectedUID: "foooo-1234",
+		expectedUID: svc.NewUID("foooo").AppendUint32(1234),
 		expectedHN:  "foooo",
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/grafana/beyla/pkg/kubeflags"
 )
 
@@ -115,7 +116,7 @@ func (md *metadataDecorator) appendMetadata(span *request.Span, info *kube.PodIn
 	// if the application/process was discovered and reported information
 	// before the kubernetes metadata was available
 	// (related issue: https://github.com/grafana/beyla/issues/1124)
-	span.ServiceID.UID = span.ServiceID.UID.Append(string(info.UID))
+	span.ServiceID.UID = svc.NewUID(string(info.UID))
 
 	// if, in the future, other pipeline steps modify the service metadata, we should
 	// replace the map literal by individual entry insertions

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
-	"github.com/grafana/beyla/pkg/internal/svc"
 	"github.com/grafana/beyla/pkg/kubeflags"
 )
 
@@ -116,7 +115,7 @@ func (md *metadataDecorator) appendMetadata(span *request.Span, info *kube.PodIn
 	// if the application/process was discovered and reported information
 	// before the kubernetes metadata was available
 	// (related issue: https://github.com/grafana/beyla/issues/1124)
-	span.ServiceID.UID = svc.UID(info.UID)
+	span.ServiceID.UID = span.ServiceID.UID.Append(string(info.UID))
 
 	// if, in the future, other pipeline steps modify the service metadata, we should
 	// replace the map literal by individual entry insertions

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -108,7 +108,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	assert.Equal(t, comm, process.ServiceName)
 	serviceInstance, ok := jaeger.FindIn(process.Tags, "service.instance.id")
 	require.Truef(t, ok, "service.instance.id not found in tags: %v", process.Tags)
-	assert.Regexp(t, `^beyla-\d+$`, serviceInstance.Value)
+	assert.Regexp(t, `^\w+$`, serviceInstance.Value)
 	sd = jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "rust"},

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -142,7 +142,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 
 	serviceInstance, ok := jaeger.FindIn(process.Tags, "service.instance.id")
 	require.Truef(t, ok, "service.instance.id not found in tags: %v", process.Tags)
-	assert.Regexp(t, `^beyla-\d+$`, serviceInstance.Value)
+	assert.Regexp(t, `^\w+$`, serviceInstance.Value)
 
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
@@ -252,7 +252,7 @@ func testGRPCTracesForServiceName(t *testing.T, svcName string) {
 
 	serviceInstance, ok := jaeger.FindIn(process.Tags, "service.instance.id")
 	require.Truef(t, ok, "service.instance.id not found in tags: %v", process.Tags)
-	assert.Regexp(t, `^beyla-\d+$`, serviceInstance.Value)
+	assert.Regexp(t, `^\w+$`, serviceInstance.Value)
 
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},
@@ -395,7 +395,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 
 	serviceInstance, ok := jaeger.FindIn(process.Tags, "service.instance.id")
 	require.Truef(t, ok, "service.instance.id not found in tags: %v", process.Tags)
-	assert.Regexp(t, `^beyla-\d+$`, serviceInstance.Value)
+	assert.Regexp(t, `^\w+$`, serviceInstance.Value)
 
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.library.name", Type: "string", Value: "github.com/grafana/beyla"},


### PR DESCRIPTION
Should fix https://github.com/grafana/beyla/issues/1124

This PR also changes the way instance IDs are composed, to avoid letting them grow too much. Now they are just Base32 hashes.