### PR TITLE
Add metrics to measure latency of k8s informer

### DIFF
--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -138,7 +138,7 @@ func setupKubernetes(ctx context.Context, ctxInfo *global.ContextInfo) {
 		return
 	}
 
-	if ctxInfo.AppO11y.K8sDatabase, err = kube.StartDatabase(informer); err != nil {
+	if ctxInfo.AppO11y.K8sDatabase, err = kube.StartDatabase(informer, ctxInfo.Metrics); err != nil {
 		slog.Error("can't setup Kubernetes database. Your traces won't be decorated with Kubernetes metadata",
 			"error", err)
 		ctxInfo.K8sInformer.ForceDisable()

--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -68,7 +68,7 @@ func (pf *ProcessFinder) Start() (<-chan *ebpf.Instrumentable, <-chan *ebpf.Inst
 	gb := pipe.NewBuilder(&nodesMap{}, pipe.ChannelBufferLen(pf.cfg.ChannelBufferLen))
 	pipe.AddStart(gb, processWatcher, ProcessWatcherFunc(pf.ctx, pf.cfg))
 	pipe.AddMiddleProvider(gb, ptrWatcherKubeEnricher,
-		WatcherKubeEnricherProvider(pf.ctx, pf.ctxInfo.K8sInformer))
+		WatcherKubeEnricherProvider(pf.ctx, pf.ctxInfo.K8sInformer, pf.ctxInfo.Metrics))
 	pipe.AddMiddleProvider(gb, criteriaMatcher, CriteriaMatcherProvider(pf.cfg))
 	pipe.AddMiddleProvider(gb, execTyper, ExecTyperProvider(pf.cfg, pf.ctxInfo.Metrics))
 	pipe.AddMiddleProvider(gb, containerDBUpdater,

--- a/pkg/internal/discover/watcher_kube.go
+++ b/pkg/internal/discover/watcher_kube.go
@@ -94,12 +94,15 @@ func (wk *watcherKubeEnricher) init() error {
 	if err := wk.informer.AddPodEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kube.PodInfo)
-			latency := time.Since(pod.CreationTimestamp.Time).Seconds()
+			d := time.Since(pod.CreationTimestamp.Time)
 			wk.podsInfoCh <- Event[*kube.PodInfo]{Type: EventCreated, Obj: obj.(*kube.PodInfo)}
-			wk.m.InformerPodAddDuration(latency)
+			wk.m.InformerAddDuration("pod", d)
 		},
 		UpdateFunc: func(_, newObj interface{}) {
+			pod := newObj.(*kube.PodInfo)
+			d := time.Since(pod.CreationTimestamp.Time)
 			wk.podsInfoCh <- Event[*kube.PodInfo]{Type: EventCreated, Obj: newObj.(*kube.PodInfo)}
+			wk.m.InformerUpdateDuration("pod", d)
 		},
 		DeleteFunc: func(obj interface{}) {
 			wk.podsInfoCh <- Event[*kube.PodInfo]{Type: EventDeleted, Obj: obj.(*kube.PodInfo)}
@@ -112,10 +115,16 @@ func (wk *watcherKubeEnricher) init() error {
 	wk.rsInfoCh = make(chan Event[*kube.ReplicaSetInfo], 10)
 	if err := wk.informer.AddReplicaSetEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
+			rs := obj.(*kube.ReplicaSetInfo)
+			d := time.Since(rs.CreationTimestamp.Time)
 			wk.rsInfoCh <- Event[*kube.ReplicaSetInfo]{Type: EventCreated, Obj: obj.(*kube.ReplicaSetInfo)}
+			wk.m.InformerAddDuration("replicaset", d)
 		},
 		UpdateFunc: func(_, newObj interface{}) {
+			rs := newObj.(*kube.ReplicaSetInfo)
+			d := time.Since(rs.CreationTimestamp.Time)
 			wk.rsInfoCh <- Event[*kube.ReplicaSetInfo]{Type: EventCreated, Obj: newObj.(*kube.ReplicaSetInfo)}
+			wk.m.InformerUpdateDuration("replicaset", d)
 		},
 		DeleteFunc: func(obj interface{}) {
 			wk.rsInfoCh <- Event[*kube.ReplicaSetInfo]{Type: EventDeleted, Obj: obj.(*kube.ReplicaSetInfo)}

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -3,6 +3,7 @@ package imetrics
 
 import (
 	"context"
+	"time"
 )
 
 // Config options for the different metrics exporters
@@ -32,20 +33,23 @@ type Reporter interface {
 	InstrumentProcess(processName string)
 	// UninstrumentProcess is invoked every time a process is removed from the instrumented processed
 	UninstrumentProcess(processName string)
-	// InformerPodAddDuration is invoked every time a pod is added to the informer
-	InformerPodAddDuration(d float64)
+	// InformerAddDuration is invoked every time a kubernetes object is added to the informer
+	InformerAddDuration(kind string, d time.Duration)
+	// InformerUpdateDuration is invoked every time a kubernetes object is updated in the informer
+	InformerUpdateDuration(kind string, d time.Duration)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
 type NoopReporter struct{}
 
-func (n NoopReporter) Start(_ context.Context)       {}
-func (n NoopReporter) TracerFlush(_ int)             {}
-func (n NoopReporter) OTELMetricExport(_ int)        {}
-func (n NoopReporter) OTELMetricExportError(_ error) {}
-func (n NoopReporter) OTELTraceExport(_ int)         {}
-func (n NoopReporter) OTELTraceExportError(_ error)  {}
-func (n NoopReporter) PrometheusRequest(_, _ string) {}
-func (n NoopReporter) InstrumentProcess(_ string)    {}
-func (n NoopReporter) UninstrumentProcess(_ string)  {}
-func (n NoopReporter) InformerPodAddDuration(_ int)  {}
+func (n NoopReporter) Start(_ context.Context)                          {}
+func (n NoopReporter) TracerFlush(_ int)                                {}
+func (n NoopReporter) OTELMetricExport(_ int)                           {}
+func (n NoopReporter) OTELMetricExportError(_ error)                    {}
+func (n NoopReporter) OTELTraceExport(_ int)                            {}
+func (n NoopReporter) OTELTraceExportError(_ error)                     {}
+func (n NoopReporter) PrometheusRequest(_, _ string)                    {}
+func (n NoopReporter) InstrumentProcess(_ string)                       {}
+func (n NoopReporter) UninstrumentProcess(_ string)                     {}
+func (n NoopReporter) InformerAddDuration(_ string, _ time.Duration)    {}
+func (n NoopReporter) InformerUpdateDuration(_ string, _ time.Duration) {}

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -32,6 +32,8 @@ type Reporter interface {
 	InstrumentProcess(processName string)
 	// UninstrumentProcess is invoked every time a process is removed from the instrumented processed
 	UninstrumentProcess(processName string)
+	// InformerPodAddDuration is invoked every time a pod is added to the informer
+	InformerPodAddDuration(d float64)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
@@ -46,3 +48,4 @@ func (n NoopReporter) OTELTraceExportError(_ error)  {}
 func (n NoopReporter) PrometheusRequest(_, _ string) {}
 func (n NoopReporter) InstrumentProcess(_ string)    {}
 func (n NoopReporter) UninstrumentProcess(_ string)  {}
+func (n NoopReporter) InformerPodAddDuration(_ int)  {}


### PR DESCRIPTION
This can be helpful to measure latency of k8s informers in Beyla and count the total requests to k8s API.