### PR TITLE
Asynchronous synchronization of Beyla cache

### DIFF
--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -21,8 +21,6 @@ import (
 
 const (
 	kubeConfigEnvVariable = "KUBECONFIG"
-	defaultResyncTime     = 30 * time.Minute
-	defaultSyncTimeout    = 60 * time.Second
 )
 
 func klog() *slog.Logger {
@@ -48,14 +46,7 @@ type MetadataProvider struct {
 }
 
 func NewMetadataProvider(config MetadataConfig) *MetadataProvider {
-	if config.SyncTimeout == 0 {
-		config.SyncTimeout = defaultSyncTimeout
-	}
-	if config.ResyncPeriod == 0 {
-		config.ResyncPeriod = defaultResyncTime
-	}
-	mp := &MetadataProvider{cfg: &config}
-	return mp
+	return &MetadataProvider{cfg: &config}
 }
 
 func (mp *MetadataProvider) IsKubeEnabled() bool {
@@ -168,27 +159,19 @@ func (mp *MetadataProvider) CurrentNodeName(ctx context.Context) (string, error)
 // for getting informer data
 func (mp *MetadataProvider) initLocalInformers(ctx context.Context) (*meta.Informers, error) {
 	done := make(chan error)
-	var informers *meta.Informers
-	go func() {
-		var err error
-		opts := append(disabledInformerOpts(mp.cfg.DisabledInformers),
-			meta.WithResyncPeriod(mp.cfg.ResyncPeriod),
-			meta.WithKubeConfigPath(mp.cfg.KubeConfigPath))
-		if informers, err = meta.InitInformers(ctx, opts...); err != nil {
-			done <- err
-		}
-		close(done)
-	}()
-
-	select {
-	case <-time.After(mp.cfg.SyncTimeout):
-		klog().Warn("kubernetes cache has not been synced after timeout. The kubernetes attributes might be incomplete."+
-			" Consider increasing the BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT value", "timeout", mp.cfg.SyncTimeout)
-	case err, ok := <-done:
-		if ok {
-			return nil, fmt.Errorf("failed to initialize Kubernetes informers: %w", err)
-		}
+	opts := append(disabledInformerOpts(mp.cfg.DisabledInformers),
+		meta.WithResyncPeriod(mp.cfg.ResyncPeriod),
+		meta.WithKubeConfigPath(mp.cfg.KubeConfigPath),
+		// we don't want that the informer starts decorating spans and flows
+		// before getting all the existing K8s metadata
+		meta.WaitForCacheSync(),
+		meta.WithCacheSyncTimeout(mp.cfg.SyncTimeout),
+	)
+	informers, err := meta.InitInformers(ctx, opts...)
+	if err != nil {
+		done <- err
 	}
+	close(done)
 	return informers, nil
 }
 

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -158,7 +158,6 @@ func (mp *MetadataProvider) CurrentNodeName(ctx context.Context) (string, error)
 // initLocalInformers initializes an informer client that directly connects to the Node Kube API
 // for getting informer data
 func (mp *MetadataProvider) initLocalInformers(ctx context.Context) (*meta.Informers, error) {
-	done := make(chan error)
 	opts := append(disabledInformerOpts(mp.cfg.DisabledInformers),
 		meta.WithResyncPeriod(mp.cfg.ResyncPeriod),
 		meta.WithKubeConfigPath(mp.cfg.KubeConfigPath),
@@ -167,12 +166,7 @@ func (mp *MetadataProvider) initLocalInformers(ctx context.Context) (*meta.Infor
 		meta.WaitForCacheSync(),
 		meta.WithCacheSyncTimeout(mp.cfg.SyncTimeout),
 	)
-	informers, err := meta.InitInformers(ctx, opts...)
-	if err != nil {
-		done <- err
-	}
-	close(done)
-	return informers, nil
+	return meta.InitInformers(ctx, opts...)
 }
 
 // initRemoteInformerCacheClient connects via gRPC/Protobuf to a remote beyla-k8s-cache service, to avoid that

--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -18,6 +18,8 @@ type Informers struct {
 	pods     cache.SharedIndexInformer
 	nodes    cache.SharedIndexInformer
 	services cache.SharedIndexInformer
+
+	waitForSync chan struct{}
 }
 
 func (inf *Informers) Subscribe(observer Observer) {
@@ -57,6 +59,10 @@ func (inf *Informers) Subscribe(observer Observer) {
 			}
 		}
 	}
+
+	// until the informer waitForSync, we won't send the sync_finished event to remote beyla clients
+	<-inf.waitForSync
+
 	// notify the end of synchronization, so the client knows that already has a snapshot
 	// of all the existing resources
 	if err := observer.On(&informer.Event{

--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -61,15 +61,24 @@ func (inf *Informers) Subscribe(observer Observer) {
 	}
 
 	// until the informer waitForSync, we won't send the sync_finished event to remote beyla clients
-	<-inf.waitForSync
+	// TODO: in some very slowed-down environments (e.g. tests with -race conditions), this last message might
+	// be sent and executed before the rest of previous updates have been processed and submitted.
+	// In production, it might mean that few initialization updates are sent right before the "sync_finished" signal.
+	// To fix that we should rearchitecture this to not directly invoking the notifications but enqueuing them
+	// in a synchronized list.
+	// Given the amount of work and complexity, we can afford this small delay, as the data eventually
+	// reaches the client right after the sync_finished signal.
+	go func() {
+		<-inf.waitForSync
 
-	// notify the end of synchronization, so the client knows that already has a snapshot
-	// of all the existing resources
-	if err := observer.On(&informer.Event{
-		Type: informer.EventType_SYNC_FINISHED,
-	}); err != nil {
-		inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
-		inf.BaseNotifier.Unsubscribe(observer)
-		return
-	}
+		// notify the end of synchronization, so the client knows that already has a snapshot
+		// of all the existing resources
+		if err := observer.On(&informer.Event{
+			Type: informer.EventType_SYNC_FINISHED,
+		}); err != nil {
+			inf.log.Debug("error notifying observer. Unsubscribing", "observerID", observer.ID(), "error", err)
+			inf.BaseNotifier.Unsubscribe(observer)
+			return
+		}
+	}()
 }

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -134,22 +134,26 @@ func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, err
 		}
 	}
 
-	svc.log.Debug("starting kubernetes informers, waiting for syncronization")
+	svc.log.Debug("starting kubernetes informers")
 	informerFactory.Start(ctx.Done())
 	go func() {
+		svc.log.Debug("waiting for informers' syncronization")
 		informerFactory.WaitForCacheSync(ctx.Done())
+		svc.log.Debug("informers synchronized")
 		close(svc.waitForSync)
 	}()
 	if config.waitCacheSync {
 		select {
 		case <-svc.waitForSync:
-			svc.log.Debug("kubernetes informers started")
+			// continue
 		case <-time.After(config.cacheSyncTimeout):
 			svc.log.Warn("Kubernetes cache has not been synced after timeout."+
 				" The Kubernetes attributes might be incomplete during an initial period."+
 				" Consider increasing the BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT value", "timeout", config.cacheSyncTimeout)
 		}
 	}
+	svc.log.Debug("kubernetes informers started")
+
 	return svc, nil
 
 }

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -32,6 +32,7 @@ const (
 	defaultResyncTime     = 30 * time.Minute
 	EnvServiceName        = "OTEL_SERVICE_NAME"
 	EnvResourceAttrs      = "OTEL_RESOURCE_ATTRIBUTES"
+	defaultSyncTimeout    = 60 * time.Second
 )
 
 var usefulEnvVars = map[string]struct{}{EnvServiceName: {}, EnvResourceAttrs: {}}
@@ -41,6 +42,10 @@ type informersConfig struct {
 	resyncPeriod    time.Duration
 	disableNodes    bool
 	disableServices bool
+
+	// waits for cache synchronization at start
+	waitCacheSync    bool
+	cacheSyncTimeout time.Duration
 
 	kubeClient kubernetes.Interface
 }
@@ -80,13 +85,27 @@ func WithKubeClient(client kubernetes.Interface) InformerOption {
 	}
 }
 
-func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, error) {
-	config := &informersConfig{resyncPeriod: defaultResyncTime}
-	for _, opt := range opts {
-		opt(config)
+func WaitForCacheSync() InformerOption {
+	return func(c *informersConfig) {
+		c.waitCacheSync = true
 	}
+}
+
+func WithCacheSyncTimeout(to time.Duration) InformerOption {
+	return func(config *informersConfig) {
+		config.cacheSyncTimeout = to
+	}
+}
+
+func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, error) {
+	config := initConfigOpts(opts)
 	log := slog.With("component", "kube.Informers")
-	k := &Informers{log: log, config: config, BaseNotifier: NewBaseNotifier(log)}
+	svc := &Informers{
+		log:          log,
+		config:       config,
+		BaseNotifier: NewBaseNotifier(log),
+		waitForSync:  make(chan struct{}),
+	}
 
 	if config.kubeClient == nil {
 		kubeCfg, err := loadKubeconfig(config.kubeConfigPath)
@@ -99,28 +118,54 @@ func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, err
 		}
 	}
 
-	informerFactory := informers.NewSharedInformerFactory(config.kubeClient, config.resyncPeriod)
+	informerFactory := informers.NewSharedInformerFactory(svc.config.kubeClient, svc.config.resyncPeriod)
 
-	if err := k.initPodInformer(informerFactory); err != nil {
+	if err := svc.initPodInformer(informerFactory); err != nil {
 		return nil, err
 	}
-	if !config.disableNodes {
-		if err := k.initNodeIPInformer(informerFactory); err != nil {
+	if !svc.config.disableNodes {
+		if err := svc.initNodeIPInformer(informerFactory); err != nil {
 			return nil, err
 		}
 	}
-	if !config.disableServices {
-		if err := k.initServiceIPInformer(informerFactory); err != nil {
+	if !svc.config.disableServices {
+		if err := svc.initServiceIPInformer(informerFactory); err != nil {
 			return nil, err
 		}
 	}
 
-	k.log.Debug("starting kubernetes informers, waiting for syncronization")
+	svc.log.Debug("starting kubernetes informers, waiting for syncronization")
 	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	k.log.Debug("kubernetes informers started")
-	return k, nil
+	go func() {
+		informerFactory.WaitForCacheSync(ctx.Done())
+		close(svc.waitForSync)
+	}()
+	if config.waitCacheSync {
+		select {
+		case <-svc.waitForSync:
+			svc.log.Debug("kubernetes informers started")
+		case <-time.After(config.cacheSyncTimeout):
+			svc.log.Warn("Kubernetes cache has not been synced after timeout."+
+				" The Kubernetes attributes might be incomplete during an initial period."+
+				" Consider increasing the BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT value", "timeout", config.cacheSyncTimeout)
+		}
+	}
+	return svc, nil
 
+}
+
+func initConfigOpts(opts []InformerOption) *informersConfig {
+	config := &informersConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+	if config.cacheSyncTimeout == 0 {
+		config.cacheSyncTimeout = defaultSyncTimeout
+	}
+	if config.resyncPeriod == 0 {
+		config.resyncPeriod = defaultResyncTime
+	}
+	return config
 }
 
 func loadKubeconfig(kubeConfigPath string) (*rest.Config, error) {


### PR DESCRIPTION
Alleviates the following issues: https://github.com/grafana/beyla/issues/1349 and https://github.com/grafana/beyla/issues/1354

The Beyla cache service was not accepting connections before it had a complete copy of the Kubernetes cache.

In big clusters (~1000 nodes) that meant that each cache instance would take some minutes to completely initialize, and beyla instances would keep reporting errors.

This PR enables the service as soon as the process start, and keeps accepting Beyla connections while the cache is still synchronizing, making sure that the Beyla clients won't receive the synchronization signal until the cache service is fully synchronized.
