### PR TITLE
Revert "Add metrics to measure latency of k8s informer (#1200)"

### DIFF
--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -134,7 +134,7 @@ func setupKubernetes(ctx context.Context, ctxInfo *global.ContextInfo) {
 		return
 	}
 
-	if ctxInfo.AppO11y.K8sDatabase, err = kube.StartDatabase(informer, ctxInfo.Metrics); err != nil {
+	if ctxInfo.AppO11y.K8sDatabase, err = kube.StartDatabase(informer); err != nil {
 		slog.Error("can't setup Kubernetes database. Your traces won't be decorated with Kubernetes metadata",
 			"error", err)
 		ctxInfo.K8sInformer.ForceDisable()

--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -70,7 +70,7 @@ func (pf *ProcessFinder) Start() (<-chan *ebpf.Instrumentable, <-chan *ebpf.Inst
 	gb := pipe.NewBuilder(&nodesMap{}, pipe.ChannelBufferLen(pf.cfg.ChannelBufferLen))
 	pipe.AddStart(gb, processWatcher, ProcessWatcherFunc(pf.ctx, pf.cfg))
 	pipe.AddMiddleProvider(gb, ptrWatcherKubeEnricher,
-		WatcherKubeEnricherProvider(pf.ctx, pf.ctxInfo.K8sInformer, pf.ctxInfo.Metrics))
+		WatcherKubeEnricherProvider(pf.ctx, pf.ctxInfo.K8sInformer))
 	pipe.AddMiddleProvider(gb, criteriaMatcher, CriteriaMatcherProvider(pf.cfg))
 	pipe.AddMiddleProvider(gb, execTyper, ExecTyperProvider(pf.cfg, pf.ctxInfo.Metrics))
 	pipe.AddMiddleProvider(gb, containerDBUpdater,

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/internal/helpers/container"
-	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/kube"
 	"github.com/grafana/beyla/pkg/internal/testutil"
 	"github.com/grafana/beyla/pkg/services"
@@ -74,7 +73,7 @@ func TestWatcherKubeEnricher(t *testing.T) {
 			k8sClient := fakek8sclientset.NewSimpleClientset()
 			informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
 			require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
-			wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer}, fakeInternalMetrics{})()
+			wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer})()
 			require.NoError(t, err)
 			inputCh, outputCh := make(chan []Event[processAttrs], 10), make(chan []Event[processAttrs], 10)
 			defer close(inputCh)
@@ -120,7 +119,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 	k8sClient := fakek8sclientset.NewSimpleClientset()
 	informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
 	require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
-	wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer}, fakeInternalMetrics{})()
+	wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer})()
 	require.NoError(t, err)
 	pipeConfig := beyla.Config{}
 	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
@@ -309,13 +308,6 @@ func fakeProcessInfo(pp processAttrs) (*services.ProcessInfo, error) {
 		ExePath:   fmt.Sprintf("/bin/process%d", pp.pid),
 	}, nil
 }
