### PR TITLE
Fix informers on stale object deletion

### DIFF
--- a/pkg/internal/goexec/instructions_test.go
+++ b/pkg/internal/goexec/instructions_test.go
@@ -1,3 +1,5 @@
+//go:build amd64
+
 package goexec
 
 import (


### PR DESCRIPTION
Some Beyla pods suddenly had an inusual memory generation, affecting also CPU due to constant garbage collections:

![image](https://github.com/user-attachments/assets/f9a60985-3f03-450e-98e3-cc2910a2b986)

At the time the memory and garbage collection started to go mad, there is a log message like this:
```
W1128 10:31:37.371693       1 reflector.go:462] k8s.io/client-go/informers/factory.go:159: watch of *v1.Pod ended with: very short watch: k8s.io/client-go/informers/factory.go:159: Unexpected watch close - watch lasted less than a second and no items received
```
Followed by many log messages like:
```
E1128 10:32:21.406329       1 reflector.go:147] k8s.io/client-go/informers/factory.go:159: Failed to watch *v1.Pod: unable to sync list result: was expecting a *v1.Pod. Got: cache.DeletedFinalStateUnknown
```

This PR handles the cache.DeletedFinalStateUnknown event to delete anyway the object that is associated to it.