### PR TITLE
Stop flooding cache logs on client disconnection/context cancelation

### DIFF
--- a/pkg/internal/discover/watcher_kube.go
+++ b/pkg/internal/discover/watcher_kube.go
@@ -70,10 +70,10 @@ func (wk *watcherKubeEnricher) ID() string { return "unique-watcher-kube-enriche
 // On is invoked every time an object metadata instance is stored or deleted in the
 // kube.Store. It will just forward the event via the channel for proper asynchronous
 // handling in the enrich main loop
-func (wk *watcherKubeEnricher) On(event *informer.Event) {
+func (wk *watcherKubeEnricher) On(event *informer.Event) error {
 	// ignoring updates on non-pod resources
 	if event.GetResource().GetPod() == nil {
-		return
+		return nil
 	}
 	switch event.Type {
 	case informer.EventType_CREATED, informer.EventType_UPDATED:
@@ -83,6 +83,7 @@ func (wk *watcherKubeEnricher) On(event *informer.Event) {
 	default:
 		wk.log.Debug("ignoring unknown event type", "event", event)
 	}
+	return nil
 }
 
 // enrich listens for any potential instrumentable process from three asyncronous sources:

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -302,6 +302,6 @@ func (f *fakeInformer) Notify(event *informer.Event) {
 	f.mt.Lock()
 	defer f.mt.Unlock()
 	for _, observer := range f.observers {
-		observer.On(event)
+		_ = observer.On(event)
 	}
 }

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -197,7 +197,7 @@ func (mp *MetadataProvider) initLocalInformers(ctx context.Context) (*meta.Infor
 func (mp *MetadataProvider) initRemoteInformerCacheClient(ctx context.Context) *cacheSvcClient {
 	client := &cacheSvcClient{
 		address:      mp.cfg.MetaCacheAddr,
-		BaseNotifier: meta.NewBaseNotifier(),
+		BaseNotifier: meta.NewBaseNotifier(klog()),
 		syncTimeout:  mp.cfg.SyncTimeout,
 	}
 	client.Start(ctx)

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -391,7 +391,7 @@ func (s *Store) Subscribe(observer meta.Observer) {
 	s.BaseNotifier.Subscribe(observer)
 	for _, pod := range s.podsByContainer {
 		if err := observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: pod}); err != nil {
-			s.log.Debug("observer failed. Unsubscribing it", "observer", observer.ID(), "error", err)
+			s.log.Debug("observer failed sending Pod info. Unsubscribing it", "observer", observer.ID(), "error", err)
 			s.BaseNotifier.Unsubscribe(observer)
 			return
 		}
@@ -401,7 +401,7 @@ func (s *Store) Subscribe(observer meta.Observer) {
 	// incomplete info
 	for _, ips := range s.objectMetaByIP {
 		if err := observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: ips}); err != nil {
-			s.log.Debug("observer failed. Unsubscribing it", "observer", observer.ID(), "error", err)
+			s.log.Debug("observer failed sending Object Meta. Unsubscribing it", "observer", observer.ID(), "error", err)
 			s.BaseNotifier.Unsubscribe(observer)
 			return
 		}

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -70,8 +70,9 @@ type Store struct {
 }
 
 func NewStore(kubeMetadata meta.Notifier) *Store {
+	log := dblog()
 	db := &Store{
-		log:                 dblog(),
+		log:                 log,
 		containerIDs:        map[string]*container.Info{},
 		namespaces:          map[uint32]*container.Info{},
 		podsByContainer:     map[string]*informer.ObjectMeta{},
@@ -81,7 +82,7 @@ func NewStore(kubeMetadata meta.Notifier) *Store {
 		containersByOwner:   map[string][]*informer.ContainerInfo{},
 		otelServiceInfoByIP: map[string]OTelServiceNamePair{},
 		metadataNotifier:    kubeMetadata,
-		BaseNotifier:        meta.NewBaseNotifier(),
+		BaseNotifier:        meta.NewBaseNotifier(log),
 	}
 	kubeMetadata.Subscribe(db)
 	return db
@@ -90,8 +91,8 @@ func NewStore(kubeMetadata meta.Notifier) *Store {
 func (s *Store) ID() string { return "unique-metadata-observer" }
 
 // On is invoked by the informer when a new Kube object is created, updated or deleted.
-// It will forward the notification to all the Stroe subscribers
-func (s *Store) On(event *informer.Event) {
+// It will forward the notification to all the Store subscribers
+func (s *Store) On(event *informer.Event) error {
 	switch event.Type {
 	case informer.EventType_CREATED:
 		s.addObjectMeta(event.Resource)
@@ -101,6 +102,7 @@ func (s *Store) On(event *informer.Event) {
 		s.deleteObjectMeta(event.Resource)
 	}
 	s.BaseNotifier.Notify(event)
+	return nil
 }
 
 // InfoForPID is an injectable dependency for system-independent testing
@@ -388,12 +390,20 @@ func (s *Store) Subscribe(observer meta.Observer) {
 	defer s.access.RUnlock()
 	s.BaseNotifier.Subscribe(observer)
 	for _, pod := range s.podsByContainer {
-		observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: pod})
+		if err := observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: pod}); err != nil {
+			s.log.Debug("observer failed. Unsubscribing it", "observer", observer.ID(), "error", err)
+			s.BaseNotifier.Unsubscribe(observer)
+			return
+		}
 	}
 	// the IPInfos could contain IPInfo data from Pods already sent in the previous loop
 	// is the subscriber the one that should decide whether to ignore such duplicates or
 	// incomplete info
 	for _, ips := range s.objectMetaByIP {
-		observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: ips})
+		if err := observer.On(&informer.Event{Type: informer.EventType_CREATED, Resource: ips}); err != nil {
+			s.log.Debug("observer failed. Unsubscribing it", "observer", observer.ID(), "error", err)
+			s.BaseNotifier.Unsubscribe(observer)
+			return
+		}
 	}
 }

--- a/pkg/internal/kube/store_test.go
+++ b/pkg/internal/kube/store_test.go
@@ -92,10 +92,10 @@ func TestContainerInfo(t *testing.T) {
 
 	store := NewStore(fInformer)
 
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA1})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaB})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA1})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaB})
 
 	assert.Equal(t, 2, len(store.containersByOwner))
 
