### PR TITLE
Add two ports to service, daemonset and servicemonitor conditionally

### DIFF
--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -53,26 +53,32 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | resources | object | `{}` |  |
 | securityContext | object | `{"privileged":true}` | Security context for privileged setup. |
 | service.annotations | object | `{}` | Service annotations. |
-| service.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
 | service.clusterIP | string | `""` | cluster IP |
-| service.enabled | bool | `false` | whether to create a service for internal metrics |
+| service.enabled | bool | `false` | whether to create a service for metrics |
+| service.internalMetrics.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
+| service.internalMetrics.port | int | `8080` | internal metrics service port |
+| service.internalMetrics.portName | string | `"internal-metrics"` | name of the port for internal metrics. |
+| service.internalMetrics.targetPort | string | `nil` | targetPort overrides the internal metrics port. It defaults to the value of `internal_metrics.prometheus.port` from the Beyla configuration file. |
 | service.labels | object | `{}` | Service labels. |
 | service.loadBalancerClass | string | `""` | loadbalancer class name |
 | service.loadBalancerIP | string | `""` | loadbalancer IP |
 | service.loadBalancerSourceRanges | list | `[]` | source ranges for loadbalancer |
-| service.port | int | `80` | service port |
-| service.portName | string | `"metrics"` | name of the port for internal metrics. |
-| service.targetPort | int | `9090` | targetPort has to be configured based on the values of `BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT` environment variable or the value of `prometheus_export.port` from beyla configuration file. see more at https://grafana.com/docs/beyla/latest/configure/options/#internal-metrics-reporter |
+| service.metrics.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
+| service.metrics.port | int | `80` | Prometheus metrics service port |
+| service.metrics.portName | string | `"metrics"` | name of the port for Prometheus metrics. |
+| service.metrics.targetPort | string | `nil` | targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port` from the Beyla configuration file. |
 | service.type | string | `"ClusterIP"` | type of the service |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.labels | object | `{}` | ServiceAccount labels. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor | object | `{"annotations":{},"enabled":false,"endpoint":{"interval":"15s"},"jobLabel":""}` | Enable creation of ServiceMonitor for scraping of prometheus HTTP endpoint |
+| serviceMonitor | object | `{"additionalLabels":{},"annotations":{},"enabled":false,"internalMetrics":{"endpoint":{"interval":"15s"}},"jobLabel":"","metrics":{"endpoint":{"interval":"15s"}}}` | Enable creation of ServiceMonitor for scraping of prometheus HTTP endpoint |
+| serviceMonitor.additionalLabels | object | `{}` | Add custom labels to the ServiceMonitor resource |
 | serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
-| serviceMonitor.endpoint | object | `{"interval":"15s"}` | ServiceMonitor scraping endpoint. Target port and path is set based on service and prometheus_export values. For additional values, see the ServiceMonitor spec |
+| serviceMonitor.internalMetrics.endpoint | object | `{"interval":"15s"}` | ServiceMonitor internal metrics scraping endpoint. Target port and path is set based on service and `internal_metrics` values. For additional values, see the ServiceMonitor spec |
 | serviceMonitor.jobLabel | string | `""` | Prometheus job label. If empty, chart release name is used |
+| serviceMonitor.metrics.endpoint | object | `{"interval":"15s"}` | ServiceMonitor Prometheus scraping endpoint. Target port and path is set based on service and `prometheus_export` values. For additional values, see the ServiceMonitor spec |
 | tolerations | list | `[]` | Tolerations allow pods to be scheduled on nodes with specific taints |
 | updateStrategy.type | string | `"RollingUpdate"` | update strategy type |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -53,6 +53,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | resources | object | `{}` |  |
 | securityContext | object | `{"privileged":true}` | Security context for privileged setup. |
 | service.annotations | object | `{}` | Service annotations. |
+| service.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
 | service.clusterIP | string | `""` | cluster IP |
 | service.enabled | bool | `false` | whether to create a service for metrics |
 | service.internalMetrics.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
@@ -63,10 +64,9 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | service.loadBalancerClass | string | `""` | loadbalancer class name |
 | service.loadBalancerIP | string | `""` | loadbalancer IP |
 | service.loadBalancerSourceRanges | list | `[]` | source ranges for loadbalancer |
-| service.metrics.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
-| service.metrics.port | int | `80` | Prometheus metrics service port |
-| service.metrics.portName | string | `"metrics"` | name of the port for Prometheus metrics. |
-| service.metrics.targetPort | string | `nil` | targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port` from the Beyla configuration file. |
+| service.port | int | `80` | Prometheus metrics service port |
+| service.portName | string | `"metrics"` | name of the port for Prometheus metrics. |
+| service.targetPort | string | `nil` | targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port` from the Beyla configuration file. |
 | service.type | string | `"ClusterIP"` | type of the service |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -102,7 +102,7 @@ spec:
             containerPort: {{ .Values.service.metrics.targetPort | default .Values.config.data.prometheus_export.port }}
             protocol: TCP
           {{- end }}
-          {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+          {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
           - name: {{ .Values.service.internalMetrics.portName }}
             containerPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
             protocol: TCP

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -97,9 +97,16 @@ spec:
                 - ALL
           {{- end }}
           ports:
-          - name: {{ .Values.service.portName }}
-            containerPort: {{ .Values.service.targetPort }}
+          {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
+          - name: {{ .Values.service.metrics.portName }}
+            containerPort: {{ .Values.service.metrics.targetPort | default .Values.config.data.prometheus_export.port }}
             protocol: TCP
+          {{- end }}
+          {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+          - name: {{ .Values.service.internalMetrics.portName }}
+            containerPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
+            protocol: TCP
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -97,9 +97,9 @@ spec:
                 - ALL
           {{- end }}
           ports:
-          {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
-          - name: {{ .Values.service.metrics.portName }}
-            containerPort: {{ .Values.service.metrics.targetPort | default .Values.config.data.prometheus_export.port }}
+          {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+          - name: {{ .Values.service.portName }}
+            containerPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
             protocol: TCP
           {{- end }}
           {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}

--- a/charts/beyla/templates/service.yaml
+++ b/charts/beyla/templates/service.yaml
@@ -44,16 +44,30 @@ spec:
   externalTrafficPolicy: {{ . }}
   {{- end }}
   ports:
-    - name: {{ .Values.service.portName }}
-      port: {{ .Values.service.port }}
+    {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
+    - name: {{ .Values.service.metrics.portName }}
+      port: {{ .Values.service.metrics.port }}
       protocol: TCP
-      targetPort: {{ .Values.service.targetPort }}
-      {{- with .Values.service.appProtocol }}
+      targetPort: {{ .Values.service.metrics.targetPort | default .Values.config.data.prometheus_export.port }}
+      {{- with .Values.service.metrics.appProtocol }}
       appProtocol: {{ . }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
-      nodePort: {{ .Values.service.nodePort }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.metrics.nodePort))) }}
+      nodePort: {{ .Values.service.metrics.nodePort }}
       {{- end }}
+    {{- end }}
+    {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+    - name: {{ .Values.service.internalMetrics.portName }}
+      port: {{ .Values.service.internalMetrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
+      {{- with .Values.service.internalMetrics.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.internalMetrics.nodePort))) }}
+      nodePort: {{ .Values.service.internalMetrics.nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "beyla.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/beyla/templates/service.yaml
+++ b/charts/beyla/templates/service.yaml
@@ -44,16 +44,16 @@ spec:
   externalTrafficPolicy: {{ . }}
   {{- end }}
   ports:
-    {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
-    - name: {{ .Values.service.metrics.portName }}
-      port: {{ .Values.service.metrics.port }}
+    {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
       protocol: TCP
-      targetPort: {{ .Values.service.metrics.targetPort | default .Values.config.data.prometheus_export.port }}
-      {{- with .Values.service.metrics.appProtocol }}
+      targetPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
+      {{- with .Values.service.appProtocol }}
       appProtocol: {{ . }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.metrics.nodePort))) }}
-      nodePort: {{ .Values.service.metrics.nodePort }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
       {{- end }}
     {{- end }}
     {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}

--- a/charts/beyla/templates/service.yaml
+++ b/charts/beyla/templates/service.yaml
@@ -56,7 +56,7 @@ spec:
       nodePort: {{ .Values.service.metrics.nodePort }}
       {{- end }}
     {{- end }}
-    {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+    {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
     - name: {{ .Values.service.internalMetrics.portName }}
       port: {{ .Values.service.internalMetrics.port }}
       protocol: TCP

--- a/charts/beyla/templates/servicemonitor.yaml
+++ b/charts/beyla/templates/servicemonitor.yaml
@@ -25,7 +25,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
     {{- end }}
-    {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+    {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
     - port: {{ .Values.service.internalMetrics.portName }}
       path: {{ .Values.config.data.internal_metrics.prometheus.path }}
       scheme: http 

--- a/charts/beyla/templates/servicemonitor.yaml
+++ b/charts/beyla/templates/servicemonitor.yaml
@@ -17,11 +17,11 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
-    - port: {{ .Values.service.metrics.portName }}
+    {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+    - port: {{ .Values.service.portName }}
       path: {{ .Values.config.data.prometheus_export.path }}
       scheme: http 
-      {{- with .Values.serviceMonitor.metrics.endpoint }}
+      {{- with .Values.serviceMonitor.endpoint }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
     {{- end }}

--- a/charts/beyla/templates/servicemonitor.yaml
+++ b/charts/beyla/templates/servicemonitor.yaml
@@ -17,12 +17,22 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: {{ .Values.service.portName }}
+    {{- if or (.Values.service.metrics.targetPort) (.Values.config.data.prometheus_export) }}
+    - port: {{ .Values.service.metrics.portName }}
       path: {{ .Values.config.data.prometheus_export.path }}
       scheme: http 
-      {{- with .Values.serviceMonitor.endpoint }}
+      {{- with .Values.serviceMonitor.metrics.endpoint }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- end }}
+    {{- if or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics) }}
+    - port: {{ .Values.service.internalMetrics.portName }}
+      path: {{ .Values.config.data.internal_metrics.prometheus.path }}
+      scheme: http 
+      {{- with .Values.serviceMonitor.internalMetrics.endpoint }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
   jobLabel: {{ .Values.serviceMonitor.jobLabel | default (include "beyla.fullname" .) }}
   selector:
     matchLabels:

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -80,15 +80,19 @@ priorityClassName: ""
   # system-node-critical
   # system-cluster-critical
 
-## -- Expose the beyla internal metrics service to be accessed from outside the cluster (LoadBalancer service).
+## -- Expose the Beyla Prometheus and internal metrics service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 ##
 service:
-  # -- whether to create a service for internal metrics
+  # -- whether to create a service for metrics
   enabled: false
   # -- type of the service
   type: ClusterIP
+  # -- Service annotations.
+  annotations: {}
+  # -- Service labels.
+  labels: {}
   # -- cluster IP
   clusterIP: ""
   # -- loadbalancer IP
@@ -97,20 +101,26 @@ service:
   loadBalancerClass: ""
   # -- source ranges for loadbalancer
   loadBalancerSourceRanges: []
-  # -- service port
-  port: 80
-  # -- targetPort has to be configured based on the values of `BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT` environment variable
-  # or the value of `prometheus_export.port` from beyla configuration file.
-  # see more at https://grafana.com/docs/beyla/latest/configure/options/#internal-metrics-reporter
-  targetPort: 9090
-  # -- Service annotations.
-  annotations: {}
-  # -- Service labels.
-  labels: {}
-  # -- name of the port for internal metrics.
-  portName: metrics
-  # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
-  appProtocol: ""
+  metrics:
+    # -- Prometheus metrics service port
+    port: 80
+    # -- targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port`
+    # from the Beyla configuration file.
+    targetPort: null
+    # -- name of the port for Prometheus metrics.
+    portName: metrics
+    # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+  internalMetrics:
+    # -- internal metrics service port
+    port: 8080
+    # -- targetPort overrides the internal metrics port. It defaults to the value of `prometheus_export.port`
+    # from the Beyla configuration file.
+    targetPort: null
+    # -- name of the port for internal metrics.
+    portName: internal-metrics
+    # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -208,11 +218,16 @@ config:
         k8s_src_owner_name:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
     # to enable network metrics
