### PR TITLE
Fix clang-format-check workflow file

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check Clang Format
         run: |
           # Check for modified C/C++ files
-          files=$(git diff --name-only origin/main...HEAD | grep -E '\.(c|cpp|h)$')
+          files=$(git diff --name-only origin/main...HEAD | grep -E '\.(c|cpp|h)$' || true)
           if [ -z "$files" ]; then
             echo "No C/C++ files modified."
             exit 0


### PR DESCRIPTION
When there were no modified files, `grep` was returning 1 rather than 0, causing the workflow to fail.

I tested this on a separate draft PR with the following scenarios, and it appears to work:
 - no modified files
 - modified non .c files
 - modified .c files (format compliant)
 - modified .c files (non-compilant)