### PR TITLE
Fix codecov flags of VM integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -42,4 +42,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/itest-covdata.txt
-          flags: integration-test
+          flags: integration-test-arm

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -48,4 +48,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./testoutput/itest-covdata.txt
-          flags: integration-test
+          flags: integration-test-vm-${{ inputs.arch }}-${{ inputs.kernel-version }}


### PR DESCRIPTION
Prevents that VM integration tests code coverage reports are overwritten as they were sharing the same Codecov flag names.