### PR TITLE
fix flaky unit tests

### DIFF
--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -668,9 +668,10 @@ func TestTraceSampling(t *testing.T) {
 		}
 
 		receiver.processSpans(exporter, spans, attrs, sampler)
-		// The result is likely 0,1,2 with 1/10th, but we don't want
-		// to maybe fail if it accidentally it randomly becomes 3
-		assert.GreaterOrEqual(t, 3, len(tr))
+		// The result is likely 0,1,2 with 1/10th, but since sampling
+		// it's a probabilistic matter, we don't want this test to become
+		// flaky as some of them could report even 4-5 samples
+		assert.GreaterOrEqual(t, 6, len(tr))
 	})
 }
 

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -599,17 +599,14 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 
 	// expect to receive only the records matching the Filters criteria
 	events := map[string]map[string]string{}
-	var event collector.MetricRecord
-	test.Eventually(t, testTimeout, func(tt require.TestingT) {
-		event = testutil.ReadChannel(t, tc.Records(), testTimeout)
-		require.Equal(tt, "http.server.request.duration", event.Name)
-	})
-	events[event.Attributes["url.path"]] = event.Attributes
-	test.Eventually(t, testTimeout, func(tt require.TestingT) {
-		event = testutil.ReadChannel(t, tc.Records(), testTimeout)
-		require.Equal(tt, "http.server.request.duration", event.Name)
-	})
-	events[event.Attributes["url.path"]] = event.Attributes
+	for i := 0; i < 10; i++ {
+		var event collector.MetricRecord
+		test.Eventually(t, testTimeout, func(tt require.TestingT) {
+			event = testutil.ReadChannel(t, tc.Records(), testTimeout)
+			require.Equal(tt, "http.server.request.duration", event.Name)
+		})
+		events[event.Attributes["url.path"]] = event.Attributes
+	}
 
 	assert.Equal(t, map[string]map[string]string{
 		"/user/1234": {


### PR DESCRIPTION
There is still a small chance that `TestTraceSampling` fails, as it's just a probabilistic matter. But should greatly reduce the frequency of failure.

Also fixes `TestSpanAttributeFilterNode`, which wrongly assumed that two consecutive metric reports would belong to different entities.