### PR TITLE
Enable batching for traces

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -243,6 +243,7 @@ func (tr *tracesOTELReceiver) provideLoop() (pipe.FinalFunc[[]request.Span], err
 	}, nil
 }
 
+// nolint:cyclop
 func getTracesExporter(ctx context.Context, cfg TracesConfig, ctxInfo *global.ContextInfo) (exporter.Traces, error) {
 	switch proto := cfg.getProtocol(); proto {
 	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
@@ -280,7 +281,7 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig, ctxInfo *global.Co
 			Headers: convertHeaders(opts.HTTPHeaders),
 		}
 		slog.Debug("getTracesExporter: confighttp.ClientConfig created", "endpoint", config.ClientConfig.Endpoint)
-		set := getTraceSettings(ctxInfo, cfg, t)
+		set := getTraceSettings(ctxInfo, t)
 		exporter, err := factory.CreateTraces(ctx, set, config)
 		if err != nil {
 			slog.Error("can't create OTLP HTTP traces exporter", "error", err)
@@ -332,7 +333,7 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig, ctxInfo *global.Co
 				InsecureSkipVerify: cfg.InsecureSkipVerify,
 			},
 		}
-		set := getTraceSettings(ctxInfo, cfg, t)
+		set := getTraceSettings(ctxInfo, t)
 		return factory.CreateTraces(ctx, set, config)
 	default:
 		slog.Error(fmt.Sprintf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
@@ -364,7 +365,7 @@ func instrumentTraceExporter(in trace.SpanExporter, internalMetrics imetrics.Rep
 	}
 }
 
