### PR TITLE
Fix crash on start

### DIFF
--- a/cmd/k8s-cache/main.go
+++ b/cmd/k8s-cache/main.go
@@ -45,7 +45,7 @@ func main() {
 	if config.ProfilePort != 0 {
 		go func() {
 			slog.Info("starting PProf HTTP listener", "port", config.ProfilePort)
-			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), http.DefaultServeMux)
 			slog.Error("PProf HTTP listener stopped working", "error", err)
 		}()
 	}

--- a/cmd/k8s-cache/main.go
+++ b/cmd/k8s-cache/main.go
@@ -45,7 +45,7 @@ func main() {
 	if config.ProfilePort != 0 {
 		go func() {
 			slog.Info("starting PProf HTTP listener", "port", config.ProfilePort)
-			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), http.DefaultServeMux)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), nil)
 			slog.Error("PProf HTTP listener stopped working", "error", err)
 		}()
 	}


### PR DESCRIPTION
Fixes a crash where Beyla cache protobuf client panicked because it was trying to close the same channel twice.