### PR TITLE
Support for RHEL 4.18 kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ See [Documentation](https://grafana.com/docs/beyla/) and the [tutorials](https:/
   enabled. BTF became enabled by default on most Linux distributions with kernel 5.14 or higher. 
   You can check if your kernel has BTF enabled by verifying if `/sys/kernel/btf/vmlinux` exists on your system.
   If you need to recompile your kernel to enable BTF, the configuration option `CONFIG_DEBUG_INFO_BTF=y` must be
-  set. 
-- eBPF enabled on the host
+  set.
+- Alternatively, RHEL 4.18 Linux kernels (at least build 348) are also supported, due to their heavily backported nature.
+- eBPF enabled on the host.
 - For instrumenting Go programs, they must have been compiled with at least Go 1.17. We currently
   support Go applications built with a major **Go version no earlier than 3 versions** behind the current
-  stable major release.  
+  stable major release.
 - Some level of elevated permissions to execute the instrumenter:
     - On host systems, running Beyla requires `sudo`.
     - For Kubernetes we have detailed configuration example on how to run with minimum

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [Documentation](https://grafana.com/docs/beyla/) and the [tutorials](https:/
   You can check if your kernel has BTF enabled by verifying if `/sys/kernel/btf/vmlinux` exists on your system.
   If you need to recompile your kernel to enable BTF, the configuration option `CONFIG_DEBUG_INFO_BTF=y` must be
   set.
-- Alternatively, RHEL 4.18 Linux kernels (at least build 348) are also supported, due to their heavily backported nature.
+- Beyla supports Linux distributions running RedHat Enterprise Linux 4.18 kernels build 348 and above as they have the required kernel backports. These include CentOS, AlmaLinux, and Oracle Linux.
 - eBPF enabled on the host.
 - For instrumenting Go programs, they must have been compiled with at least Go 1.17. We currently
   support Go applications built with a major **Go version no earlier than 3 versions** behind the current

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -45,6 +45,7 @@ Beyla offers the following features:
   You can check if your kernel has BTF enabled by verifying if `/sys/kernel/btf/vmlinux` exists on your system.
   If you need to recompile your kernel to enable BTF, the configuration option `CONFIG_DEBUG_INFO_BTF=y` must be
   set.
+- Alternatively, RHEL 4.18 Linux kernels (at least build 348) are also supported, due to their heavily backported nature.
 - eBPF enabled in the host.
 - For instrumenting Go programs, they must have been compiled with at least Go 1.17. We currently
   support Go applications built with a major **Go version no earlier than 3 versions** behind the current

--- a/pkg/beyla/os.go
+++ b/pkg/beyla/os.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/beyla/pkg/internal/helpers"
 )
 
-// Minimum required Kernel version: 5.8
-const minKernMaj, minKernMin = 5, 8
+// Minimum required Kernel version: 4.18
+const minKernMaj, minKernMin = 4, 18
 
 var kernelVersion = ebpfcommon.KernelVersion
 

--- a/pkg/beyla/os.go
+++ b/pkg/beyla/os.go
@@ -17,6 +17,10 @@ const minKernMaj, minKernMin = 4, 18
 
 var kernelVersion = ebpfcommon.KernelVersion
 
+func KernelVersion() (major, minor int) {
+	return kernelVersion()
+}
+
 // CheckOSSupport returns an error if the running operating system does not support
 // the minimum required Beyla features.
 func CheckOSSupport() error {

--- a/pkg/beyla/os_test.go
+++ b/pkg/beyla/os_test.go
@@ -42,8 +42,8 @@ func TestCheckOSSupport_Unsupported(t *testing.T) {
 	for _, tc := range []testCase{
 		{maj: 0, min: 0},
 		{maj: 3, min: 11},
-		{maj: 5, min: 0},
-		{maj: 5, min: 7},
+		{maj: 4, min: 0},
+		{maj: 4, min: 17},
 	} {
 		t.Run(fmt.Sprintf("%d.%d", tc.maj, tc.min), func(t *testing.T) {
 			overrideKernelVersion(tc)

--- a/pkg/internal/ebpf/instrumenter.go
+++ b/pkg/internal/ebpf/instrumenter.go
@@ -92,7 +92,11 @@ func (i *instrumenter) kprobes(p KprobesTracer) error {
 		log.Debug("going to add kprobe to function", "function", kfunc, "probes", kprobes)
 
 		if err := i.kprobe(kfunc, kprobes); err != nil {
-			return fmt.Errorf("instrumenting function %q: %w", kfunc, err)
+			if kprobes.Required {
+				return fmt.Errorf("instrumenting function %q: %w", kfunc, err)
+			}
+
+			log.Debug("error instrumenting kprobe", "function", kfunc, "error", err)
 		}
 		p.AddCloser(i.closables...)
 	}

--- a/pkg/internal/ebpf/ktracer/ktracer.go
+++ b/pkg/internal/ebpf/ktracer/ktracer.go
@@ -250,7 +250,7 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.FunctionPrograms {
 			End:      p.bpfObjects.KretprobeSysClone,
 		},
 		"sys_clone3": {
-			Required: true,
+			Required: false,
 			End:      p.bpfObjects.KretprobeSysClone,
 		},
 		"sys_exit": {

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -88,7 +88,7 @@ func TestMultiProcess(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	if kprobeTraces {
+	if kprobeTracesEnabled() {
 		t.Run("Nested traces with kprobes: rust -> java -> node -> go -> python -> rails", func(t *testing.T) {
 			testNestedHTTPTracesKProbes(t)
 		})

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -96,7 +96,7 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 	 We check that the traceID has that 16 character 0 suffix and then we
 	 use the first 16 characters for looking up by Parent span.
 	*/
-	if kprobeTraces {
+	if kprobeTracesEnabled() {
 		assert.NotEmpty(t, span.TraceID)
 		assert.Truef(t, strings.HasSuffix(span.TraceID, traceIDLookup),
 			"string %q should have suffix %q", span.TraceID, traceIDLookup)

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -84,7 +84,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	require.Len(t, res, 1)
 	parent := res[0]
 	require.NotEmpty(t, parent.TraceID)
-	if kprobeTraces {
+	if kprobeTracesEnabled() {
 		require.Equal(t, traceID, parent.TraceID)
 		// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
 		childOfPID := trace.ChildrenOf(parentID)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -11,10 +11,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/test/integration/components/docker"
 )
 
-var kprobeTraces = true // allow tests to run distributed traces tests
+func kprobeTracesEnabled() bool {
+	major, minor := beyla.KernelVersion()
+
+	return major > 5 || (major == 5 && minor >= 17)
+}
 
 func TestSuite(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
@@ -492,6 +497,11 @@ func TestSuite_OverrideServiceName(t *testing.T) {
 }
 
 func TestSuiteNodeClient(t *testing.T) {
+	if !kprobeTracesEnabled() {
+		t.Skip("distributed traces not supported")
+		return
+	}
+
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient.log"))
 	compose.Env = append(compose.Env, `BEYLA_EXECUTABLE_NAME=node`, `NODE_APP=client`)
 	require.NoError(t, err)
@@ -505,6 +515,11 @@ func TestSuiteNodeClient(t *testing.T) {
 }
 
 func TestSuiteNodeClientTLS(t *testing.T) {
+	if !kprobeTracesEnabled() {
+		t.Skip("distributed traces not supported")
+		return
+	}
+
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient-tls.log"))
 	compose.Env = append(compose.Env, `BEYLA_EXECUTABLE_NAME=node`, `NODE_APP=client_tls`)
 	require.NoError(t, err)

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -370,7 +370,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 	require.Len(t, res, 1)
 	parent := res[0]
 	require.NotEmpty(t, parent.TraceID)
-	if kprobeTraces {
+	if kprobeTracesEnabled() {
 		require.Equal(t, traceID, parent.TraceID)
 		// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
 		childOfPID := trace.ChildrenOf(parentID)


### PR DESCRIPTION
Relax the minimum supported version and tweak a few tests to allow Beyla to run on RHEL 4.8 kernel series.

From the package description:

>"This is the package which provides the Linux kernel for Red Hat Enterprise
Linux. It is based on upstream Linux at version 4.18.0 and maintains kABI
compatibility of a set of approved symbols, however it is heavily modified with
backports and fixes pulled from newer upstream Linux kernel releases. This means
this is not a 4.18.0 kernel anymore: it includes several components which come
from newer upstream linux versions, while maintaining a well tested and stable
core. Some of the components/backports that may be pulled in are: changes like
updates to the core kernel (eg.: scheduler, cgroups, memory management, security
fixes and features), updates to block layer, supported filesystems, major driver
updates for supported hardware in Red Hat Enterprise Linux, enhancements for
enterprise customers, etc."

([source](https://oraclelinux.pkgs.org/8/ol8-baseos-latest-x86_64/kernel-4.18.0-240.el8.x86_64.rpm.html))

These are the kernels whose version is analogous  to **4.18.0-xxx.el8** and they feature the functionality required by Beyla, included but not limited to:
 - BTF support
 - BPF ring buffers

Early RHEL 4.18 kernels (such as 4.18.0-240.el8) do not yet feature BPF ring buffers and are not supported.
These kernels *do not* support `BEYLA_BPF_TRACK_REQUEST_HEADERS=1`.

Tested on:
 - CentOS 8 (4.18.0-348.7.1.el8_5.x86_64)
 - AlmaLinux 8 (4.18.0-553.16.1.el8_10.x86_64)

Resolves #1146 
