### PR TITLE
Add src_name and dst_name for attribute filtering

### DIFF
--- a/pkg/internal/filter/attribute.go
+++ b/pkg/internal/filter/attribute.go
@@ -57,7 +57,7 @@ func newFilter[T any](config AttributeFamilyConfig, getters attributes.NamedGett
 	for attrStr, match := range config {
 		normalAttr, ok := attrProm2Normal[attr.Name(attrStr).Prom()]
 		if !ok {
-			return nil, fmt.Errorf("attribute filter: unknown attribute name %q", attrStr)
+			return nil, fmt.Errorf("attribute filter: unknown attribute name %q, available: %v", attrStr, attrProm2Normal)
 		}
 		matcher, err := buildMatcher(getters, normalAttr, &match)
 		if err != nil {

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -34,8 +34,12 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		getter = func(s *Span) attribute.KeyValue { return semconv.HTTPRoute(s.Route) }
 	case attr.HTTPUrlPath:
 		getter = func(s *Span) attribute.KeyValue { return HTTPUrlPath(s.Path) }
+	case attr.SrcName:
+		fallthrough
 	case attr.ClientAddr:
 		getter = func(s *Span) attribute.KeyValue { return ClientAddr(SpanPeer(s)) }
+	case attr.DstName:
+		fallthrough
 	case attr.ServerAddr:
 		getter = func(s *Span) attribute.KeyValue { return ServerAddr(SpanHost(s)) }
 	case attr.ServerPort:
@@ -124,8 +128,12 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 		getter = func(s *Span) string { return s.Route }
 	case attr.HTTPUrlPath:
 		getter = func(s *Span) string { return s.Path }
+	case attr.SrcName:
+		fallthrough
 	case attr.ClientAddr:
 		getter = SpanPeer
+	case attr.DstName:
+		fallthrough
 	case attr.ServerAddr:
 		getter = SpanHost
 	case attr.ServerPort:


### PR DESCRIPTION
This will allow application attributes to filter on src_name and dst_name record attributes just like net o11y.