### PR TITLE
Add clang-tidy make target

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -26,11 +26,5 @@ jobs:
 
       - name: Check Clang Tidy
         run: |
-          cd bpf
-          clang-tidy-20 *.c *.h | tee clang-tidy-output.txt
-
-          if [ $? -ne 0 ] || grep -q "warning:" clang-tidy-output.txt; then
-            echo "clang-tidy found warnings or errors."
-            exit 1
-          fi
+          CLANG_TIDY=clang-tidy-20 make clang-tidy
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ DRONE ?= drone
 CLANG ?= clang
 CFLAGS := -O2 -g -Wall -Werror $(CFLAGS)
 
+CLANG_TIDY ?= clang-tidy
+
 # regular expressions for excluded file patterns
 EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/pingserver/)|(/grafana/beyla/test/)|(integration/components)|(/grafana/beyla/docs/)|(/grafana/beyla/configs/)|(/grafana/beyla/examples/)"
 
@@ -355,3 +357,7 @@ clean-testoutput:
 .PHONY: check-ebpf-integrity
 check-ebpf-integrity: docker-generate
 	git diff --name-status --exit-code || (echo "Run make docker-generate locally and commit the code changes" && false)
+
+.PHONY: clang-tidy
+clang-tidy:
+	cd bpf && $(CLANG_TIDY) *.c *.h

--- a/bpf/.clang-tidy
+++ b/bpf/.clang-tidy
@@ -18,7 +18,7 @@ Checks:
   - '-readability-function-cognitive-complexity'
   - '-readability-magic-numbers'
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none
 ExtraArgs: ['--target=bpf', '-Iheaders', '-D__TARGET_ARCH_x86', '-DBPF_DEBUG', '-DBPF_TRACEPARENT']


### PR DESCRIPTION
- add a new `clang-tidy` make target for convenience (which can then be referenced in the README - separate PR)
- instead of filtering for warnings to error out, simply turn warnings into errors