### PR TITLE
Add target for ARM integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -1,0 +1,43 @@
+name: Pull request integration tests ARM
+
+on:
+  push:
+    branches: [ 'main', 'release-*' ]
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+  test:
+    name: test
+    runs-on: github-hosted-ubuntu-arm64-large
+    strategy:
+      matrix:
+        go: [ '1.23' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Clean up disk space
+        run: |
+          docker system prune -af
+          docker volume prune -f
+      - name: Run integration tests
+        run: make integration-test-arm
+        timeout-minutes: 60
+      - name: Upload integration test logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test Logs
+          path: |
+            testoutput/*.log
+            testoutput/kind
+      - name: Report coverage
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: ./testoutput/itest-covdata.txt
+          flags: integration-test

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,12 @@ run-integration-test-vm:
 	@echo "### Running integration tests"
 	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration -run "^TestMultiProcess"
 
+.PHONY: run-integration-test-arm
+run-integration-test-arm:
+	@echo "### Running integration tests"
+	go clean -testcache
+	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration -run "^TestMultiProcess"
+
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test
 	$(MAKE) run-integration-test || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
@@ -257,6 +263,12 @@ integration-test: prereqs prepare-integration-test
 .PHONY: integration-test-k8s
 integration-test-k8s: prereqs prepare-integration-test
 	$(MAKE) run-integration-test-k8s || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
+	$(MAKE) itest-coverage-data
+	$(MAKE) cleanup-integration-test
+
+.PHONY: integration-test-arm
+integration-test-arm: prereqs prepare-integration-test
+	$(MAKE) run-integration-test-arm || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)
 	$(MAKE) itest-coverage-data
 	$(MAKE) cleanup-integration-test
 

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -50,12 +50,12 @@ services:
       LOG_LEVEL: DEBUG
 
   rtestserver:
-    image: ghcr.io/grafana/beyla-test/greeting-rust/0.0.2
+    image: ghcr.io/grafana/beyla-test/greeting-rust/0.0.4
     ports:
       - 8091:8090
 
   rtestserverssl:
-    image: ghcr.io/grafana/beyla-test/greeting-rust-ssl/0.0.1
+    image: ghcr.io/grafana/beyla-test/greeting-rust-ssl/0.0.2
     ports:
       - 8491:8490
     environment:
@@ -100,17 +100,17 @@ services:
       - 3031:3030
 
   utestserver:
-    image: ghcr.io/grafana/beyla-test/greeting-rails/0.0.1
+    image: ghcr.io/grafana/beyla-test/greeting-rails/0.0.2
     ports:
       - 3041:3040
 
   utestserverssl:
-    image: ghcr.io/grafana/beyla-test/greeting-rails-ssl/0.0.1
+    image: ghcr.io/grafana/beyla-test/greeting-rails-ssl/0.0.2
     ports:
       - 3044:3043
         
   jtestserver:
-    image: ghcr.io/grafana/beyla-test/greeting-java-jar/0.0.3
+    image: ghcr.io/grafana/beyla-test/greeting-java-jar/0.0.4
     ports:
       - "8086:8085"
 


### PR DESCRIPTION
This adds a new github workflow to run the MultiProc tests on the arm runner, as a subset of the integration tests. It also updates a few image versions to point to newly built multi-arch versions (both x64 and arm64).

Resolves: #591 