### PR TITLE
Revert: reducing scope of informer

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -108,12 +108,11 @@ func buildCommonContextInfo(
 	ctxInfo := &global.ContextInfo{
 		Prometheus: promMgr,
 		K8sInformer: kube.NewMetadataProvider(kube.MetadataConfig{
-			Enable:                config.Attributes.Kubernetes.Enable,
-			EnableNetworkMetadata: config.Enabled(beyla.FeatureNetO11y),
-			KubeConfigPath:        config.Attributes.Kubernetes.KubeconfigPath,
-			SyncTimeout:           config.Attributes.Kubernetes.InformersSyncTimeout,
-			ResyncPeriod:          config.Attributes.Kubernetes.InformersResyncPeriod,
-			DisabledInformers:     config.Attributes.Kubernetes.DisableInformers,
+			Enable:            config.Attributes.Kubernetes.Enable,
+			KubeConfigPath:    config.Attributes.Kubernetes.KubeconfigPath,
+			SyncTimeout:       config.Attributes.Kubernetes.InformersSyncTimeout,
+			ResyncPeriod:      config.Attributes.Kubernetes.InformersResyncPeriod,
+			DisabledInformers: config.Attributes.Kubernetes.DisableInformers,
 		}),
 	}
 	switch {

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -72,7 +72,7 @@ func TestWatcherKubeEnricher(t *testing.T) {
 			// Setup a fake K8s API connected to the watcherKubeEnricher
 			k8sClient := fakek8sclientset.NewSimpleClientset()
 			informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
-			require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
+			require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient))
 			wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer})()
 			require.NoError(t, err)
 			inputCh, outputCh := make(chan []Event[processAttrs], 10), make(chan []Event[processAttrs], 10)
@@ -118,7 +118,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 	// Setup a fake K8s API connected to the watcherKubeEnricher
 	k8sClient := fakek8sclientset.NewSimpleClientset()
 	informer := kube.Metadata{SyncTimeout: 30 * time.Minute}
-	require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient, ""))
+	require.NoError(t, informer.InitFromClient(context.TODO(), k8sClient))
 	wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &informerProvider{informer: &informer})()
 	require.NoError(t, err)
 	pipeConfig := beyla.Config{}


### PR DESCRIPTION
Reverts this PR https://github.com/grafana/beyla/pull/1210

We did the wrong assumption that global entities were only required for Network Metrics. But service graph metrics also require being decorated from cluster-wide pods.

Since we are working on a definitive solution based on external informers caches, I'm just reverting this change to avoid bugs and simplifying the code.