### PR TITLE
Add workflow for checking git-lfs files

### DIFF
--- a/.github/workflows/git-lfs-check.yml
+++ b/.github/workflows/git-lfs-check.yml
@@ -1,0 +1,40 @@
+name: Check git-lfs files
+
+on:
+  push:
+    branches: [ 'main', 'release-*' ]
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+  git-lfs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Check git-lfs files
+        run: |
+
+          files=$(git diff --name-only origin/main...HEAD | grep '\.o$' || true)
+          if [ -z "$files" ]; then
+            echo "No .o files modified"
+            exit 0
+          fi
+
+          for file in $files; do
+            contents=$(git cat-file -p :$file)
+
+            # Check if the file is binary or an LFS pointer
+            if [[ $contents == *"version https://git-lfs.github.com/spec/v1"* ]]; then
+              echo "The file '$file' is correctly tracked by LFS."
+            elif [[ ! $contents =~ ^[[:print:]]*$ ]]; then
+              echo "Error: The file '$file' is a binary file and should not be committed directly."
+              exit 1
+            fi
+          done
+


### PR DESCRIPTION
Adds a check that prevents files that should have been tracked by git-lfs to be directly committed to the git repository.

Tested for failure: https://github.com/grafana/beyla/actions/runs/10999538512/job/30539903906
Tested for success: https://github.com/grafana/beyla/actions/runs/10999512344/job/30539820365