### PR TITLE
Tune up versioned docker release scripts

### DIFF
--- a/.github/workflows/publish_dockerhub_release.yml
+++ b/.github/workflows/publish_dockerhub_release.yml
@@ -10,8 +10,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-multiarch:
+    runs-on: ubuntu-latest-8-cores
 
     steps:
       - id: checkout
@@ -24,9 +24,6 @@ jobs:
         with:
           repository: grafana/beyla
           context: .
-          # cache image layers from/to github actions internal cache, for faster building
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: |-
             "linux/amd64"
             "linux/arm64"
@@ -42,9 +39,6 @@ jobs:
           repository: grafana/beyla-k8s-cache
           file: k8scache.Dockerfile
           context: .
-          # cache image layers from/to github actions internal cache, for faster building
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: |-
             "linux/amd64"
             "linux/arm64"


### PR DESCRIPTION
After verifying that the `publish_dockerhub_main.yml` action now works, this PR does the equivalent changes to the `publish_dockerhub_release.yml` action.