### PR TITLE
Add timeout to grpc server.Send

### DIFF
--- a/examples/k8s-meta-cache/k8s-cache-example-client/main.go
+++ b/examples/k8s-meta-cache/k8s-cache-example-client/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -45,5 +46,6 @@ func main() {
 			break
 		}
 		fmt.Printf("Received event: %v\n", event)
+		time.Sleep(24 * time.Hour)
 	}
 }

--- a/examples/k8s-meta-cache/k8s-cache-example-client/main.go
+++ b/examples/k8s-meta-cache/k8s-cache-example-client/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -46,6 +45,5 @@ func main() {
 			break
 		}
 		fmt.Printf("Received event: %v\n", event)
-		time.Sleep(24 * time.Hour)
 	}
 }

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -204,11 +204,6 @@ func (inf *Informers) initPodInformer(informerFactory informers.SharedInformerFa
 		}
 
 		startTime := pod.GetCreationTimestamp().String()
-		if inf.log.Enabled(context.TODO(), slog.LevelDebug) {
-			inf.log.Debug("inserting pod", "name", pod.Name, "namespace", pod.Namespace, "uid", pod.UID,
-				"node", pod.Spec.NodeName, "startTime", startTime, "containers", containers)
-		}
-
 		return &indexableEntity{
 			ObjectMeta: pod.ObjectMeta,
 			EncodedMeta: &informer.ObjectMeta{

--- a/pkg/kubecache/meta/observer_test.go
+++ b/pkg/kubecache/meta/observer_test.go
@@ -1,0 +1,56 @@
+package meta
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/beyla/pkg/kubecache/informer"
+)
+
+type fakeObserver struct {
+	errorRate int
+	count     int
+}
+
+func (f *fakeObserver) ID() string {
+	return fmt.Sprintf("%p", f)
+}
+
+func (f *fakeObserver) On(_ *informer.Event) error {
+	f.count++
+	if f.errorRate > 0 && f.count%f.errorRate == 0 {
+		return errors.New("fake error on " + f.ID())
+	}
+	return nil
+}
+
+func TestNotificationErrors(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	log := slog.With("test", "TestNotificationErrors")
+	n := NewBaseNotifier(log)
+	fo5 := &fakeObserver{errorRate: 5}
+	fo10 := &fakeObserver{errorRate: 10}
+	foNever1 := &fakeObserver{errorRate: 0}
+	fonever2 := &fakeObserver{errorRate: 0}
+	n.Subscribe(fo5)
+	n.Subscribe(foNever1)
+	n.Subscribe(fo10)
+	n.Subscribe(fonever2)
+
+	for i := 0; i < 20; i++ {
+		n.Notify(&informer.Event{})
+	}
+
+	// check that the observers that return an error are unsubscribed
+	assert.Equal(t, 5, fo5.count)
+	assert.Equal(t, 10, fo10.count)
+	assert.Equal(t, 20, foNever1.count)
+	assert.Equal(t, 20, fonever2.count)
+}


### PR DESCRIPTION
The cache memory leak seems to appear when a client is blocked somehow, then the `Send` method stays blocked inside the informer's EventHandler, which causes the informer to accumulate data indefinitely until OOMing.

I was able to reproduce it locally.

This PR adds a timeout to the send invocation. If the Send times out, the server context is canceled, and the subscriber removed.