### PR TITLE
Fix missing check for ignored metrics for Prometheus export

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -584,7 +584,7 @@ func (r *metricsReporter) otelSpanObserved(span *request.Span) bool {
 
 // nolint:cyclop
 func (r *metricsReporter) observe(span *request.Span) {
-	if span.InternalSignal() {
+	if span.InternalSignal() || span.IgnoreMetrics() {
 		return
 	}
 	t := span.Timings()

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -582,9 +582,13 @@ func (r *metricsReporter) otelSpanObserved(span *request.Span) bool {
 	return r.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetrics()
 }
 
+func (r *metricsReporter) otelSpanFiltered(span *request.Span) bool {
+	return span.InternalSignal() || span.IgnoreMetrics()
+}
+
 // nolint:cyclop
 func (r *metricsReporter) observe(span *request.Span) {
-	if span.InternalSignal() || span.IgnoreMetrics() {
+	if r.otelSpanFiltered(span) {
 		return
 	}
 	t := span.Timings()

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -316,31 +316,45 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	svcExportTraces := svc.Attrs{}
 	svcExportTraces.SetExportsOTelTraces()
 
+	ignoredSpan := request.Span{Service: svcExportTraces, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200}
+	ignoredSpan.SetIgnoreMetrics()
+
 	tests := []struct {
 		name      string
 		span      request.Span
 		discarded bool
+		filtered  bool
 	}{
 		{
 			name:      "Foo span is not filtered",
 			span:      request.Span{Service: svcNoExport, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/foo", RequestStart: 100, End: 200},
 			discarded: false,
+			filtered:  false,
 		},
 		{
 			name:      "/v1/metrics span is filtered",
 			span:      request.Span{Service: svcExportMetrics, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/metrics", RequestStart: 100, End: 200},
 			discarded: true,
+			filtered:  false,
+		},
+		{
+			name:      "/v1/traces span is filtered because we ignore this span",
+			span:      ignoredSpan,
+			discarded: false,
+			filtered:  true,
 		},
 		{
 			name:      "/v1/traces span is not filtered",
 			span:      request.Span{Service: svcExportTraces, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200},
 			discarded: false,
+			filtered:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.discarded, !mr.otelSpanObserved(&tt.span), tt.name)
+			assert.Equal(t, tt.discarded, !(mr.otelSpanObserved(&tt.span)), tt.name)
+			assert.Equal(t, tt.filtered, mr.otelSpanFiltered(&tt.span), tt.name)
 		})
 	}
 }


### PR DESCRIPTION
Our prometheus export loop didn't check the filtering setup in the config, the OTel loop does.

Closes https://github.com/grafana/beyla/issues/1435

I'll back-port this to 1.9 and 1.8