-#    network:
-#      enable: true
+    # network:
+    #   enable: true
     prometheus_export:
       port: 9090
       path: /metrics
+    # to enable internal metrics
+    # internal_metrics:
+    #   prometheus:
+    #     port: 6060
+    #     path: /internal/metrics
 
 ## Env variables that will override configmap values
 ## For example:
@@ -240,11 +255,18 @@ serviceMonitor:
   additionalLabels: {}
   # -- ServiceMonitor annotations
   annotations: {}
-  # -- ServiceMonitor scraping endpoint.
+  metrics:
+  # -- ServiceMonitor Prometheus scraping endpoint.
   # Target port and path is set based on service and prometheus_export values.
   # For additional values, see the ServiceMonitor spec
-  endpoint:
-    interval: 15s
+    endpoint:
+      interval: 15s
+  internalMetrics:
+  # -- ServiceMonitor internal metrics scraping endpoint.
+  # Target port and path is set based on service and prometheus_export values.
+  # For additional values, see the ServiceMonitor spec
+    endpoint:
+      interval: 15s
   # -- Prometheus job label.
   # If empty, chart release name is used
   jobLabel: ""

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -101,16 +101,15 @@ service:
   loadBalancerClass: ""
   # -- source ranges for loadbalancer
   loadBalancerSourceRanges: []