-func getTraceSettings(ctxInfo *global.ContextInfo, cfg TracesConfig, in trace.SpanExporter) exporter.Settings {
+func getTraceSettings(ctxInfo *global.ContextInfo, in trace.SpanExporter) exporter.Settings {
 	var traceProvider trace2.TracerProvider
 	telemetryLevel := configtelemetry.LevelNone
 	traceProvider = tracenoop.NewTracerProvider()

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -3,8 +3,6 @@ package otel
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strconv"
 	"sync"
@@ -12,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mariomac/guara/pkg/test"
-	"github.com/mariomac/pipes/pipe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -751,166 +747,6 @@ func TestCodeToStatusCode(t *testing.T) {
 
 		result := codeToStatusCode(code)
 		assert.Equal(t, expected, result)
-	})
-}
-
-func TestTraces_InternalInstrumentation(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	// fake OTEL collector server
-	coll := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-	}))
-	defer coll.Close()
-	// Wait for the HTTP server to be alive
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		resp, err := coll.Client().Get(coll.URL + "/foo")
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-	builder := pipe.NewBuilder(&testPipeline{}, pipe.ChannelBufferLen(10))
-	// create a simple dummy graph to send data to the Metrics reporter, which will send
-	// metrics to the fake collector
-	sendData := make(chan struct{}, 10)
-	pipe.AddStart(builder, func(impl *testPipeline) *pipe.Start[[]request.Span] {
-		return &impl.inputNode
-	}, func(out chan<- []request.Span) {
-		// on every send data signal, the traces generator sends a dummy trace
-		for range sendData {
-			out <- []request.Span{{Type: request.EventTypeHTTP}}
-		}
-	})
-	internalTraces := &fakeInternalTraces{}
-	pipe.AddFinalProvider(builder, func(impl *testPipeline) *pipe.Final[[]request.Span] {
-		return &impl.exporter
-	}, TracesReceiver(context.Background(),
-		TracesConfig{
-			CommonEndpoint:    coll.URL,
-			BatchTimeout:      10 * time.Millisecond,
-			ReportersCacheLen: 16,
-			Instrumentations:  []string{instrumentations.InstrumentationALL},
-		},
-		&global.ContextInfo{
-			Metrics: internalTraces,
-		},
-		attributes.Selection{},
-	))
-	graph, err := builder.Build()
-	require.NoError(t, err)
-
-	graph.Start()
-
-	sendData <- struct{}{}
-	var previousSum, previousCount int
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		// we can't guarantee the number of calls at test time, but they must be at least 1
-		previousSum, previousCount = internalTraces.SumCount()
-		assert.LessOrEqual(t, 1, previousSum)
-		assert.LessOrEqual(t, 1, previousCount)
-		// the sum of metrics should be larger or equal than the number of calls (1 call : n metrics)
-		assert.LessOrEqual(t, previousCount, previousSum)
-		// no call should return error
-		assert.Empty(t, internalTraces.Errors())
-	})
-
-	sendData <- struct{}{}
-	// after some time, the number of calls should be higher than before
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		sum, count := internalTraces.SumCount()
-		assert.LessOrEqual(t, previousSum, sum)
-		assert.LessOrEqual(t, previousCount, count)
-		assert.LessOrEqual(t, count, sum)
-		// no call should return error
-		assert.Zero(t, internalTraces.Errors())
-	})
-
-	// collector starts failing, so errors should be received
-	coll.CloseClientConnections()
-	coll.Close()
-	// Wait for the HTTP server to be stopped
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		_, err := coll.Client().Get(coll.URL + "/foo")
-		require.Error(t, err)
-	})
-
-	var previousErrCount int
-	sendData <- struct{}{}
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		previousSum, previousCount = internalTraces.SumCount()
-		// calls should start returning errors
-		previousErrCount = internalTraces.Errors()
-		assert.NotZero(t, previousErrCount)
-	})
-
-	// after a while, metrics sum should not increase but errors do
-	sendData <- struct{}{}
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		sum, count := internalTraces.SumCount()
-		assert.Equal(t, previousSum, sum)
-		assert.Equal(t, previousCount, count)
-		assert.Less(t, previousErrCount, internalTraces.Errors())
-	})
-}
-
-func TestTraces_InternalInstrumentationSampling(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	// fake OTEL collector server
-	coll := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-	}))
-	defer coll.Close()
-	// Wait for the HTTP server to be alive
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		resp, err := coll.Client().Get(coll.URL + "/foo")
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	builder := pipe.NewBuilder(&testPipeline{})
-	// create a simple dummy graph to send data to the Metrics reporter, which will send
-	// metrics to the fake collector
-	sendData := make(chan struct{})
-	pipe.AddStart(builder, func(impl *testPipeline) *pipe.Start[[]request.Span] {
-		return &impl.inputNode
-	}, func(out chan<- []request.Span) { // on every send data signal, the traces generator sends a dummy trace
-		for range sendData {
-			out <- []request.Span{{Type: request.EventTypeHTTP}}
-		}
-	})
-	internalTraces := &fakeInternalTraces{}
-	pipe.AddFinalProvider(builder, func(impl *testPipeline) *pipe.Final[[]request.Span] {
-		return &impl.exporter
-	}, TracesReceiver(context.Background(),
-		TracesConfig{
-			CommonEndpoint:    coll.URL,
-			BatchTimeout:      10 * time.Millisecond,
-			ExportTimeout:     5 * time.Second,
-			Sampler:           Sampler{Name: "always_off"}, // we won't send any trace
-			ReportersCacheLen: 16,
-			Instrumentations:  []string{instrumentations.InstrumentationALL},
-		},
-		&global.ContextInfo{
-			Metrics: internalTraces,
-		},
-		attributes.Selection{},
-	))
-
-	graph, err := builder.Build()
-	require.NoError(t, err)
-
-	graph.Start()
-
-	// Let's make 10 traces, none should be seen
-	for i := 0; i < 10; i++ {
-		sendData <- struct{}{}
-	}
-	var previousSum, previousCount int
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		// we shouldn't see any data
-		previousSum, previousCount = internalTraces.SumCount()
-		assert.Equal(t, 0, previousSum)
-		assert.Equal(t, 0, previousCount)
-		// no call should return error
-		assert.Empty(t, internalTraces.Errors())
 	})
 }
 

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -3,6 +3,8 @@ package otel
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"sync"
@@ -10,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/mariomac/pipes/pipe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -866,6 +870,103 @@ func TestTracesInstrumentations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTraces_InternalInstrumentation(t *testing.T) {
+	defer restoreEnvAfterExecution()()
+	// fake OTEL collector server
+	coll := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer coll.Close()
+	// Wait for the HTTP server to be alive
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		resp, err := coll.Client().Get(coll.URL + "/foo")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+	builder := pipe.NewBuilder(&testPipeline{}, pipe.ChannelBufferLen(10))
+	// create a simple dummy graph to send data to the Metrics reporter, which will send
+	// metrics to the fake collector
+	sendData := make(chan struct{}, 10)
+	pipe.AddStart(builder, func(impl *testPipeline) *pipe.Start[[]request.Span] {
+		return &impl.inputNode
+	}, func(out chan<- []request.Span) {
+		// on every send data signal, the traces generator sends a dummy trace
+		for range sendData {
+			out <- []request.Span{{Type: request.EventTypeHTTP}}
+		}
+	})
+	internalTraces := &fakeInternalTraces{}
+	pipe.AddFinalProvider(builder, func(impl *testPipeline) *pipe.Final[[]request.Span] {
+		return &impl.exporter
+	}, TracesReceiver(context.Background(),
+		TracesConfig{
+			CommonEndpoint:    coll.URL,
+			BatchTimeout:      10 * time.Millisecond,
+			ReportersCacheLen: 16,
+			Instrumentations:  []string{instrumentations.InstrumentationALL},
+		},
+		&global.ContextInfo{
+			Metrics: internalTraces,
+		},
+		attributes.Selection{},
+	))
+	graph, err := builder.Build()
+	require.NoError(t, err)
+
+	graph.Start()
+
+	sendData <- struct{}{}
+	var previousSum, previousCount int
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		// we can't guarantee the number of calls at test time, but they must be at least 1
+		previousSum, previousCount = internalTraces.SumCount()
+		assert.LessOrEqual(t, 1, previousSum)
+		assert.LessOrEqual(t, 1, previousCount)
+		// the sum of metrics should be larger or equal than the number of calls (1 call : n metrics)
+		assert.LessOrEqual(t, previousCount, previousSum)
+		// no call should return error
+		assert.Empty(t, internalTraces.Errors())
+	})
+
+	sendData <- struct{}{}
+	// after some time, the number of calls should be higher than before
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		sum, count := internalTraces.SumCount()
+		assert.LessOrEqual(t, previousSum, sum)
+		assert.LessOrEqual(t, previousCount, count)
+		assert.LessOrEqual(t, count, sum)
+		// no call should return error
+		assert.Zero(t, internalTraces.Errors())
+	})
+
+	// collector starts failing, so errors should be received
+	coll.CloseClientConnections()
+	coll.Close()
+	// Wait for the HTTP server to be stopped
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		_, err := coll.Client().Get(coll.URL + "/foo")
+		require.Error(t, err)
+	})
+
+	var previousErrCount int
+	sendData <- struct{}{}
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		previousSum, previousCount = internalTraces.SumCount()
+		// calls should start returning errors
+		previousErrCount = internalTraces.Errors()
+		assert.NotZero(t, previousErrCount)
+	})
+
+	// after a while, metrics sum should not increase but errors do
+	sendData <- struct{}{}
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		sum, count := internalTraces.SumCount()
+		assert.Equal(t, previousSum, sum)
+		assert.Equal(t, previousCount, count)
+		assert.Less(t, previousErrCount, internalTraces.Errors())
+	})
 }
 
 func TestTracesAttrReuse(t *testing.T) {


### PR DESCRIPTION
This PR re-enables support for batching in traces. It uses the experimental API for batching introduced recently
This is the issue to track the progress: https://github.com/open-telemetry/opentelemetry-collector/issues/8122