-
-type fakeInternalMetrics struct {
-	imetrics.NoopReporter
-}
-
-func (fakeInternalMetrics) InformerAddDuration(_ string, _ time.Duration)    {}
-func (fakeInternalMetrics) InformerUpdateDuration(_ string, _ time.Duration) {}
 
 type informerProvider struct {
 	informer *kube.Metadata

--- a/pkg/internal/imetrics/imetrics.go
+++ b/pkg/internal/imetrics/imetrics.go
@@ -3,7 +3,6 @@ package imetrics
 
 import (
 	"context"
-	"time"
 )
 
 // Config options for the different metrics exporters
@@ -33,23 +32,17 @@ type Reporter interface {
 	InstrumentProcess(processName string)
 	// UninstrumentProcess is invoked every time a process is removed from the instrumented processed
 	UninstrumentProcess(processName string)
-	// InformerAddDuration is invoked every time a kubernetes object is added to the informer
-	InformerAddDuration(kind string, d time.Duration)
-	// InformerUpdateDuration is invoked every time a kubernetes object is updated in the informer
-	InformerUpdateDuration(kind string, d time.Duration)
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
 type NoopReporter struct{}
 
-func (n NoopReporter) Start(_ context.Context)                          {}
-func (n NoopReporter) TracerFlush(_ int)                                {}
-func (n NoopReporter) OTELMetricExport(_ int)                           {}
-func (n NoopReporter) OTELMetricExportError(_ error)                    {}
-func (n NoopReporter) OTELTraceExport(_ int)                            {}
-func (n NoopReporter) OTELTraceExportError(_ error)                     {}
-func (n NoopReporter) PrometheusRequest(_, _ string)                    {}
-func (n NoopReporter) InstrumentProcess(_ string)                       {}
-func (n NoopReporter) UninstrumentProcess(_ string)                     {}
-func (n NoopReporter) InformerAddDuration(_ string, _ time.Duration)    {}
-func (n NoopReporter) InformerUpdateDuration(_ string, _ time.Duration) {}
+func (n NoopReporter) Start(_ context.Context)       {}
+func (n NoopReporter) TracerFlush(_ int)             {}
+func (n NoopReporter) OTELMetricExport(_ int)        {}
+func (n NoopReporter) OTELMetricExportError(_ error) {}
+func (n NoopReporter) OTELTraceExport(_ int)         {}
+func (n NoopReporter) OTELTraceExportError(_ error)  {}
+func (n NoopReporter) PrometheusRequest(_, _ string) {}
+func (n NoopReporter) InstrumentProcess(_ string)    {}
+func (n NoopReporter) UninstrumentProcess(_ string)  {}

--- a/pkg/internal/transform/kube/db.go
+++ b/pkg/internal/transform/kube/db.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"time"
 
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/beyla/pkg/internal/helpers/container"
-	"github.com/grafana/beyla/pkg/internal/imetrics"
 	"github.com/grafana/beyla/pkg/internal/kube"
 )
 
@@ -56,7 +54,7 @@ func CreateDatabase(kubeMetadata *kube.Metadata) Database {
 	}
 }
 
-func StartDatabase(kubeMetadata *kube.Metadata, m imetrics.Reporter) (*Database, error) {
+func StartDatabase(kubeMetadata *kube.Metadata) (*Database, error) {
 	db := CreateDatabase(kubeMetadata)
 	db.informer.AddContainerEventHandler(&db)
 
@@ -75,17 +73,11 @@ func StartDatabase(kubeMetadata *kube.Metadata, m imetrics.Reporter) (*Database,
 	}
 	if err := db.informer.AddServiceIPEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			svc := obj.(*kube.ServiceInfo)
-			d := time.Since(svc.CreationTimestamp.Time)
 			db.UpdateNewServicesByIPIndex(obj.(*kube.ServiceInfo))
-			m.InformerAddDuration("service", d)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			svc := newObj.(*kube.ServiceInfo)
-			d := time.Since(svc.CreationTimestamp.Time)
 			db.UpdateDeletedServicesByIPIndex(oldObj.(*kube.ServiceInfo))
 			db.UpdateNewServicesByIPIndex(newObj.(*kube.ServiceInfo))
-			m.InformerUpdateDuration("service", d)
 		},
 		DeleteFunc: func(obj interface{}) {
 			db.UpdateDeletedServicesByIPIndex(obj.(*kube.ServiceInfo))
@@ -95,17 +87,11 @@ func StartDatabase(kubeMetadata *kube.Metadata, m imetrics.Reporter) (*Database,
 	}
 	if err := db.informer.AddNodeEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			n := obj.(*kube.NodeInfo)
-			d := time.Since(n.CreationTimestamp.Time)
 			db.UpdateNewNodesByIPIndex(obj.(*kube.NodeInfo))
-			m.InformerAddDuration("node", d)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			n := newObj.(*kube.NodeInfo)
-			d := time.Since(n.CreationTimestamp.Time)
 			db.UpdateDeletedNodesByIPIndex(oldObj.(*kube.NodeInfo))
 			db.UpdateNewNodesByIPIndex(newObj.(*kube.NodeInfo))
-			m.InformerUpdateDuration("node", d)
 		},
 		DeleteFunc: func(obj interface{}) {
 			db.UpdateDeletedNodesByIPIndex(obj.(*kube.NodeInfo))


### PR DESCRIPTION
This reverts commit 6960d77c4043220eaafe617f52a2d6a9a805ef14.

These metrics are not accurate as they are using Pod creation time as reference.
The idea was to track latency of informers but the approach is not correct. 

Alternatively we could have a counter, which would track how many times the
handlers of an informer are called, but I don't think that's very useful.

