### PR TITLE
Helm chart: remove duplicity of labels

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.4.5
+version: 1.4.6
 appVersion: 1.8.6
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/

--- a/charts/beyla/templates/cache-deployment.yaml
+++ b/charts/beyla/templates/cache-deployment.yaml
@@ -24,7 +24,6 @@ spec:
         {{- tpl (toYaml . | nindent 8) $root }}
       {{- end }}
       labels:
-        {{- include "beyla.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ .Values.k8sCache.service.name }}
     spec:
       {{- if .Values.serviceAccount.create }}


### PR DESCRIPTION
The `beyla.labels` script applies for the Beyla instance but not for the Beyla cache instance, which already defines some labels.

This duplicity caused our deployment tools to fail.