### PR TITLE
Fix OS capabilities

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -43,7 +43,7 @@ const (
 var DefaultConfig = Config{
 	ChannelBufferLen: 10,
 	LogLevel:         "INFO",
-	EnforceSysCaps:   true,
+	EnforceSysCaps:   false,
 	EBPF: ebpfcommon.TracerConfig{
 		BatchLength:        100,
 		BatchTimeout:       time.Second,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -107,7 +107,7 @@ network:
 		ServiceName:      "svc-name",
 		ChannelBufferLen: 33,
 		LogLevel:         "INFO",
-		EnforceSysCaps:   true,
+		EnforceSysCaps:   false,
 		Printer:          false,
 		TracePrinter:     "json",
 		EBPF: ebpfcommon.TracerConfig{

--- a/pkg/beyla/os.go
+++ b/pkg/beyla/os.go
@@ -69,6 +69,26 @@ func (e osCapabilitiesError) Error() string {
 	return sb.String()
 }
 
+func testAndSet(caps *helpers.OSCapabilities, capError *osCapabilitiesError, c helpers.OSCapability) {
+	if !caps.Has(c) {
+		capError.Set(c)
+	}
+}
+
+func checkCapabilitiesForSetOptions(config *Config, caps *helpers.OSCapabilities, capError *osCapabilitiesError) {
+	if config.Enabled(FeatureAppO11y) {
+		testAndSet(caps, capError, unix.CAP_CHECKPOINT_RESTORE)
+		testAndSet(caps, capError, unix.CAP_SYS_PTRACE)
+	}
+
+	if config.Enabled(FeatureNetO11y) {
+		// test for net raw only if we don't have net admin
+		if !caps.Has(unix.CAP_NET_ADMIN) {
+			testAndSet(caps, capError, unix.CAP_NET_RAW)
+		}
+	}
+}
+
 func CheckOSCapabilities(config *Config) error {
 	caps, err := helpers.GetCurrentProcCapabilities()
 
@@ -78,17 +98,11 @@ func CheckOSCapabilities(config *Config) error {
 
 	var capError osCapabilitiesError
 
-	testAndSet := func(c helpers.OSCapability) {
-		if !caps.Has(c) {
-			capError.Set(c)
-		}
-	}
-
 	major, minor := kernelVersion()
 
 	// below kernels 5.8 all BPF permissions were bundled under SYS_ADMIN
 	if (major == 5 && minor < 8) || (major < 5) {
-		testAndSet(unix.CAP_SYS_ADMIN)
+		testAndSet(caps, &capError, unix.CAP_SYS_ADMIN)
 
 		if capError.Empty() {
 			return nil
@@ -103,26 +117,16 @@ func CheckOSCapabilities(config *Config) error {
 	}
 
 	// core capabilities
-	testAndSet(unix.CAP_BPF)
-	testAndSet(unix.CAP_PERFMON)
-	testAndSet(unix.CAP_DAC_READ_SEARCH)
+	testAndSet(caps, &capError, unix.CAP_BPF)
+	testAndSet(caps, &capError, unix.CAP_PERFMON)
+	testAndSet(caps, &capError, unix.CAP_DAC_READ_SEARCH)
 
 	// CAP_SYS_RESOURCE is only required on kernels < 5.11
 	if (major == 5 && minor < 11) || (major < 5) {
-		testAndSet(unix.CAP_SYS_RESOURCE)
+		testAndSet(caps, &capError, unix.CAP_SYS_RESOURCE)
 	}
 
-	if config.Enabled(FeatureAppO11y) {
-		testAndSet(unix.CAP_CHECKPOINT_RESTORE)
-		testAndSet(unix.CAP_SYS_PTRACE)
-	}
-
-	if config.Enabled(FeatureNetO11y) {
-		// test for net raw only if we don't have net admin
-		if !caps.Has(unix.CAP_NET_ADMIN) {
-			testAndSet(unix.CAP_NET_RAW)
-		}
-	}
+	checkCapabilitiesForSetOptions(config, caps, &capError)
 
 	if capError.Empty() {
 		return nil

--- a/pkg/beyla/os.go
+++ b/pkg/beyla/os.go
@@ -84,12 +84,28 @@ func CheckOSCapabilities(config *Config) error {
 		}
 	}
 
+	major, minor := kernelVersion()
+
+	// below kernels 5.8 all BPF permissions were bundled under SYS_ADMIN
+	if (major == 5 && minor < 8) || (major < 5) {
+		testAndSet(unix.CAP_SYS_ADMIN)
+
+		if capError.Empty() {
+			return nil
+		}
+
+		return capError
+	}
+
+	// if sys admin is set, we have all capabilities
+	if caps.Has(unix.CAP_SYS_ADMIN) {
+		return nil
+	}
+
 	// core capabilities
 	testAndSet(unix.CAP_BPF)
 	testAndSet(unix.CAP_PERFMON)
 	testAndSet(unix.CAP_DAC_READ_SEARCH)
-
-	major, minor := kernelVersion()
 
 	// CAP_SYS_RESOURCE is only required on kernels < 5.11
 	if (major == 5 && minor < 11) || (major < 5) {
@@ -102,7 +118,10 @@ func CheckOSCapabilities(config *Config) error {
 	}
 
 	if config.Enabled(FeatureNetO11y) {
-		testAndSet(unix.CAP_NET_RAW)
+		// test for net raw only if we don't have net admin
+		if !caps.Has(unix.CAP_NET_ADMIN) {
+			testAndSet(unix.CAP_NET_RAW)
+		}
 	}
 
 	if capError.Empty() {

--- a/pkg/beyla/os_test.go
+++ b/pkg/beyla/os_test.go
@@ -105,14 +105,14 @@ type capTestData struct {
 }
 
 var capTests = []capTestData{
-	{osCap: unix.CAP_BPF, class: capCore},
-	{osCap: unix.CAP_PERFMON, class: capCore},
-	{osCap: unix.CAP_DAC_READ_SEARCH, class: capCore},
+	{osCap: unix.CAP_BPF, class: capCore, kernMaj: 6, kernMin: 10},
+	{osCap: unix.CAP_PERFMON, class: capCore, kernMaj: 6, kernMin: 10},
+	{osCap: unix.CAP_DAC_READ_SEARCH, class: capCore, kernMaj: 6, kernMin: 10},
 	{osCap: unix.CAP_SYS_RESOURCE, class: capCore, kernMaj: 5, kernMin: 10},
-	{osCap: unix.CAP_SYS_RESOURCE, class: capCore, kernMaj: 4, kernMin: 11},
-	{osCap: unix.CAP_CHECKPOINT_RESTORE, class: capApp},
-	{osCap: unix.CAP_SYS_PTRACE, class: capApp},
-	{osCap: unix.CAP_NET_RAW, class: capNet},
+	{osCap: unix.CAP_SYS_ADMIN, class: capCore, kernMaj: 4, kernMin: 11},
+	{osCap: unix.CAP_CHECKPOINT_RESTORE, class: capApp, kernMaj: 6, kernMin: 10},
+	{osCap: unix.CAP_SYS_PTRACE, class: capApp, kernMaj: 6, kernMin: 10},
+	{osCap: unix.CAP_NET_RAW, class: capNet, kernMaj: 6, kernMin: 10},
 }
 
 func TestCheckOSCapabilities(t *testing.T) {


### PR DESCRIPTION
There were few bugs in the OS capability checking which are being fixed with this PR:

1. If SYS_ADMIN is present, it effectively means all capabilities.
2. If we have kernel older than 5.8, SYS_ADMIN is a must, the others weren't split off yet.
3. If we have NET_ADMIN we also have NET_RAW, so we can relax that check.

Given that I failed to run Beyla with SYS_ADMIN, I don't think we should enforce the capabilities, we should only warn. This is very hard to get right 100% and it shouldn't be a hard check. 