### PR TITLE
Downgrade release 1.8 branch to Go 1.22 in go.mod

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-ARG GOVERSION="1.23.0"
+ARG GOVERSION="1.23.1"
 
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla
 
-go 1.23
+go 1.22
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396


### PR DESCRIPTION
This is required to integrate Beyla 1.8 with Alloy.

The rest of the build and test pipeline still uses Go 1.23