### PR TITLE
K8s cache: Improving performance of client cancellation

### DIFF
--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -81,7 +81,7 @@ func WithKubeClient(client kubernetes.Interface) InformerOption {
 }
 
 func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, error) {
-	config := &informersConfig{resyncPeriod: 30 * time.Minute}
+	config := &informersConfig{resyncPeriod: defaultResyncTime}
 	for _, opt := range opts {
 		opt(config)
 	}

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/peer"
 
 	"github.com/grafana/beyla/pkg/kubecache"
@@ -17,8 +20,7 @@ import (
 	"github.com/grafana/beyla/pkg/kubecache/meta"
 )
 
-// TODO: make configurable
-const sendTimeout = 5 * time.Second
+const defaultSendTimeout = 10 * time.Second
 
 // InformersCache configures and starts the gRPC service
 type InformersCache struct {
@@ -29,9 +31,43 @@ type InformersCache struct {
 	started   atomic.Bool
 	informers *meta.Informers
 	log       *slog.Logger
+
+	// TODO: allow configuring by user
+	SendTimeout time.Duration
+
+	ssi *connectionInterceptor
+}
+
+// connection interceptor hooks into the credentials negotiation
+// to store each client connection, which can be prematurely closed
+// if we detect that the client connection is blocked
+type connectionInterceptor struct {
+	credentials.TransportCredentials
+	log   *slog.Logger
+	conns sync.Map
+}
+
+func (ci *connectionInterceptor) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, authInfo, err := ci.TransportCredentials.ServerHandshake(conn)
+	if err == nil {
+		id := conn.RemoteAddr().String()
+		ci.conns.Store(id, conn)
+	}
+	return conn, authInfo, err
+}
+
+func (ci *connectionInterceptor) closeConnection(id string) {
+	if conn, ok := ci.conns.LoadAndDelete(id); ok {
+		if err := conn.(net.Conn).Close(); err != nil {
+			ci.log.Debug("error closing connection", "error", err)
+		}
+	}
 }
 
 func (ic *InformersCache) Run(ctx context.Context, opts ...meta.InformerOption) error {
+	if ic.SendTimeout == 0 {
+		ic.SendTimeout = defaultSendTimeout
+	}
 	if ic.started.Swap(true) {
 		return errors.New("server already started")
 	}
@@ -47,9 +83,12 @@ func (ic *InformersCache) Run(ctx context.Context, opts ...meta.InformerOption) 
 		return fmt.Errorf("initializing informers: %w", err)
 	}
 
+	// TODO: allow configuring credentials
+	ic.ssi = &connectionInterceptor{TransportCredentials: insecure.NewCredentials(), log: ic.log}
 	s := grpc.NewServer(
 		// TODO: configure other aspects (e.g. secure connections)
 		grpc.MaxConcurrentStreams(uint32(ic.Config.MaxConnections)),
+		grpc.Creds(ic.ssi),
 	)
 	informer.RegisterEventStreamServiceServer(s, ic)
 
@@ -77,12 +116,20 @@ func (ic *InformersCache) Subscribe(_ *informer.SubscribeMessage, server informe
 	if !ok {
 		return fmt.Errorf("failed to extract peer information")
 	}
-	connCtx, cancel := context.WithCancel(server.Context())
-	o := &connection{cancel: cancel, id: p.Addr.String(), server: server}
+	o := &connection{
+		id:          p.Addr.String(),
+		server:      server,
+		sendTimeout: ic.SendTimeout,
+		barrier:     make(chan struct{}, 1),
+	}
 	ic.log.Info("client subscribed", "id", o.ID())
-	ic.informers.Subscribe(o)
-	// Keep the connection open
-	<-connCtx.Done()
+
+	go ic.informers.Subscribe(o)
+
+	o.watchForActiveConnection()
+
+	// canceling the context in case the client disconnected due to timeout
+	ic.ssi.closeConnection(o.ID())
 	ic.log.Info("client disconnected", "id", o.ID())
 	ic.informers.Unsubscribe(o)
 	return nil
@@ -91,34 +138,53 @@ func (ic *InformersCache) Subscribe(_ *informer.SubscribeMessage, server informe
 // connection implements the meta.Observer pattern to store the handle to
 // each client connection subscription
 type connection struct {
-	cancel func()
 	id     string
 	server grpc.ServerStreamingServer[informer.Event]
+
+	sendTimeout time.Duration
+	barrier     chan struct{}
 }
 
 func (o *connection) ID() string {
 	return o.id
 }
 
-func (o *connection) On(event *informer.Event) error {
-	// Theoretically Go is ready to run hundreds of thousands of parallel goroutines
-	// TODO: if one goroutine per message is too much CPU, find another formula to cancel if a client is not responding
-	done := make(chan error, 1)
-	go func() {
-		if err := o.server.Send(event); err != nil {
-			slog.Debug("sending message. Closing client connection", "clientID", o.ID(), "error", err)
-			o.cancel()
-			done <- err
+// watchForActiveConnection is a blocking function that waits for the client to
+// finish its connection. It also unblocks the connection if a timeout
+// is detected for the gRPC Send method (this method uses barriers to coordinate the
+// submission of messages with the On(...) method).
+func (o *connection) watchForActiveConnection() {
+	for {
+		// wait for On(...) to be called
+		select {
+		case <-o.server.Context().Done():
+			// client disconnected. Exiting
+			return
+		case <-o.barrier:
+			// On(...) started. Continue
 		}
-		close(done)
-	}()
-	timeout := time.After(sendTimeout)
-	select {
-	case err := <-done:
-		// might be just nil if the connection succeeded
-		return err
-	case <-timeout:
-		o.cancel()
-		return errors.New("timeout sending message to client. Closing connection " + o.ID())
+
+		// wait for On(...) to finish, or a timeout
+		select {
+		case <-o.server.Context().Done():
+			// client disconnected. Exiting
+			return
+		case <-time.After(o.sendTimeout):
+			// timeout! exit to cancel the connection
+			return
+		case <-o.barrier:
+			// On(...) finished. Continue
+		}
 	}
+}
+
+func (o *connection) On(event *informer.Event) error {
+	o.barrier <- struct{}{}
+	err := o.server.Send(event)
+	if err != nil {
+		slog.Debug("sending message. Closing client connection", "clientID", o.ID(), "error", err)
+		return err
+	}
+	o.barrier <- struct{}{}
+	return nil
 }


### PR DESCRIPTION
previous mechanism for client cancellation was relying on one goroutine per each client message. While performance was kept in acceptable bounds, it caused some peaks of CPU and memory when big deployments reported changes.

This new solution just uses a single goroutine per client connection.

Unit tests are added to verify the validity of the solution.