### PR TITLE
Correct documentation of routes default behavior

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -706,7 +706,7 @@ Higher values reduce the load on the Kubernetes API service.
 YAML section `routes`.
 
 This section can be only configured via the YAML file. If no `routes` section is provided in
-the YAML file, a default routes' pipeline stage will be created and filtered with the `wildcard`
+the YAML file, a default routes' pipeline stage will be created and filtered with the `heuristic`
 routes decorator.
 
 | YAML       | Environment variable | Type            | Default |

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -117,7 +117,7 @@ var DefaultConfig = Config{
 			FetchTimeout: 500 * time.Millisecond,
 		},
 	},
-	Routes:       &transform.RoutesConfig{Unmatch: transform.UnmatchHeuristic},
+	Routes:       &transform.RoutesConfig{Unmatch: transform.UnmatchDefault},
 	NetworkFlows: defaultNetworkConfig,
 	Processes: process.CollectConfig{
 		RunMode:  process.RunModePrivileged,

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -23,7 +23,7 @@ const (
 	// UnmatchHeuristic detects the route field using a heuristic
 	UnmatchHeuristic = UnmatchType("heuristic")
 
-	UnmatchDefault = UnmatchWildcard
+	UnmatchDefault = UnmatchHeuristic
 )
 
 type IgnoreMode string


### PR DESCRIPTION
In a part of the docs it still says that `wildcard` is the default.

Our own code was also misleading.