### PR TITLE
Fix missing service info

### DIFF
--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -344,10 +344,6 @@ func (s *Store) ServiceNameNamespaceForIP(ip string) (string, string) {
 	s.access.Lock()
 	defer s.access.Unlock()
 
-	if serviceInfo, ok := s.otelServiceInfoByIP[ip]; ok {
-		return serviceInfo.Name, serviceInfo.Namespace
-	}
-
 	name, namespace := "", ""
 	if om, ok := s.objectMetaByIP[ip]; ok {
 		name, namespace = s.serviceNameNamespaceForMetadata(om)

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -339,16 +339,21 @@ func (s *Store) ServiceNameNamespaceForIP(ip string) (string, string) {
 		s.access.RUnlock()
 		return serviceInfo.Name, serviceInfo.Namespace
 	}
+	s.access.RUnlock()
+
+	s.access.Lock()
+	defer s.access.Unlock()
+
+	if serviceInfo, ok := s.otelServiceInfoByIP[ip]; ok {
+		return serviceInfo.Name, serviceInfo.Namespace
+	}
 
 	name, namespace := "", ""
 	if om, ok := s.objectMetaByIP[ip]; ok {
 		name, namespace = s.serviceNameNamespaceForMetadata(om)
 	}
-	s.access.RUnlock()
 
-	s.access.Lock()
 	s.otelServiceInfoByIP[ip] = OTelServiceNamePair{Name: name, Namespace: namespace}
-	s.access.Unlock()
 
 	return name, namespace
 }

--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -52,7 +52,7 @@ func (inf *Informers) Subscribe(observer Observer) {
 		for _, service := range inf.services.GetStore().List() {
 			// ignore headless services from being added
 			if headlessService(service.(*indexableEntity).EncodedMeta) {
-				return
+				continue
 			}
 			if err := observer.On(&informer.Event{
 				Type:     informer.EventType_CREATED,


### PR DESCRIPTION
This PR fixes two bugs in the k8s service discovery:

1. We had an early return in the loop that lists services, instead of a continue on a headless service.
2. While eyeballing the code when looking for the bug, we noticed a slight timing hole with the cache, which was unlikely the culprit but it's good to fix.

Closes https://github.com/grafana/beyla/issues/933
Closes https://github.com/grafana/beyla/issues/1426

I'll backport this to 1.9