-  metrics:
-    # -- Prometheus metrics service port
-    port: 80
-    # -- targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port`
-    # from the Beyla configuration file.
-    targetPort: null
-    # -- name of the port for Prometheus metrics.
-    portName: metrics
-    # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
-    appProtocol: ""
+  # -- Prometheus metrics service port
+  port: 80
+  # -- targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port`
+  # from the Beyla configuration file.
+  targetPort: null
+  # -- name of the port for Prometheus metrics.
+  portName: metrics
+  # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
   internalMetrics:
     # -- internal metrics service port
     port: 8080

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -114,7 +114,7 @@ service:
   internalMetrics:
     # -- internal metrics service port
     port: 8080
-    # -- targetPort overrides the internal metrics port. It defaults to the value of `prometheus_export.port`
+    # -- targetPort overrides the internal metrics port. It defaults to the value of `internal_metrics.prometheus.port`
     # from the Beyla configuration file.
     targetPort: null
     # -- name of the port for internal metrics.
@@ -257,13 +257,13 @@ serviceMonitor:
   annotations: {}
   metrics:
   # -- ServiceMonitor Prometheus scraping endpoint.
-  # Target port and path is set based on service and prometheus_export values.
+  # Target port and path is set based on service and `prometheus_export` values.
   # For additional values, see the ServiceMonitor spec
     endpoint:
       interval: 15s
   internalMetrics:
   # -- ServiceMonitor internal metrics scraping endpoint.