@@ -122,7 +122,7 @@ func TestContainerInfo(t *testing.T) {
 	assert.Equal(t, 3, len(store.otelServiceInfoByIP))
 	// Delete the pod which had good definition for the OTel variables.
 	// We expect much different service names now
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA})
 	// We cleaned up the cache for service IPs. We must clean all of it
 	// otherwise there will be stale data left
 	assert.Equal(t, 0, len(store.otelServiceInfoByIP))
@@ -159,8 +159,8 @@ func TestContainerInfo(t *testing.T) {
 
 	assert.Equal(t, 5, len(store.otelServiceInfoByIP))
 
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA1})
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaB})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA1})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaB})
 
 	assert.Equal(t, 0, len(store.otelServiceInfoByIP))
 
@@ -259,15 +259,15 @@ func TestMemoryCleanedUp(t *testing.T) {
 
 	store := NewStore(fInformer)
 
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA1})
-	store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaB})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA1})
+	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaB})
 
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA1})
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA})
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaB})
-	store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &service})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA1})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaA})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &podMetaB})
+	_ = store.On(&informer.Event{Type: informer.EventType_DELETED, Resource: &service})
 
 	assert.Equal(t, 0, len(store.containerIDs))
 	assert.Equal(t, 0, len(store.containerByPID))
@@ -283,7 +283,7 @@ func TestMetaByIPEntryRemovedIfIPGroupChanges(t *testing.T) {
 	// GIVEN a store with
 	store := NewStore(&fakeInformer{})
 	// WHEN an object is created with several IPs
-	store.On(&informer.Event{
+	_ = store.On(&informer.Event{
 		Type: informer.EventType_CREATED,
 		Resource: &informer.ObjectMeta{
 			Name:      "object_1",
@@ -304,7 +304,7 @@ func TestMetaByIPEntryRemovedIfIPGroupChanges(t *testing.T) {
 	assert.Equal(t, []string{"3.1.1.1", "3.2.2.2"}, om.Ips)
 
 	// AND WHEN an object is updated with a different set of IPs
-	store.On(&informer.Event{
+	_ = store.On(&informer.Event{
 		Type: informer.EventType_UPDATED,
 		Resource: &informer.ObjectMeta{
 			Name:      "object_1",
@@ -349,6 +349,6 @@ func (f *fakeInformer) Notify(event *informer.Event) {
 	f.mt.Lock()
 	defer f.mt.Unlock()
 	for _, observer := range f.observers {
-		observer.On(event)
+		_ = observer.On(event)
 	}
 }

--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -25,30 +25,45 @@ func (inf *Informers) Subscribe(observer Observer) {
 
 	// as a "welcome" message, we send the whole kube metadata to the new observer
 	for _, pod := range inf.pods.GetStore().List() {
-		observer.On(&informer.Event{
+		if err := observer.On(&informer.Event{
 			Type:     informer.EventType_CREATED,
 			Resource: pod.(*indexableEntity).EncodedMeta,
-		})
+		}); err != nil {
+			inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
+			inf.BaseNotifier.Unsubscribe(observer)
+			return
+		}
 	}
 	if !inf.config.disableNodes {
 		for _, node := range inf.nodes.GetStore().List() {
-			observer.On(&informer.Event{
+			if err := observer.On(&informer.Event{
 				Type:     informer.EventType_CREATED,
 				Resource: node.(*indexableEntity).EncodedMeta,
-			})
+			}); err != nil {
+				inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
+				inf.BaseNotifier.Unsubscribe(observer)
+				return
+			}
 		}
 	}
 	if !inf.config.disableServices {
 		for _, service := range inf.services.GetStore().List() {
-			observer.On(&informer.Event{
+			if err := observer.On(&informer.Event{
 				Type:     informer.EventType_CREATED,
 				Resource: service.(*indexableEntity).EncodedMeta,
-			})
+			}); err != nil {
+				inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
+				return
+			}
 		}
 	}
 	// notify the end of synchronization, so the client knows that already has a snapshot
 	// of all the existing resources
-	observer.On(&informer.Event{
+	if err := observer.On(&informer.Event{
 		Type: informer.EventType_SYNC_FINISHED,
-	})
+	}); err != nil {
+		inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
+		inf.BaseNotifier.Unsubscribe(observer)
+		return
+	}
 }

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -86,7 +86,7 @@ func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, err
 		opt(config)
 	}
 	log := slog.With("component", "kube.Informers")
-	k := &Informers{log: log, config: config, BaseNotifier: NewBaseNotifier()}
+	k := &Informers{log: log, config: config, BaseNotifier: NewBaseNotifier(log)}
 
 	if config.kubeClient == nil {
 		kubeCfg, err := loadKubeconfig(config.kubeConfigPath)

--- a/pkg/transform/k8s_test.go
+++ b/pkg/transform/k8s_test.go
@@ -176,6 +176,6 @@ func (f *fakeInformer) Unsubscribe(observer meta.Observer) {
 
 func (f *fakeInformer) Notify(event *informer.Event) {
 	for _, observer := range f.observers {
-		observer.On(event)
+		_ = observer.On(event)
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/beyla/issues/1323

Also solves a potential leak where failed clients might be still running their goroutine.