### PR TITLE
Fixing Docker Generator build action

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -18,8 +18,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -27,7 +35,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
 


### PR DESCRIPTION
The published generator image has become outdated and we can't update it because, by some reason, docker-build action does not support multiplatform by default ([logs](https://github.com/grafana/beyla/actions/runs/10828123908/job/30042775295)).