### PR TITLE
Some informer optimizations

### DIFF
--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -50,6 +50,10 @@ func (inf *Informers) Subscribe(observer Observer) {
 	}
 	if !inf.config.disableServices {
 		for _, service := range inf.services.GetStore().List() {
+			// ignore headless services from being added
+			if headlessService(service.(*indexableEntity).EncodedMeta) {
+				return
+			}
 			if err := observer.On(&informer.Event{
 				Type:     informer.EventType_CREATED,
 				Resource: service.(*indexableEntity).EncodedMeta,

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -21,6 +21,7 @@ import (
 )
 
 const defaultSendTimeout = 10 * time.Second
+const barrierBufferLen = 10
 
 // InformersCache configures and starts the gRPC service
 type InformersCache struct {
@@ -125,7 +126,7 @@ func (ic *InformersCache) Subscribe(_ *informer.SubscribeMessage, server informe
 		id:          connectionID,
 		server:      server,
 		sendTimeout: ic.SendTimeout,
-		barrier:     make(chan struct{}, 1),
+		barrier:     make(chan struct{}, barrierBufferLen),
 	}
 	o.log.Info("client subscribed")
 


### PR DESCRIPTION
Removes some messages that were flooding debug log.

Prevents forwarding headless services to the client.

Slightly optimizes the informers' storage.