### PR TITLE
Fix the return value of bpf_strstr_tp_loop when it does not meet the …

### DIFF
--- a/bpf/trace_common.h
+++ b/bpf/trace_common.h
@@ -93,8 +93,7 @@ static __always_inline unsigned char *bpf_strstr_tp_loop(unsigned char *buf, int
     bpf_loop(nr_loops, tp_match, &data, 0);
 
     if (data.pos) {
-        u32 pos = (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? 0 : data.pos;
-        return &(buf[pos]);
+        return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? 0 : &(buf[data.pos]);
     }
 
     return 0;


### PR DESCRIPTION
When I was reading the code, I discovered this small mistake. Although I don't think it will have any real impact, I still believe it's necessary to correct it.