-  # Target port and path is set based on service and prometheus_export values.
+  # Target port and path is set based on service and `internal_metrics` values.
   # For additional values, see the ServiceMonitor spec
     endpoint:
       interval: 15s

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -227,7 +227,7 @@ config:
     # internal_metrics:
     #   prometheus:
     #     port: 6060
-    #     path: /internal/metrics
+    #     path: /metrics
 
 ## Env variables that will override configmap values
 ## For example:


### PR DESCRIPTION
Closes #1165 

Instead of having a Service with single port and having to choose whether that is the Prometheus metrics or the internal metrics port, this allows for having a single Service with either one or two ports. By default, for ease of use, these are using the values from the Beyla config `.Values.config.data.prometheus_export.port` and `.Values.config.data.internal_metrics.prometheus.port` but can be overridden.

In order to accommodate this change, in `values.yaml` the structure of the Service and ServiceMonitor sections were changed to have dedicated subproperties for the two ports.

The most minimal and easy way to use this change is to enable the Service (and possibly the ServiceMonitor) through the values and then set up the Beyla configuration, for example:

```yaml
service:
  enabled: true
config:
  create: true
  name: ""
  data:
    prometheus_export:
      port: 9090
      path: /metrics
    internal_metrics:
      prometheus:
        port: 6060
        path: /internal/metrics
serviceMonitor:
  enabled: true
```

This will result in both the Service and ServiceMonitor being created and using the ports/paths specified in the Beyla config. 