### PR TITLE
K8s cache: fix coverage report and add graceful stop

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,8 +1,11 @@
 codecov:
   require_ci_to_pass: yes
+  default_rules:
+    informational: true
   status:
-    patch: false
-    changes: false
+    project: off
+    patch: off
+    changes: off
   notify:
     wait_for_ci: yes
 github_checks: false

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,8 @@
-coverage:
+codecov:
   require_ci_to_pass: yes
   notify:
     wait_for_ci: yes
+coverage:
   status:
     project:
       default:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,8 @@
 codecov:
   require_ci_to_pass: yes
+  status:
+    patch: false
+    changes: false
   notify:
     wait_for_ci: yes
 github_checks: false

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
   status:
     project:
       default:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,11 +1,10 @@
-codecov:
-  require_ci_to_pass: yes
-  default_rules:
-    informational: true
+coverage:
   status:
-    project: off
-    patch: off
-    changes: off
-  notify:
-    wait_for_ci: yes
-github_checks: false
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+github_checks:
+  annotations: false

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,3 +2,4 @@ codecov:
   require_ci_to_pass: yes
   notify:
     wait_for_ci: yes
+github_checks: false

--- a/test/integration/k8s/manifests/06-beyla-external-informer.yml
+++ b/test/integration/k8s/manifests/06-beyla-external-informer.yml
@@ -117,9 +117,6 @@ metadata:
   namespace: default
   labels:
     app: k8s-cache
-    # this label will trigger a deletion of beyla pods before tearing down
-    # kind, to force Beyla writing the coverage data
-    teardown: delete
 spec:
   replicas: 1
   selector:
@@ -130,6 +127,9 @@ spec:
       name: k8s-cache
       labels:
         app: k8s-cache
+        # this label will trigger a deletion of beyla pods before tearing down
+        # kind, to force Beyla writing the coverage data
+        teardown: delete
     spec:
       # required to let the service accessing the K8s API
       serviceAccountName: beyla


### PR DESCRIPTION
The K8s cache service was not gracefully stopping on sigint/sigterm.

* It took many seconds to remove the pod.
* Coverage data was not reported in integration tests.

This PR also prevents codecov to fail when the new PR does not meet a given coverage threshold.