### PR TITLE
Avoid that a Pod update removes the container metadata

### DIFF
--- a/pkg/internal/transform/kube/db.go
+++ b/pkg/internal/transform/kube/db.go
@@ -198,14 +198,6 @@ func (id *Database) addPods(pod *kube.PodInfo) {
 func (id *Database) deletePods(pod *kube.PodInfo) {
 	for _, ip := range pod.IPInfo.IPs {
 		delete(id.podsByIP, ip)
-		for _, cid := range pod.ContainerIDs {
-			cnt, ok := id.containerIDs[cid]
-			delete(id.containerIDs, cid)
-			if ok {
-				delete(id.namespaces, cnt.PIDNamespace)
-				delete(id.fetchedPodsCache, cnt.PIDNamespace)
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/beyla/issues/1152

After a Pod update event, the container metadata was removed but never restored, so the PIDs<->Pod information was lost.
