### PR TITLE
Allow configuring informer resync time

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -681,6 +681,25 @@ reduces the load of the Kubernetes API.
 The Pods informer can't be disabled. For that purpose, you should disable the whole
 Kubernetes metadata decoration.
 
+| YAML                     | Environment variable                | Type     | Default |
+|--------------------------|-------------------------------------|----------|---------|
+| `informers_sync_timeout` | `BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT` | Duration | 30s     |
+
+Maximum time that Beyla will wait for getting all the Kubernetes metadata before starting
+to decorate metrics and traces. If this timeout is reached, Beyla will start normally but
+the metadata attributes might be incomplete until all the Kubernetes metadata is locally
+updated in background.
+
+| YAML                      | Environment variable                 | Type     | Default |
+|---------------------------|--------------------------------------|----------|---------|
+| `informers_resync_period` | `BEYLA_KUBE_INFORMERS_RESYNC_PERIOD` | Duration | 30m     |
+
+Beyla is subscribed to immediately receive any update on resources' metadata. In addition,
+Beyla will periodically resynchronize the whole Kubernetes metadata, at the frequency specified
+by this property.
+
+Higher values will reduce the load on the Kubernetes API service.
+
 ## Routes decorator
 
 YAML section `routes`.

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -685,8 +685,8 @@ Kubernetes metadata decoration.
 |--------------------------|-------------------------------------|----------|---------|
 | `informers_sync_timeout` | `BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT` | Duration | 30s     |
 
-Maximum time that Beyla will wait for getting all the Kubernetes metadata before starting
-to decorate metrics and traces. If this timeout is reached, Beyla will start normally but
+Maximum time that Beyla waits for getting all the Kubernetes metadata before starting
+to decorate metrics and traces. If this timeout is reached, Beyla starts normally but
 the metadata attributes might be incomplete until all the Kubernetes metadata is locally
 updated in background.
 
@@ -695,10 +695,10 @@ updated in background.
 | `informers_resync_period` | `BEYLA_KUBE_INFORMERS_RESYNC_PERIOD` | Duration | 30m     |
 
 Beyla is subscribed to immediately receive any update on resources' metadata. In addition,
-Beyla will periodically resynchronize the whole Kubernetes metadata, at the frequency specified
+Beyla periodically resynchronizes the whole Kubernetes metadata at the frequency specified
 by this property.
 
-Higher values will reduce the load on the Kubernetes API service.
+Higher values reduce the load on the Kubernetes API service.
 
 ## Routes decorator
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -110,8 +110,9 @@ var DefaultConfig = Config{
 			HostnameDNSResolution: true,
 		},
 		Kubernetes: transform.KubernetesDecorator{
-			Enable:               kubeflags.EnabledDefault,
-			InformersSyncTimeout: 30 * time.Second,
+			Enable:                kubeflags.EnabledDefault,
+			InformersSyncTimeout:  30 * time.Second,
+			InformersResyncPeriod: 30 * time.Minute,
 		},
 		HostID: HostIDConfig{
 			FetchTimeout: 500 * time.Millisecond,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -174,9 +174,10 @@ network:
 				HostnameDNSResolution: true,
 			},
 			Kubernetes: transform.KubernetesDecorator{
-				KubeconfigPath:       "/foo/bar",
-				Enable:               kubeflags.EnabledTrue,
-				InformersSyncTimeout: 30 * time.Second,
+				KubeconfigPath:        "/foo/bar",
+				Enable:                kubeflags.EnabledTrue,
+				InformersSyncTimeout:  30 * time.Second,
+				InformersResyncPeriod: 30 * time.Minute,
 			},
 			HostID: HostIDConfig{
 				Override:     "the-host-id",

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -107,13 +107,14 @@ func buildCommonContextInfo(
 	promMgr := &connector.PrometheusManager{}
 	ctxInfo := &global.ContextInfo{
 		Prometheus: promMgr,
-		K8sInformer: kube.NewMetadataProvider(
-			config.Attributes.Kubernetes.Enable,
-			config.Attributes.Kubernetes.DisableInformers,
-			config.Attributes.Kubernetes.KubeconfigPath,
-			config.Enabled(beyla.FeatureNetO11y),
-			config.Attributes.Kubernetes.InformersSyncTimeout,
-		),
+		K8sInformer: kube.NewMetadataProvider(kube.MetadataConfig{
+			Enable:                config.Attributes.Kubernetes.Enable,
+			EnableNetworkMetadata: config.Enabled(beyla.FeatureNetO11y),
+			KubeConfigPath:        config.Attributes.Kubernetes.KubeconfigPath,
+			SyncTimeout:           config.Attributes.Kubernetes.InformersSyncTimeout,
+			ResyncPeriod:          config.Attributes.Kubernetes.InformersResyncPeriod,
+			DisabledInformers:     config.Attributes.Kubernetes.DisableInformers,
+		}),
 	}
 	switch {
 	case config.InternalMetrics.Prometheus.Port != 0:

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -72,8 +72,8 @@ func TestWatcherKubeEnricher(t *testing.T) {
 			containerInfoForPID = fakeContainerInfo
 			// Setup a fake K8s API connected to the watcherKubeEnricher
 			k8sClient := fakek8sclientset.NewSimpleClientset()
-			informer := kube.Metadata{}
-			require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, "", 30*time.Minute))
+			informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
+			require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
 			wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer}, fakeInternalMetrics{})()
 			require.NoError(t, err)
 			inputCh, outputCh := make(chan []Event[processAttrs], 10), make(chan []Event[processAttrs], 10)
@@ -118,8 +118,8 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 	processInfo = fakeProcessInfo
 	// Setup a fake K8s API connected to the watcherKubeEnricher
 	k8sClient := fakek8sclientset.NewSimpleClientset()
-	informer := kube.Metadata{}
-	require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, "", 30*time.Minute))
+	informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
+	require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
 	wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer}, fakeInternalMetrics{})()
 	require.NoError(t, err)
 	pipeConfig := beyla.Config{}

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -40,7 +40,7 @@ func gctx(groups attributes.AttrGroups) *global.ContextInfo {
 	return &global.ContextInfo{
 		Metrics:               imetrics.NoopReporter{},
 		MetricAttributeGroups: groups,
-		K8sInformer:           kube.NewMetadataProvider(kubeflags.EnabledFalse, nil, "", false, 0),
+		K8sInformer:           kube.NewMetadataProvider(kube.MetadataConfig{Enable: kubeflags.EnabledFalse}),
 		HostID:                "host-id",
 	}
 }

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -31,6 +31,9 @@ type KubernetesDecorator struct {
 
 	InformersSyncTimeout time.Duration `yaml:"informers_sync_timeout" env:"BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT"`
 
+	// InformersResyncPeriod defaults to 30m. Higher values will reduce the load on the Kube API.
+	InformersResyncPeriod time.Duration `yaml:"informers_resync_period" env:"BEYLA_KUBE_INFORMERS_RESYNC_PERIOD"`
+
 	// DropExternal will drop, in NetO11y component, any flow where the source or destination
 	// IPs are not matched to any kubernetes entity, assuming they are cluster-external
 	DropExternal bool `yaml:"drop_external" env:"BEYLA_NETWORK_DROP_EXTERNAL"`


### PR DESCRIPTION
This PR:
* Changes the behavior of the informer synchronization timeout, which might be high in large clusters. Instead of disabling kubernetes decoration, shows a warning and starts decoration while the metadata is still updated in the background.
* Makes the informer resync time configurable, and increases its default value to 30 minutes. Higher values will cause less load in the Kube API.