### PR TITLE
Stop flooding WARNING logs with 'couldn't delete flow entry'

### DIFF
--- a/pkg/internal/netolly/ebpf/sock_tracer.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer.go
@@ -187,7 +187,7 @@ func (m *SockFlowFetcher) LookupAndDeleteMap() map[NetFlowId][]NetFlowMetrics {
 	// TODO: detect whether LookupAndDelete is supported (Kernel>=4.20) and use it selectively
 	for iterator.Next(&id, &metrics) {
 		if err := flowMap.Delete(id); err != nil {
-			tlog().Warn("couldn't delete flow entry", "flowId", id)
+			tlog().Debug("couldn't delete flow entry", "flowId", id, "error", err)
 		}
 		// We observed that eBFP PerCPU map might insert multiple times the same key in the map
 		// (probably due to race conditions) so we need to re-join metrics again at userspace

--- a/pkg/internal/netolly/ebpf/tracer.go
+++ b/pkg/internal/netolly/ebpf/tracer.go
@@ -343,7 +343,7 @@ func (m *FlowFetcher) LookupAndDeleteMap() map[NetFlowId][]NetFlowMetrics {
 	// TODO: detect whether LookupAndDelete is supported (Kernel>=4.20) and use it selectively
 	for iterator.Next(&id, &metrics) {
 		if err := flowMap.Delete(id); err != nil {
-			tlog().Warn("couldn't delete flow entry", "flowId", id)
+			tlog().Debug("couldn't delete flow entry", "flowId", id, "error", err)
 		}
 		// We observed that eBFP PerCPU map might insert multiple times the same key in the map
 		// (probably due to race conditions) so we need to re-join metrics again at userspace


### PR DESCRIPTION
some pod logss are flooded with warnings like:
```
time=2024-11-25T15:02:55.048Z level=WARN msg="couldn't delete flow entry" component=ebpf.FlowFetcher flowId="{SrcIp:{In6U:{U6Addr8:[0 0 0 0 0 0 0 0 0 0 255 255 10 8 202 113]}} DstIp:{In6U:{U6Addr8:[0 0 0 0 0 0 0 0 0 0 255 255 10 8 19 21]}} EthProtocol:2048 SrcPort:36378 DstPort:9095 TransportProtocol:6 IfIndex:0}"
time=2024-11-25T15:03:15.012Z level=WARN msg="couldn't delete flow entry" component=ebpf.FlowFetcher flowId="{SrcIp:{In6U:{U6Addr8:[0 0 0 0 0 0 0 0 0 0 255 255 10 0 0 71]}} DstIp:{In6U:{U6Addr8:[0 0 0 0 0 0 0 0 0 0 255 255 10 8 89 13]}} EthProtocol:2048 SrcPort:47004 DstPort:9095 TransportProtocol:6 IfIndex:0}"
```
They don't really mean anything to the final user. I moved them to "debug".