### PR TITLE
Update github workflows to use upload-artifact@v4

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: make integration-test
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Logs

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -29,7 +29,7 @@ jobs:
         run: make integration-test-arm
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Logs

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: make integration-test-k8s
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: K8s test Logs

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run oats tests
         run: make oats-test
       - name: Upload oats test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Oats test logs

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -35,7 +35,7 @@ jobs:
           sudo make -C test/vm KERNEL_VER=${{ inputs.kernel-version }} ARCH=${{ inputs.arch }} && [ -f testoutput/success ]
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Logs


### PR DESCRIPTION
`actions/upload-artifact@v3` is scheduled to be deprecated. This PR updates to last version