### PR TITLE
Allow filtering by client/server in application traces

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -269,6 +269,25 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		ProcessMemoryVirtual.Section:  {SubGroups: []*AttrReportGroup{&processAttributes}},
 		ProcessDiskIO.Section:         {SubGroups: []*AttrReportGroup{&processAttributes}},
 		ProcessNetIO.Section:          {SubGroups: []*AttrReportGroup{&processAttributes}},
+		// span and service graph metrics don't yet implement attribute selection,
+		// but their values can still be filtered, so we list them here just to
+		// make the filter recognize its attributes
+		// TODO: when service graph and spam metrics implement attribute selection, replace this section by proper metric names
+		"---- temporary placeholder for span and service graph metrics ----": {
+			Attributes: map[attr.Name]Default{
+				attr.Client:            false,
+				attr.ClientNamespace:   false,
+				attr.Server:            false,
+				attr.ServerNamespace:   false,
+				attr.Source:            false,
+				attr.Service:           false,
+				attr.ServiceInstanceID: false,
+				attr.ServiceNamespace:  false,
+				attr.SpanKind:          false,
+				attr.SpanName:          false,
+				attr.StatusCode:        false,
+			},
+		},
 	}
 }
 

--- a/pkg/internal/ebpf/ktracer/ktracer.go
+++ b/pkg/internal/ebpf/ktracer/ktracer.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ktracer
 
 import (

--- a/pkg/internal/ebpf/ktracer/ktracer_notlinux.go
+++ b/pkg/internal/ebpf/ktracer/ktracer_notlinux.go
@@ -1,0 +1,40 @@
+//go:build !linux
+
+// this file is emptied on purpose to allow Beyla compiling in non-linux environments
+
+package ktracer
+
+import (
+	"context"
+	"io"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/grafana/beyla/pkg/beyla"
+	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
+	"github.com/grafana/beyla/pkg/internal/exec"
+	"github.com/grafana/beyla/pkg/internal/goexec"
+	"github.com/grafana/beyla/pkg/internal/imetrics"
+	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
+)
+
+type Tracer struct{}
+
+func New(_ *beyla.Config, _ imetrics.Reporter) *Tracer                         { return nil }
+func (p *Tracer) AllowPID(_, _ uint32, _ *svc.ID)                              {}
+func (p *Tracer) BlockPID(_, _ uint32)                                         {}
+func (p *Tracer) Load() (*ebpf.CollectionSpec, error)                          { return nil, nil }
+func (p *Tracer) BpfObjects() any                                              { return nil }
+func (p *Tracer) AddCloser(_ ...io.Closer)                                     {}
+func (p *Tracer) GoProbes() map[string][]ebpfcommon.FunctionPrograms           { return nil }
+func (p *Tracer) KProbes() map[string]ebpfcommon.FunctionPrograms              { return nil }
+func (p *Tracer) UProbes() map[string]map[string]ebpfcommon.FunctionPrograms   { return nil }
+func (p *Tracer) Tracepoints() map[string]ebpfcommon.FunctionPrograms          { return nil }
+func (p *Tracer) SocketFilters() []*ebpf.Program                               { return nil }
+func (p *Tracer) RecordInstrumentedLib(_ uint64)                               {}
+func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool                         { return false }
+func (p *Tracer) Run(_ context.Context, _ chan<- []request.Span)               {}
+func (p *Tracer) Constants(_ *exec.FileInfo, _ *goexec.Offsets) map[string]any { return nil }
+func (p *Tracer) SetupTC()                                                     {}
+func (p *Tracer) SetupTailCalls()                                              {}

--- a/pkg/internal/ebpf/ktracer/ktracer_test.go
+++ b/pkg/internal/ebpf/ktracer/ktracer_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ktracer
 
 import (

--- a/pkg/internal/filter/attribute_test.go
+++ b/pkg/internal/filter/attribute_test.go
@@ -10,6 +10,7 @@ import (
 
 	attr "github.com/grafana/beyla/pkg/export/attributes/names"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
+	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/pkg/internal/testutil"
 )
 
@@ -97,4 +98,50 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestAttributeFilter_SpanMetrics(t *testing.T) {
+	// if the attributes are not existing, we should just ignore them
+	filterFunc, err := ByAttribute[*request.Span](AttributeFamilyConfig{
+		"client": MatchDefinition{NotMatch: "filtered"},
+		"server": MatchDefinition{NotMatch: "filtered"},
+	}, request.SpanPromGetters)()
+	require.NoError(t, err)
+
+	in := make(chan []*request.Span, 10)
+	defer close(in)
+	out := make(chan []*request.Span, 10)
+	go filterFunc(in, out)
+
+	// will drop filtered events
+	in <- []*request.Span{
+		{Type: request.EventTypeHTTP, PeerName: "someclient", Host: "filtered"},
+		{Type: request.EventTypeHTTPClient, PeerName: "filtered", Host: "someserver"},
+		{Type: request.EventTypeHTTPClient, PeerName: "aserver", Host: "aclient"},
+	}
+
+	// no record will be dropped
+	in <- []*request.Span{
+		{Type: request.EventTypeHTTP, PeerName: "client", Host: "server"},
+		{Type: request.EventTypeHTTPClient, PeerName: "server", Host: "client"},
+	}
+
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*request.Span{
+		{Type: request.EventTypeHTTPClient, PeerName: "aserver", Host: "aclient"},
+	}, filtered)
+
+	filtered = testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*request.Span{
+		{Type: request.EventTypeHTTP, PeerName: "client", Host: "server"},
+		{Type: request.EventTypeHTTPClient, PeerName: "server", Host: "client"},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+
 }

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -124,9 +124,9 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 		getter = func(s *Span) string { return s.Route }
 	case attr.HTTPUrlPath:
 		getter = func(s *Span) string { return s.Path }
-	case attr.ClientAddr:
+	case attr.Client, attr.ClientAddr:
 		getter = SpanPeer
-	case attr.ServerAddr:
+	case attr.Server, attr.ServerAddr:
 		getter = SpanHost
 	case attr.ServerPort:
 		getter = func(s *Span) string { return strconv.Itoa(s.HostPort) }


### PR DESCRIPTION
Now Beyla can filter by some attributes that were exclusive for service graph and span metrics.

