### PR TITLE
Helm chart: removed unneeded exposed port from Cache Service

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.4.13
+version: 1.4.14
 appVersion: 1.8.8
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.4.13](https://img.shields.io/badge/Version-1.4.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.8](https://img.shields.io/badge/AppVersion-1.8.8-informational?style=flat-square)
+![Version: 1.4.14](https://img.shields.io/badge/Version-1.4.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.8](https://img.shields.io/badge/AppVersion-1.8.8-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 

--- a/charts/beyla/templates/cache-service.yaml
+++ b/charts/beyla/templates/cache-service.yaml
@@ -21,12 +21,6 @@ spec:
       protocol: TCP
       targetPort: grpc
       name: grpc
-{{ if .Values.k8sCache.internalMetrics.port }}
-    - port: {{ .Values.k8sCache.internalMetrics.port }}
-      targetPort: {{ .Values.k8sCache.internalMetrics.portName }}
-      name: {{ .Values.k8sCache.internalMetrics.portName }}
-      protocol: TCP
-{{- end }}
   selector:
     app.kubernetes.io/name: {{ .Values.k8sCache.service.name }}
 {{- end }}


### PR DESCRIPTION
Copilot cheated me 😖

To scrape Beyla cache instances we just need to expose the port on each scrapable Pod, not in the service.