### PR TITLE
Improve k8s env parsing

### DIFF
--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -72,7 +72,7 @@ func (pf *ProcessFinder) Start() (<-chan *ebpf.Instrumentable, <-chan *ebpf.Inst
 	pipe.AddMiddleProvider(gb, ptrWatcherKubeEnricher,
 		WatcherKubeEnricherProvider(pf.ctx, pf.ctxInfo.K8sInformer))
 	pipe.AddMiddleProvider(gb, criteriaMatcher, CriteriaMatcherProvider(pf.cfg))
-	pipe.AddMiddleProvider(gb, execTyper, ExecTyperProvider(pf.cfg, pf.ctxInfo.Metrics))
+	pipe.AddMiddleProvider(gb, execTyper, ExecTyperProvider(pf.cfg, pf.ctxInfo.Metrics, pf.ctxInfo.K8sInformer))
 	pipe.AddMiddleProvider(gb, containerDBUpdater, ContainerDBUpdaterProvider(pf.ctx, pf.ctxInfo.K8sInformer))
 	pipe.AddFinalProvider(gb, traceAttacher, TraceAttacherProvider(&TraceAttacher{
 		Cfg:                 pf.cfg,

--- a/pkg/internal/exec/file.go
+++ b/pkg/internal/exec/file.go
@@ -36,7 +36,7 @@ func (fi *FileInfo) ExecutableName() string {
 	return parts[len(parts)-1]
 }
 
-func FindExecELF(p *services.ProcessInfo, svcID svc.ID) (*FileInfo, error) {
+func FindExecELF(p *services.ProcessInfo, svcID svc.ID, k8sEnabled bool) (*FileInfo, error) {
 	// In container environments or K8s, we can't just open the executable exe path, because it might
 	// be in the volume of another pod/container. We need to access it through the /proc/<pid>/exe symbolic link
 	ns, err := FindNamespace(p.Pid)
@@ -67,24 +67,27 @@ func FindExecELF(p *services.ProcessInfo, svcID svc.ID) (*FileInfo, error) {
 		return nil, err
 	}
 
-	envVars, err := EnvVars(p.Pid)
+	// If Kubernetes is enabled we use the K8S metadata as the source of truth
+	if !k8sEnabled {
+		envVars, err := EnvVars(p.Pid)
 
-	if err != nil {
-		return nil, err
-	}
+		if err != nil {
+			return nil, err
+		}
 
-	file.Service.EnvVars = envVars
-	if svcName, ok := file.Service.EnvVars[envServiceName]; ok {
-		file.Service.Name = svcName
-	} else {
-		if resourceAttrs, ok := file.Service.EnvVars[envResourceAttrs]; ok {
-			allVars := map[string]string{}
-			collect := func(k string, v string) {
-				allVars[k] = v
-			}
-			attributes.ParseOTELResourceVariable(resourceAttrs, collect)
-			if result, ok := allVars[serviceNameKey]; ok {
-				file.Service.Name = result
+		file.Service.EnvVars = envVars
+		if svcName, ok := file.Service.EnvVars[envServiceName]; ok {
+			file.Service.Name = svcName
+		} else {
+			if resourceAttrs, ok := file.Service.EnvVars[envResourceAttrs]; ok {
+				allVars := map[string]string{}
+				collect := func(k string, v string) {
+					allVars[k] = v
+				}
+				attributes.ParseOTELResourceVariable(resourceAttrs, collect)
+				if result, ok := allVars[serviceNameKey]; ok {
+					file.Service.Name = result
+				}
 			}
 		}
 	}

--- a/pkg/internal/exec/file.go
+++ b/pkg/internal/exec/file.go
@@ -67,27 +67,27 @@ func FindExecELF(p *services.ProcessInfo, svcID svc.ID, k8sEnabled bool) (*FileI
 		return nil, err
 	}
 
-	// If Kubernetes is enabled we use the K8S metadata as the source of truth
-	if !k8sEnabled {
-		envVars, err := EnvVars(p.Pid)
+	envVars, err := EnvVars(p.Pid)
 
-		if err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
+	}
 
-		file.Service.EnvVars = envVars
-		if svcName, ok := file.Service.EnvVars[envServiceName]; ok {
+	file.Service.EnvVars = envVars
+	if svcName, ok := file.Service.EnvVars[envServiceName]; ok {
+		// If Kubernetes is enabled we use the K8S metadata as the source of truth
+		if !k8sEnabled {
 			file.Service.Name = svcName
-		} else {
-			if resourceAttrs, ok := file.Service.EnvVars[envResourceAttrs]; ok {
-				allVars := map[string]string{}
-				collect := func(k string, v string) {
-					allVars[k] = v
-				}
-				attributes.ParseOTELResourceVariable(resourceAttrs, collect)
-				if result, ok := allVars[serviceNameKey]; ok {
-					file.Service.Name = result
-				}
+		}
+	} else {
+		if resourceAttrs, ok := file.Service.EnvVars[envResourceAttrs]; ok {
+			allVars := map[string]string{}
+			collect := func(k string, v string) {
+				allVars[k] = v
+			}
+			attributes.ParseOTELResourceVariable(resourceAttrs, collect)
+			if result, ok := allVars[serviceNameKey]; ok {
+				file.Service.Name = result
 			}
 		}
 	}

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -16,8 +16,6 @@ func dblog() *slog.Logger {
 }
 
 const (
-	envServiceName      = "OTEL_SERVICE_NAME"
-	envResourceAttrs    = "OTEL_RESOURCE_ATTRIBUTES"
 	serviceNameKey      = "service.name"
 	serviceNamespaceKey = "service.namespace"
 )
@@ -294,7 +292,7 @@ func (s *Store) serviceNameNamespaceOwnerID(ownerKey, name, namespace string) (s
 }
 
 func (s *Store) nameFromResourceAttrs(variable string, c *informer.ContainerInfo) (string, bool) {
-	if resourceVars, ok := c.Env[envResourceAttrs]; ok {
+	if resourceVars, ok := c.Env[meta.EnvResourceAttrs]; ok {
 		allVars := map[string]string{}
 		collect := func(k string, v string) {
 			allVars[k] = v
@@ -315,7 +313,7 @@ func isValidServiceName(name string) bool {
 func (s *Store) serviceNameFromEnv(ownerKey string) (string, bool) {
 	if containers, ok := s.containersByOwner[ownerKey]; ok {
 		for _, c := range containers {
-			if serviceName, ok := c.Env[envServiceName]; ok {
+			if serviceName, ok := c.Env[meta.EnvServiceName]; ok {
 				return serviceName, isValidServiceName(serviceName)
 			}
 

--- a/pkg/kubecache/meta/envutil.go
+++ b/pkg/kubecache/meta/envutil.go
@@ -1,0 +1,119 @@
+package meta
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+)
+
+func splitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// formatMap formats map[string]string to a string.
+func formatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+func extractFieldPathAsString(accessor metav1.ObjectMeta, fieldPath string) (string, error) {
+	if path, subscript, ok := splitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return formatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return formatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+func getFieldRef(accessor metav1.ObjectMeta, from *v1.EnvVarSource) (string, error) {
+	return extractFieldPathAsString(accessor, from.FieldRef.FieldPath)
+}
+
+func getConfigMapRefValue(client kubernetes.Interface, namespace string, configMapSelector *v1.ConfigMapKeySelector) (string, error) {
+	configMap, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapSelector.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if data, ok := configMap.Data[configMapSelector.Key]; ok {
+		return string(data), nil
+	}
+	return "", fmt.Errorf("key %s not found in config map %s", configMapSelector.Key, configMapSelector.Name)
+}
+
+func getSecretRefValue(client kubernetes.Interface, namespace string, secretSelector *v1.SecretKeySelector) (string, error) {
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), secretSelector.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if data, ok := secret.Data[secretSelector.Key]; ok {
+		return string(data), nil
+	}
+	return "", fmt.Errorf("key %s not found in secret %s", secretSelector.Key, secretSelector.Name)
+}
+
+func GetEnvVarRefValue(kc kubernetes.Interface, ns string, from *v1.EnvVarSource, obj metav1.ObjectMeta, c *v1.Container) (string, error) {
+	if from.SecretKeyRef != nil {
+		return getSecretRefValue(kc, ns, from.SecretKeyRef)
+	}
+
+	if from.ConfigMapKeyRef != nil {
+		return getConfigMapRefValue(kc, ns, from.ConfigMapKeyRef)
+	}
+
+	if from.FieldRef != nil {
+		return getFieldRef(obj, from)
+	}
+
+	return "", fmt.Errorf("invalid valueFrom")
+}

--- a/pkg/kubecache/meta/envutil.go
+++ b/pkg/kubecache/meta/envutil.go
@@ -102,6 +102,7 @@ func getSecretRefValue(client kubernetes.Interface, namespace string, secretSele
 	return "", fmt.Errorf("key %s not found in secret %s", secretSelector.Key, secretSelector.Name)
 }
 
+// Code adopted from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/set/env/env_resolve.go#L248
 func GetEnvVarRefValue(kc kubernetes.Interface, ns string, from *v1.EnvVarSource, obj metav1.ObjectMeta, c *v1.Container) (string, error) {
 	if from.SecretKeyRef != nil {
 		return getSecretRefValue(kc, ns, from.SecretKeyRef)

--- a/pkg/kubecache/meta/envutil.go
+++ b/pkg/kubecache/meta/envutil.go
@@ -103,7 +103,7 @@ func getSecretRefValue(client kubernetes.Interface, namespace string, secretSele
 }
 
 // Code adopted from https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/set/env/env_resolve.go#L248
-func GetEnvVarRefValue(kc kubernetes.Interface, ns string, from *v1.EnvVarSource, obj metav1.ObjectMeta, c *v1.Container) (string, error) {
+func GetEnvVarRefValue(kc kubernetes.Interface, ns string, from *v1.EnvVarSource, obj metav1.ObjectMeta) (string, error) {
 	if from.SecretKeyRef != nil {
 		return getSecretRefValue(kc, ns, from.SecretKeyRef)
 	}

--- a/pkg/kubecache/meta/envutil_test.go
+++ b/pkg/kubecache/meta/envutil_test.go
@@ -1,0 +1,191 @@
+package meta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetEnvFromConfigMap(t *testing.T) {
+	inputs := []struct {
+		name      string
+		configMap *corev1.ConfigMap
+		result    string
+		key       string
+		err       error
+		hasError  bool
+	}{
+		{
+			name: "lowercase map",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "testconfigmap"},
+				Data: map[string]string{
+					"env":          "prod",
+					"test-key":     "testValue",
+					"test-key-two": "testValueTwo",
+				},
+			},
+			key:      "test-key",
+			result:   "testValue",
+			err:      nil,
+			hasError: false,
+		},
+		{
+			name: "uppercase map",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "testconfigmapuppercasekey"},
+				Data: map[string]string{
+					"ENV":          "prod",
+					"TEST_KEY":     "testValue",
+					"TEST_KEY_TWO": "testValueTwo",
+				},
+			},
+			key:      "TEST_KEY",
+			result:   "testValue",
+			err:      nil,
+			hasError: false,
+		},
+		{
+			name: "key not exists",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "testconfigmapuppercasekey"},
+				Data: map[string]string{
+					"ENV":          "prod",
+					"TEST_KEY":     "testValue",
+					"TEST_KEY_TWO": "testValueTwo",
+				},
+			},
+			key:      "TEST_KEY_NOT_EXISTS",
+			result:   "",
+			err:      nil,
+			hasError: true,
+		},
+		{
+			name: "uppercase map with error",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "testconfigmapuppercasekey"},
+				Data: map[string]string{
+					"ENV":          "prod",
+					"TEST_KEY":     "testValue",
+					"TEST_KEY_TWO": "testValueTwo",
+				},
+			},
+			key:      "TEST_KEY",
+			result:   "",
+			err:      fmt.Errorf("Whatever"),
+			hasError: true,
+		},
+	}
+
+	for _, i := range inputs {
+		t.Run(i.name, func(t *testing.T) {
+			v, err := extractConfigMapRefValue(i.configMap, i.err, &corev1.ConfigMapKeySelector{Key: i.key})
+			assert.Equal(t, i.hasError, err != nil)
+			assert.Equal(t, i.result, v)
+		})
+	}
+}
+
+func TestSetEnvFromSecret(t *testing.T) {
+	inputs := []struct {
+		name      string
+		configMap *corev1.Secret
+		result    string
+		key       string
+		err       error
+		hasError  bool
+	}{
+		{
+			name: "lowercase map",
+			configMap: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsecret"},
+				Data: map[string][]byte{
+					"env":          []byte("prod"),
+					"test-key":     []byte("testValue"),
+					"test-key-two": []byte("testValueTwo"),
+				},
+			},
+			key:      "test-key",
+			result:   "testValue",
+			err:      nil,
+			hasError: false,
+		},
+		{
+			name: "uppercase map",
+			configMap: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsecretuppercasekey"},
+				Data: map[string][]byte{
+					"ENV":          []byte("prod"),
+					"TEST_KEY":     []byte("testValue"),
+					"TEST_KEY_TWO": []byte("testValueTwo"),
+				},
+			},
+			key:      "TEST_KEY",
+			result:   "testValue",
+			err:      nil,
+			hasError: false,
+		},
+		{
+			name: "key not exists",
+			configMap: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsecretuppercasekey"},
+				Data: map[string][]byte{
+					"ENV":          []byte("prod"),
+					"TEST_KEY":     []byte("testValue"),
+					"TEST_KEY_TWO": []byte("testValueTwo"),
+				},
+			},
+			key:      "TEST_KEY_NOT_EXISTS",
+			result:   "",
+			err:      nil,
+			hasError: true,
+		},
+		{
+			name: "uppercase map with error",
+			configMap: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsecretuppercasekey"},
+				Data: map[string][]byte{
+					"ENV":          []byte("prod"),
+					"TEST_KEY":     []byte("testValue"),
+					"TEST_KEY_TWO": []byte("testValueTwo"),
+				},
+			},
+			key:      "TEST_KEY",
+			result:   "",
+			err:      fmt.Errorf("Whatever"),
+			hasError: true,
+		},
+	}
+
+	for _, i := range inputs {
+		t.Run(i.name, func(t *testing.T) {
+			v, err := extractSecretRefValue(i.configMap, i.err, &corev1.SecretKeySelector{Key: i.key})
+			assert.Equal(t, i.hasError, err != nil)
+			assert.Equal(t, i.result, v)
+		})
+	}
+}
+
+func TestFieldRef(t *testing.T) {
+	source := corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			FieldPath: "metadata.labels['app.kubernetes.io/component']",
+		},
+	}
+
+	obj := metav1.ObjectMeta{
+		Labels: map[string]string{
+			"opentelemetry.io/name":       "opentelemetry-demo-kafka",
+			"app.kubernetes.io/instance":  "opentelemetry-demo",
+			"app.kubernetes.io/component": "kafka",
+			"app.kubernetes.io/name":      "opentelemetry-demo-kafka",
+		},
+	}
+
+	v, err := getFieldRef(obj, &source)
+	assert.NoError(t, err)
+	assert.Equal(t, "kafka", v)
+}

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -275,7 +275,7 @@ func envToMap(kc kubernetes.Interface, objMeta metav1.ObjectMeta, c *v1.Containe
 			if envV.Value != "" {
 				envMap[envV.Name] = envV.Value
 			} else if envV.ValueFrom != nil {
-				if v, err := GetEnvVarRefValue(kc, objMeta.Namespace, envV.ValueFrom, objMeta, c); err == nil {
+				if v, err := GetEnvVarRefValue(kc, objMeta.Namespace, envV.ValueFrom, objMeta); err == nil {
 					if v != "" {
 						envMap[envV.Name] = v
 					}

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -31,6 +31,8 @@ const (
 	defaultResyncTime     = 30 * time.Minute
 )
 
+var usefulEnvVars = map[string]struct{}{"OTEL_SERVICE_NAME": {}, "OTEL_RESOURCE_ATTRIBUTES": {}}
+
 type informersConfig struct {
 	kubeConfigPath  string
 	resyncPeriod    time.Duration
@@ -266,7 +268,9 @@ func (inf *Informers) initPodInformer(informerFactory informers.SharedInformerFa
 func envToMap(env []v1.EnvVar) map[string]string {
 	envMap := map[string]string{}
 	for _, envV := range env {
-		envMap[envV.Name] = envV.Value
+		if _, ok := usefulEnvVars[envV.Name]; ok {
+			envMap[envV.Name] = envV.Value
+		}
 	}
 
 	return envMap

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -29,9 +29,11 @@ const (
 	typePod               = "Pod"
 	typeService           = "Service"
 	defaultResyncTime     = 30 * time.Minute
+	EnvServiceName        = "OTEL_SERVICE_NAME"
+	EnvResourceAttrs      = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
-var usefulEnvVars = map[string]struct{}{"OTEL_SERVICE_NAME": {}, "OTEL_RESOURCE_ATTRIBUTES": {}}
+var usefulEnvVars = map[string]struct{}{EnvServiceName: {}, EnvResourceAttrs: {}}
 
 type informersConfig struct {
 	kubeConfigPath  string

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -275,10 +275,7 @@ func envToMap(kc kubernetes.Interface, objMeta metav1.ObjectMeta, c *v1.Containe
 			if envV.Value != "" {
 				envMap[envV.Name] = envV.Value
 			} else if envV.ValueFrom != nil {
-				fmt.Printf("**** Have value from %v for %v\n", envV.ValueFrom, envV.Name)
-				if v, err := GetEnvVarRefValue(kc, objMeta.Namespace, envV.ValueFrom, objMeta, c); err != nil {
-					fmt.Printf("**** Got value '%v'\n", v)
-
+				if v, err := GetEnvVarRefValue(kc, objMeta.Namespace, envV.ValueFrom, objMeta, c); err == nil {
 					if v != "" {
 						envMap[envV.Name] = v
 					}

--- a/pkg/kubecache/meta/informers_init_test.go
+++ b/pkg/kubecache/meta/informers_init_test.go
@@ -6,11 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEnvironmentFiltering(t *testing.T) {
 	vars := []v1.EnvVar{{Name: "A", Value: "B"}, {Value: "C"}, {}, {Name: "OTEL_SERVICE_NAME", Value: "service_name"}, {Name: "OTEL_RESOURCE_ATTRIBUTES", Value: "resource_attributes"}}
-	filtered := envToMap(vars)
+
+	c := v1.Container{
+		Env: vars,
+	}
+
+	filtered := envToMap(nil, metav1.ObjectMeta{}, &c)
 	assert.Equal(t, 2, len(filtered))
 
 	serviceName, ok := filtered["OTEL_SERVICE_NAME"]

--- a/pkg/kubecache/meta/informers_init_test.go
+++ b/pkg/kubecache/meta/informers_init_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/kubecache/meta/informers_init_test.go
+++ b/pkg/kubecache/meta/informers_init_test.go
@@ -1,0 +1,23 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestEnvironmentFiltering(t *testing.T) {
+	vars := []v1.EnvVar{{Name: "A", Value: "B"}, {Value: "C"}, {}, {Name: "OTEL_SERVICE_NAME", Value: "service_name"}, {Name: "OTEL_RESOURCE_ATTRIBUTES", Value: "resource_attributes"}}
+	filtered := envToMap(vars)
+	assert.Equal(t, 2, len(filtered))
+
+	serviceName, ok := filtered["OTEL_SERVICE_NAME"]
+	assert.True(t, ok)
+	assert.Equal(t, "service_name", serviceName)
+
+	resourceAttrs, ok := filtered["OTEL_RESOURCE_ATTRIBUTES"]
+	assert.True(t, ok)
+	assert.Equal(t, "resource_attributes", resourceAttrs)
+}


### PR DESCRIPTION
Our current implementation of fetching k8s environment variables doesn't work if there are variable references. This causes a consistency problem with the way we determine the service name. Namely, we have code that looks up the environment variables at PID level, which means we'll see the variables the process sees. However for name resolution we rely on the k8s attributes, which can produce a different name if the variables are references.

To mitigate this I did the following:
- If Kubernetes metadata is enabled, we won't fetch the service name from the environment variables at PID time. We rely on getting this information from the k8s informer.
- I extended the k8s informer variable name resolving to support references, mostly based on what this code does https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/set/env/env_resolve.go#L248.

I added some tests, ~~but I need to add more~~ (Added tests for config maps, secrets, and field references).