### PR TITLE
Add configuration options to Kube Cache service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - errorlint
     - cyclop
     - errname
-    - exportloopref
     - gocritic
     - goimports
     - gosimple

--- a/cmd/k8s-cache/main.go
+++ b/cmd/k8s-cache/main.go
@@ -2,45 +2,60 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
+	"github.com/grafana/beyla/pkg/buildinfo"
+	"github.com/grafana/beyla/pkg/kubecache"
 	"github.com/grafana/beyla/pkg/kubecache/meta"
 	"github.com/grafana/beyla/pkg/kubecache/service"
 )
-
-const defaultPort = 50055
 
 // main code of te Kubernetes K8s informer's metadata cache service, when it runs as a separate service and not
 // as a library inside Beyla
 
 func main() {
-	// TODO: use buildinfo to print version
-	// TODO: let configure logger
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug})))
+	lvl := slog.LevelVar{}
+	lvl.Set(slog.LevelInfo)
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: &lvl,
+	})))
 
-	ic := service.InformersCache{
-		Port: defaultPort,
+	slog.Info("Beyla's Kubernetes Metadata cache service", "Version", buildinfo.Version, "Revision", buildinfo.Revision)
+
+	configPath := flag.String("config", "", "path to the configuration file")
+	flag.Parse()
+	if cfg := os.Getenv("BEYLA_K8S_CACHE_CONFIG_PATH"); cfg != "" {
+		configPath = &cfg
 	}
-	portStr := os.Getenv("BEYLA_K8S_CACHE_PORT")
-	if portStr != "" {
-		var err error
-		if ic.Port, err = strconv.Atoi(portStr); err != nil {
-			slog.Error("invalid BEYLA_K8S_CACHE_PORT, using default port", "error", err)
-			ic.Port = defaultPort
-		}
+	config := loadFromFile(configPath)
+	if err := lvl.UnmarshalText([]byte(config.LogLevel)); err != nil {
+		slog.Error("unknown log level specified, choices are [DEBUG, INFO, WARN, ERROR]", "error", err)
+		os.Exit(-1)
 	}
+
+	if config.ProfilePort != 0 {
+		go func() {
+			slog.Info("starting PProf HTTP listener", "port", config.ProfilePort)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), nil)
+			slog.Error("PProf HTTP listener stopped working", "error", err)
+		}()
+	}
+
+	ic := service.InformersCache{Config: config}
 
 	// Adding shutdown hook for graceful stop.
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	if err := ic.Run(ctx,
-		// TODO: make it configurable
-		meta.WithResyncPeriod(30*time.Minute)); err != nil {
+		meta.WithResyncPeriod(config.InformerResyncPeriod)); err != nil {
 		slog.Error("starting informers' cache service", "error", err)
 		os.Exit(-1)
 	}
@@ -50,4 +65,24 @@ func main() {
 		slog.Info("Waiting 1s to collect coverage data...")
 		time.Sleep(time.Second)
 	}
+}
+
+func loadFromFile(configPath *string) *kubecache.Config {
+	var configReader io.ReadCloser
+	if configPath != nil && *configPath != "" {
+		var err error
+		if configReader, err = os.Open(*configPath); err != nil {
+			slog.Error("can't open "+*configPath, "error", err)
+			os.Exit(-1)
+		}
+		defer configReader.Close()
+	}
+	config, err := kubecache.LoadConfig(configReader)
+	if err != nil {
+		slog.Error("wrong configuration", "error", err)
+		// nolint:gocritic
+		os.Exit(-1)
+	}
+
+	return config
 }

--- a/pkg/kubecache/config.go
+++ b/pkg/kubecache/config.go
@@ -1,0 +1,53 @@
+package kubecache
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/caarlos0/env/v9"
+	"gopkg.in/yaml.v3"
+)
+
+// Config options of the Kubernetes Cache service. Check the "DefaultConfig" variable for a view of the default values.
+type Config struct {
+	// LogLevel can be one of: debug, info, warn, error
+	LogLevel string `yaml:"log_level" env:"BEYLA_K8S_CACHE_LOG_LEVEL"`
+	// Port where the service is going to listen to
+	Port int `yaml:"port" env:"BEYLA_K8S_CACHE_PORT"`
+	// MaxConnection is the maximum number of concurrent clients that the service can handle at the same time
+	MaxConnections int `yaml:"max_connections" env:"BEYLA_K8S_CACHE_MAX_CONNECTIONS"`
+	// ProfilePort is the port where the pprof server is going to listen to. 0 (default) means disabled
+	ProfilePort int `yaml:"profile_port" env:"BEYLA_K8S_CACHE_PROFILE_PORT"`
+	// InformerResyncPeriod is the time interval between complete resyncs of the informers
+	InformerResyncPeriod time.Duration `yaml:"informer_resync_period" env:"BEYLA_K8S_CACHE_INFORMER_RESYNC_PERIOD"`
+}
+
+var DefaultConfig = Config{
+	LogLevel:             "info",
+	Port:                 50055,
+	MaxConnections:       100,
+	InformerResyncPeriod: 30 * time.Minute,
+	ProfilePort:          0,
+}
+
+// LoadConfig overrides configuration in the following order (from less to most priority)
+// 1 - Default configuration (DefaultConfig variable)
+// 2 - Contents of the provided file reader (nillable)
+// 3 - Environment variables
+func LoadConfig(file io.Reader) (*Config, error) {
+	cfg := DefaultConfig
+	if file != nil {
+		cfgBuf, err := io.ReadAll(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading YAML configuration: %w", err)
+		}
+		if err := yaml.Unmarshal(cfgBuf, &cfg); err != nil {
+			return nil, fmt.Errorf("parsing YAML configuration: %w", err)
+		}
+	}
+	if err := env.Parse(&cfg); err != nil {
+		return nil, fmt.Errorf("reading env vars: %w", err)
+	}
+	return &cfg, nil
+}


### PR DESCRIPTION
Prior to dogfooding, this PR adds some extra configuration options to the service.