### PR TITLE
Kafka server spans shouldn't be producers and consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,9 @@ compile-cache:
 	@echo "### Compiling Beyla K8s cache"
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -ldflags="-X '$(BUILDINFO_PKG).Version=$(RELEASE_VERSION)' -X '$(BUILDINFO_PKG).Revision=$(RELEASE_REVISION)'" -a -o bin/$(CACHE_CMD) $(CACHE_MAIN_GO_FILE)
 
+.PHONY: debug
+debug:
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod vendor -gcflags "-N -l" -ldflags="-X '$(BUILDINFO_PKG).Version=$(RELEASE_VERSION)' -X '$(BUILDINFO_PKG).Revision=$(RELEASE_REVISION)'" -a -o bin/$(CMD) $(MAIN_GO_FILE)
 
 .PHONY: dev
 dev: prereqs generate compile-for-coverage

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -672,11 +672,11 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 
 func spanKind(span *request.Span) trace2.SpanKind {
 	switch span.Type {
-	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer:
+	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer:
 		return trace2.SpanKindServer
 	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient:
 		return trace2.SpanKindClient
-	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
+	case request.EventTypeKafkaClient:
 		switch span.Method {
 		case request.MessagingPublish:
 			return trace2.SpanKindProducer


### PR DESCRIPTION
We were marking Kafka server spans the same as client spans, so if Kafka itself was monitored we might be getting confusing spans in Tempo. This PR changes the kafka server spans to be server, rather than client.

Relates to https://github.com/grafana/beyla/issues/1423