### PR TITLE
Use scratch to build Beyla images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY third_party_licenses.csv third_party_licenses.csv
 RUN make compile
 
 # Create final image from minimal + built binary
-FROM debian:bookworm-slim
+FROM scratch
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"
 
@@ -41,7 +41,5 @@ COPY --from=builder /opt/app-root/NOTICE .
 COPY --from=builder /opt/app-root/third_party_licenses.csv .
 
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-
-USER 0:0
 
 ENTRYPOINT [ "/beyla" ]


### PR DESCRIPTION
It looks like using debian to build images for Beyla has problems with vulnerabilities.
We are trying `scratch` to build the images.