### PR TITLE
flaky language detection test: add extra logs

### DIFF
--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -11,6 +11,7 @@ import (
 	trace2 "go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/beyla/pkg/internal/request"
+	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func TestTracePrinterValidEnabled(t *testing.T) {
@@ -39,6 +40,7 @@ func TestTracePrinterValidEnabled(t *testing.T) {
 
 func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
 	fakeSpan := request.Span{
+		ServiceID:      svc.ID{Name: "bar", Namespace: "foo", SDKLanguage: svc.InstrumentableGolang},
 		Type:           request.EventTypeHTTP,
 		Method:         "method",
 		Path:           "path",
@@ -95,7 +97,7 @@ func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
 
 func TestTracePrinterResolve_PrinterText(t *testing.T) {
 	expected := "(25µs[20µs]) HTTP 200 method path [peer as peername:1234]->" +
-		"[host as hostname:5678] size:1024B svc=[ go]" +
+		"[host as hostname:5678] size:1024B svc=[foo/bar go]" +
 		" traceparent=[00-01020300000000000000000000000000-0102030000000000[0102040000000000]-01]\n"
 
 	actual := traceFuncHelper(t, TracePrinterText)

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -122,7 +122,8 @@ func (ta *TraceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 		return false
 	}
 
-	ta.log.Info("instrumenting process", "cmd", ie.FileInfo.CmdExePath, "pid", ie.FileInfo.Pid, "ino", ie.FileInfo.Ino)
+	ta.log.Info("instrumenting process",
+		"cmd", ie.FileInfo.CmdExePath, "pid", ie.FileInfo.Pid, "ino", ie.FileInfo.Ino, "type", ie.Type)
 	ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
 
 	// builds a tracer for that executable
@@ -188,7 +189,8 @@ func (ta *TraceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 	ta.log.Debug("new executable for discovered process",
 		"pid", ie.FileInfo.Pid,
 		"child", ie.ChildPids,
-		"exec", ie.FileInfo.CmdExePath)
+		"exec", ie.FileInfo.CmdExePath,
+		"type", ie.Type)
 	// allowing the tracer to forward traces from the discovered PID and its children processes
 	ta.monitorPIDs(tracer, ie)
 	ta.existingTracers[ie.FileInfo.Ino] = tracer
@@ -231,7 +233,8 @@ func (ta *TraceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 	ta.log.Debug("reusing Generic tracer for",
 		"pid", ie.FileInfo.Pid,
 		"child", ie.ChildPids,
-		"exec", ie.FileInfo.CmdExePath)
+		"exec", ie.FileInfo.CmdExePath,
+		"language", ie.Type)
 
 	ta.monitorPIDs(tracer, ie)
 	ta.existingTracers[ie.FileInfo.Ino] = tracer
@@ -247,7 +250,8 @@ func (ta *TraceAttacher) updateTracerProbes(tracer *ebpf.ProcessTracer, ie *ebpf
 	ta.log.Debug("reusing Generic tracer for",
 		"pid", ie.FileInfo.Pid,
 		"child", ie.ChildPids,
-		"exec", ie.FileInfo.CmdExePath)
+		"exec", ie.FileInfo.CmdExePath,
+		"language", ie.Type)
 
 	ta.monitorPIDs(tracer, ie)
 

--- a/pkg/internal/ebpf/common/httpfltr_transform_test.go
+++ b/pkg/internal/ebpf/common/httpfltr_transform_test.go
@@ -8,26 +8,25 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/beyla/pkg/internal/request"
-	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
 func TestHTTPInfoParsing(t *testing.T) {
 	t.Run("Test basic parsing", func(t *testing.T) {
-		tr := makeHTTPInfo("POST", "/users", "127.0.0.1", "127.0.0.2", "curl", 12345, 8080, 200, 5)
+		tr := makeHTTPInfo("POST", "/users", "127.0.0.1", "127.0.0.2", 12345, 8080, 200, 5)
 		s := httpInfoToSpan(&tr)
-		assertMatchesInfo(t, &s, "POST", "/users", "127.0.0.1", "127.0.0.2", "curl", 8080, 200, 5)
+		assertMatchesInfo(t, &s, "POST", "/users", "127.0.0.1", "127.0.0.2", 8080, 200, 5)
 	})
 
 	t.Run("Test empty URL", func(t *testing.T) {
-		tr := makeHTTPInfo("POST", "", "127.0.0.1", "127.0.0.2", "curl", 12345, 8080, 200, 5)
+		tr := makeHTTPInfo("POST", "", "127.0.0.1", "127.0.0.2", 12345, 8080, 200, 5)
 		s := httpInfoToSpan(&tr)
-		assertMatchesInfo(t, &s, "POST", "", "127.0.0.1", "127.0.0.2", "curl", 8080, 200, 5)
+		assertMatchesInfo(t, &s, "POST", "", "127.0.0.1", "127.0.0.2", 8080, 200, 5)
 	})
 
 	t.Run("Test parsing with URL parameters", func(t *testing.T) {
-		tr := makeHTTPInfo("POST", "/users?query=1234", "127.0.0.1", "127.0.0.2", "curl", 12345, 8080, 200, 5)
+		tr := makeHTTPInfo("POST", "/users?query=1234", "127.0.0.1", "127.0.0.2", 12345, 8080, 200, 5)
 		s := httpInfoToSpan(&tr)
-		assertMatchesInfo(t, &s, "POST", "/users", "127.0.0.1", "127.0.0.2", "curl", 8080, 200, 5)
+		assertMatchesInfo(t, &s, "POST", "/users", "127.0.0.1", "127.0.0.2", 8080, 200, 5)
 	})
 }
 
@@ -59,7 +58,7 @@ func TestMethodURLParsing(t *testing.T) {
 	assert.Empty(t, i.url())
 }
 
-func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint32, status uint16, durationMs uint64) HTTPInfo {
+func makeHTTPInfo(method, path, peer, host string, peerPort, hostPort uint32, status uint16, durationMs uint64) HTTPInfo {
 	bpfInfo := BPFHTTPInfo{
 		Type:            1,
 		Status:          status,
@@ -72,7 +71,6 @@ func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint
 		Peer:        peer,
 		URL:         path,
 		Host:        host,
-		Service:     svc.ID{Name: comm, SDKLanguage: svc.InstrumentableRuby},
 	}
 
 	i.ConnInfo.D_port = uint16(hostPort)
@@ -81,17 +79,15 @@ func makeHTTPInfo(method, path, peer, host, comm string, peerPort, hostPort uint
 	return i
 }
 
-func assertMatchesInfo(t *testing.T, span *request.Span, method, path, peer, host, comm string, hostPort int, status int, durationMs uint64) {
+func assertMatchesInfo(t *testing.T, span *request.Span, method, path, peer, host string, hostPort int, status int, durationMs uint64) {
 	assert.Equal(t, method, span.Method)
 	assert.Equal(t, path, span.Path)
 	assert.Equal(t, host, span.Host)
 	assert.Equal(t, hostPort, span.HostPort)
 	assert.Equal(t, peer, span.Peer)
 	assert.Equal(t, status, span.Status)
-	assert.Equal(t, comm, span.ServiceID.Name)
-	assert.Equal(t, svc.InstrumentableRuby, span.ServiceID.SDKLanguage)
-	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.Start))
-	assert.Equal(t, int64(durationMs*1000000), int64(span.End-span.RequestStart))
+	assert.Equal(t, int64(durationMs*1000000), span.End-span.Start)
+	assert.Equal(t, int64(durationMs*1000000), span.End-span.RequestStart)
 }
 
 func makeBPFInfoWithBuf(buf []uint8) BPFHTTPInfo {

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -647,7 +647,7 @@ func newRequest(serviceName string, method, path, peer string, status int) []req
 		Start:        2,
 		RequestStart: 1,
 		End:          3,
-		ServiceID:    svc.ID{HostName: "the-host", Namespace: "ns", Name: serviceName},
+		ServiceID:    svc.ID{HostName: "the-host", Namespace: "ns", Name: serviceName, SDKLanguage: svc.InstrumentableGolang},
 	}}
 }
 
@@ -663,7 +663,7 @@ func newRequestWithTiming(svcName string, kind request.EventType, method, path, 
 		RequestStart: int64(goStart),
 		Start:        int64(start),
 		End:          int64(end),
-		ServiceID:    svc.ID{HostName: "the-host", Name: svcName},
+		ServiceID:    svc.ID{HostName: "the-host", Name: svcName, SDKLanguage: svc.InstrumentableGolang},
 	}}
 }
 
@@ -678,7 +678,7 @@ func newGRPCRequest(svcName string, path string, status int) []request.Span {
 		Start:        2,
 		RequestStart: 1,
 		End:          3,
-		ServiceID:    svc.ID{HostName: "the-host", Name: svcName},
+		ServiceID:    svc.ID{HostName: "the-host", Name: svcName, SDKLanguage: svc.InstrumentableGolang},
 	}}
 }
 
