### PR TITLE
Add missing mutex in kube store functions

### DIFF
--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -227,6 +227,8 @@ func (s *Store) ObjectMetaByIP(ip string) *informer.ObjectMeta {
 }
 
 func (s *Store) ServiceNameNamespaceForMetadata(om *informer.ObjectMeta) (string, string) {
+	s.access.RLock()
+	defer s.access.RUnlock()
 	var name string
 	var namespace string
 	if owner := TopOwner(om.Pod); owner != nil {
@@ -240,6 +242,8 @@ func (s *Store) ServiceNameNamespaceForMetadata(om *informer.ObjectMeta) (string
 // ServiceNameNamespaceForIP returns the service name and namespace for a given IP address
 // This means that, for a given Pod, we will not return the Pod Name, but the Pod Owner Name
 func (s *Store) ServiceNameNamespaceForIP(ip string) (string, string) {
+	s.access.RLock()
+	defer s.access.RUnlock()
 	if serviceInfo, ok := s.otelServiceInfoByIP[ip]; ok {
 		return serviceInfo.Name, serviceInfo.Namespace
 	}


### PR DESCRIPTION
Currently we've seen some crashes due some mutex missing:

```
fatal error: concurrent map read and map write

goroutine 269 [running]:
github.com/grafana/beyla/pkg/internal/kube.(*Store).ServiceNameNamespaceForIP(0xc0166850e0, {0xc008261ca0, 0xd})
	/opt/app-root/pkg/internal/kube/store.go:243 +0x3a
github.com/grafana/beyla/pkg/transform.(*NameResolver).resolveFromK8s(...)
	/opt/app-root/pkg/transform/name_resolver.go:198
github.com/grafana/beyla/pkg/transform.(*NameResolver).dnsResolve(0xc016d02620, 0xc00afdc7f0, {0xc008261ca0, 0xd})
	/opt/app-root/pkg/transform/name_resolver.go:178 +0xc5
github.com/grafana/beyla/pkg/transform.(*NameResolver).resolve(0xc015e26e60?, 0xc016d5c000?, {0xc008261ca0, 0xd})
	/opt/app-root/pkg/transform/name_resolver.go:142 +0x31
github.com/grafana/beyla/pkg/transform.(*NameResolver).resolveNames(0xc016d02620, 0xc00afdc760)
	/opt/app-root/pkg/transform/name_resolver.go:118 +0x45
github.com/grafana/beyla/pkg/transform.nameResolver.func1(0xc015e26e00, 0xc015e26e70)
	/opt/app-root/pkg/transform/name_resolver.go:94 +0xbe
github.com/mariomac/pipes/pipe.(*middle[...]).start.func1()
	/opt/app-root/vendor/github.com/mariomac/pipes/pipe/node.go:195 +0x3b
created by github.com/mariomac/pipes/pipe.(*middle[...]).start in goroutine 99
	/opt/app-root/vendor/github.com/mariomac/pipes/pipe/node.go:194 +0x276
```