### PR TITLE
Helm chart 1.5.0

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.4.14
-appVersion: 1.8.8
+version: 1.5.0
+appVersion: 1.9.0
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.4.14](https://img.shields.io/badge/Version-1.4.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.8](https://img.shields.io/badge/AppVersion-1.8.8-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 


### PR DESCRIPTION
After releasing Beyla 1.9 and merging this change in the Helm chart: https://github.com/grafana/beyla/pull/1273, we need to update the Helm version and rebuild the docs.