### PR TITLE
Fix wrong language detection

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -270,6 +270,8 @@ func (ta *TraceAttacher) monitorPIDs(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 		ie.FileInfo.Service.SetAutoName()
 	}
 
+	ie.FileInfo.Service.SDKLanguage = ie.Type
+
 	// allowing the tracer to forward traces from the discovered PID and its children processes
 	tracer.AllowPID(uint32(ie.FileInfo.Pid), ie.FileInfo.Ns, &ie.FileInfo.Service)
 	for _, pid := range ie.ChildPids {


### PR DESCRIPTION
not in all the paths where `monitorPIDs` is invoked, the SDKLanguage value is set before, so the "ProcessAlive" signal could create exporters with incorrect/unset SDK language.

I re-ran the K8s tests many times and, despite there are still some flaky tests that should be fixed in future PRs, the language detection bug has not been reproduced.
