### PR TITLE
Fix network flows flaky test

### DIFF
--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"sigs.k8s.io/e2e-framework/pkg/features"
-
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
@@ -23,7 +21,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 		docker.ImageBuild{Tag: "beyla-k8s-cache:dev", Dockerfile: k8s.DockerfileBeylaK8sCache},
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
 	); err != nil {
@@ -36,7 +33,6 @@ func TestMain(m *testing.M) {
 		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("testserver:dev"),
-		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("beyla-k8s-cache:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
@@ -72,10 +68,5 @@ func TestInformersCache_ProcessMetrics(t *testing.T) {
 }
 
 func TestInformersCache_NetworkMetrics(t *testing.T) {
-	// we don't deploy any pinger
-	// it will reuse internal-pinger from MetricsDecoration_HTTP test
-	cluster.TestEnv().Test(t, features.New("network flow bytes").
-		Assess("catches network metrics between connected pods", otel.DoTestNetFlowBytesForExistingConnections).
-		Feature(),
-	)
+	cluster.TestEnv().Test(t, otel.FeatureNetworkFlowBytes())
 }

--- a/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"sigs.k8s.io/e2e-framework/pkg/features"
-
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
@@ -49,18 +47,5 @@ func TestMain(m *testing.M) {
 }
 
 func TestNetworkFlowBytes(t *testing.T) {
-	pinger := kube.Template[k8s.Pinger]{
-		TemplateFile: k8s.UninstrumentedPingerManifest,
-		Data: k8s.Pinger{
-			PodName:   "internal-pinger",
-			TargetURL: "http://testserver:8080/iping",
-		},
-	}
-	cluster.TestEnv().Test(t, features.New("network flow bytes").
-		Setup(pinger.Deploy()).
-		Teardown(pinger.Delete()).
-		Assess("catches network metrics between connected pods", DoTestNetFlowBytesForExistingConnections).
-		Assess("catches external traffic", testNetFlowBytesForExternalTraffic).
-		Feature(),
-	)
+	cluster.TestEnv().Test(t, FeatureNetworkFlowBytes())
 }

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -13,8 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 
+	"github.com/grafana/beyla/test/integration/components/kube"
 	"github.com/grafana/beyla/test/integration/components/prom"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
 )
 
 const (
@@ -26,12 +29,27 @@ const (
 var podSubnets = []string{"10.244.0.0/16", "fd00:10:244::/56"}
 var svcSubnets = []string{"10.96.0.0/16", "fd00:10:96::/112"}
 
-func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-	pq := prom.Client{HostPort: prometheusHostPort}
+func FeatureNetworkFlowBytes() features.Feature {
+	pinger := kube.Template[k8s.Pinger]{
+		TemplateFile: k8s.UninstrumentedPingerManifest,
+		Data: k8s.Pinger{
+			PodName:   "internal-pinger-net",
+			TargetURL: "http://testserver:8080/iping",
+		},
+	}
+	return features.New("network flow bytes").
+		Setup(pinger.Deploy()).
+		Teardown(pinger.Delete()).
+		Assess("catches network metrics between connected pods", testNetFlowBytesForExistingConnections).
+		Assess("catches external traffic", testNetFlowBytesForExternalTraffic).
+		Feature()
+}
 
+func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := prom.Client{HostPort: prometheusHostPort}
 	// testing request flows (to testserver as Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name="testserver"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="testserver"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -43,7 +61,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 		assert.Equal(t, "beyla-network-flows", metric["job"])
 		assert.Equal(t, "my-kube", metric["k8s_cluster_name"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
-		assert.Equal(t, "internal-pinger", metric["k8s_src_name"])
+		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
 		assert.Equal(t, "Pod", metric["k8s_src_owner_type"])
 		assert.Equal(t, "Pod", metric["k8s_src_type"])
 		assert.Regexp(t,
@@ -62,7 +80,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 	})
 	// testing request flows (to testserver as Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name=~"testserver-.*"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name=~"testserver-.*"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -73,7 +91,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 		assertIsIP(t, metric["dst_address"])
 		assert.Equal(t, "beyla-network-flows", metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
-		assert.Equal(t, "internal-pinger", metric["k8s_src_name"])
+		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
 		assert.Equal(t, "Pod", metric["k8s_src_owner_type"])
 		assert.Equal(t, "Pod", metric["k8s_src_type"])
 		assert.Regexp(t,
@@ -97,7 +115,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 
 	// testing response flows (from testserver Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger-net"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -116,7 +134,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 			metric["k8s_src_node_name"])
 		assertIsIP(t, metric["k8s_src_node_ip"])
 		assert.Equal(t, "default", metric["k8s_dst_namespace"])
-		assert.Equal(t, "internal-pinger", metric["k8s_dst_name"])
+		assert.Equal(t, "internal-pinger-net", metric["k8s_dst_name"])
 		assert.Equal(t, "Pod", metric["k8s_dst_owner_type"])
 		assert.Equal(t, "Pod", metric["k8s_dst_type"])
 		assert.Regexp(t,
@@ -132,7 +150,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 
 	// testing response flows (from testserver Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger"}`)
+		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger-net"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -148,7 +166,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 		assert.Equal(t, "Service", metric["k8s_src_type"])
 		// services don't have host IP or name
 		assert.Equal(t, "default", metric["k8s_dst_namespace"])
-		assert.Equal(t, "internal-pinger", metric["k8s_dst_name"])
+		assert.Equal(t, "internal-pinger-net", metric["k8s_dst_name"])
 		assert.Equal(t, "Pod", metric["k8s_dst_owner_type"])
 		assert.Equal(t, "Pod", metric["k8s_dst_type"])
 		assert.Regexp(t,
@@ -162,7 +180,7 @@ func DoTestNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T,
 	})
 
 	// check that there aren't captured flows if there is no communication
-	results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name="otherinstance"}`)
+	results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="otherinstance"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 

--- a/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"sigs.k8s.io/e2e-framework/pkg/features"
-
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
@@ -49,17 +47,5 @@ func TestMain(m *testing.M) {
 }
 
 func TestNetworkFlowBytes_Prom(t *testing.T) {
-	pinger := kube.Template[k8s.Pinger]{
-		TemplateFile: k8s.UninstrumentedPingerManifest,
-		Data: k8s.Pinger{
-			PodName:   "internal-pinger",
-			TargetURL: "http://testserver:8080/iping",
-		},
-	}
-	cluster.TestEnv().Test(t, features.New("network flow bytes").
-		Setup(pinger.Deploy()).
-		Teardown(pinger.Delete()).
-		Assess("catches network metrics between connected pods", otel.DoTestNetFlowBytesForExistingConnections).
-		Feature(),
-	)
+	cluster.TestEnv().Test(t, otel.FeatureNetworkFlowBytes())
 }

--- a/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"sigs.k8s.io/e2e-framework/pkg/features"
-
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
@@ -49,17 +47,5 @@ func TestMain(m *testing.M) {
 }
 
 func TestNetworkSKFlowBytes_Prom(t *testing.T) {
-	pinger := kube.Template[k8s.Pinger]{
-		TemplateFile: k8s.UninstrumentedPingerManifest,
-		Data: k8s.Pinger{
-			PodName:   "internal-pinger",
-			TargetURL: "http://testserver:8080/iping",
-		},
-	}
-	cluster.TestEnv().Test(t, features.New("network flow bytes").
-		Setup(pinger.Deploy()).
-		Teardown(pinger.Delete()).
-		Assess("catches network metrics between connected pods", otel.DoTestNetFlowBytesForExistingConnections).
-		Feature(),
-	)
+	cluster.TestEnv().Test(t, otel.FeatureNetworkFlowBytes())
 }


### PR DESCRIPTION
To speedup network flows testing, we were reusing the `internal-pinger` pod from a previous test, however, depending on the order of the events, the test might fail:

1. Internal-pinger is deployed.
1. The app o11y pipeline gets the internal-pinger metadata.
1. Internal pinger sends a ping.
1. Net o11y pipeline detects the packet before it gets the Pod metadata from the informer (it works in another thread than app o11y), so reports it without metadata.
1. The app o11y pipeline detects the call and sends it properly decorated.
1. The app o11y HTTP test succeeds and `internal-pinger` is removed.
1. The Net O11y integration test is run, assuming that the net pipeline should have detected the flow in the previous HTTP test.
1. The Net O11y integration test fails, because the flow was detected but not properly decorated with the internal-pinger metadata. 