@@ -807,7 +807,7 @@ func newHTTPInfo(method, path, peer string, status int) []request.Span {
 		Start:        2,
 		RequestStart: 2,
 		End:          3,
-		ServiceID:    svc.ID{HostName: "the-host", Name: "comm"},
+		ServiceID:    svc.ID{HostName: "the-host", Name: "comm", SDKLanguage: svc.InstrumentableGolang},
 	}}
 }
 

--- a/pkg/internal/svc/svc.go
+++ b/pkg/internal/svc/svc.go
@@ -9,7 +9,7 @@ import (
 type InstrumentableType int
 
 const (
-	InstrumentableGolang = InstrumentableType(iota)
+	InstrumentableGolang InstrumentableType = iota + 1
 	InstrumentableJava
 	InstrumentableDotnet
 	InstrumentablePython
@@ -41,7 +41,8 @@ func (it InstrumentableType) String() string {
 	case InstrumentableGeneric:
 		return "generic"
 	default:
-		return "unknown(bug!)"
+		// if this appears, it's a bug!!
+		return "unknown"
 	}
 }
 


### PR DESCRIPTION
Checking the logs of the tests that fail because Beyla does not properly seem to detect the language, I observe that actually the language is correctly detected.

However, at some point, the `svc.ID.SDKLanguage` field is not properly copied along with the rest of the `svc.ID` struct, then its value remains to `0`, which was the value of `InstrumentableGolang`. 

This PR just adds extra logging information to try to see where this might be failing.