### PR TITLE
Use scratch for the rest of Beyla images

### DIFF
--- a/k8scache.Dockerfile
+++ b/k8scache.Dockerfile
@@ -22,7 +22,7 @@ COPY .git/ .git/
 RUN make compile-cache
 
 # Create final image from minimal + built binary
-FROM debian:bookworm-slim
+FROM scratch
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"
 
@@ -32,7 +32,5 @@ COPY --from=builder /opt/app-root/bin/k8s-cache .
 COPY --from=builder /opt/app-root/LICENSE .
 COPY --from=builder /opt/app-root/NOTICE .
 COPY --from=builder /opt/app-root/third_party_licenses.csv .
-
-USER 0:0
 
 ENTRYPOINT [ "/k8s-cache" ]

--- a/test/integration/components/beyla-k8s-cache/Dockerfile
+++ b/test/integration/components/beyla-k8s-cache/Dockerfile
@@ -23,10 +23,9 @@ COPY Makefile Makefile
 RUN make compile-cache-for-coverage
 
 # Create final image from minimal + built binary
-FROM debian:bookworm-slim
+FROM scratch
 
 WORKDIR /
 COPY --from=builder /src/bin/k8s-cache .
-USER 0:0
 
 ENTRYPOINT [ "/k8s-cache" ]

--- a/test/integration/components/beyla/Dockerfile
+++ b/test/integration/components/beyla/Dockerfile
@@ -23,10 +23,9 @@ COPY Makefile Makefile
 RUN make compile-for-coverage
 
 # Create final image from minimal + built binary
-FROM debian:bookworm-slim
+FROM scratch
 
 WORKDIR /
 COPY --from=builder /src/bin/beyla .
-USER 0:0
 
 ENTRYPOINT [ "/beyla" ]

--- a/test/integration/components/beyla/Dockerfile_dbg
+++ b/test/integration/components/beyla/Dockerfile_dbg
@@ -26,13 +26,12 @@ COPY Makefile Makefile
 # Build
 RUN make compile-for-coverage
 
-FROM debian:bookworm-slim
+FROM scratch
 
 # Copy the native executable into the containers
 COPY --from=builder /src/bin/beyla /beyla
 COPY --from=builder /beyla_wrapper.sh /beyla_wrapper.sh
 
 WORKDIR /
-USER 0:0
 
 ENTRYPOINT [ "/beyla_wrapper.sh" ]


### PR DESCRIPTION
Use `scratch` build container for the rest of Dockerfiles that builds Beyla or Beyla k8s cache.