### PR TITLE
allow restricting Kube metadata to local node only (#1440)

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         go: [ '1.23' ]

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         go: [ '1.23' ]

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -681,6 +681,17 @@ reduces the load of the Kubernetes API.
 The Pods informer can't be disabled. For that purpose, you should disable the whole
 Kubernetes metadata decoration.
 
+| YAML                       | Environment variable                  | Type    | Default |
+|----------------------------|---------------------------------------|---------|---------|
+| `meta_restrict_local_node` | `BEYLA_KUBE_META_RESTRICT_LOCAL_NODE` | boolean | false   |
+
+If true, Beyla stores Pod and Node metadata only from the node where the Beyla instance is running.
+
+This option decreases the memory used to store the metadata, but some metrics
+(such as network bytes or service graph metrics) would miss the metadata from destination
+pods that are located in a different node.
+
+
 | YAML                     | Environment variable                | Type     | Default |
 |--------------------------|-------------------------------------|----------|---------|
 | `informers_sync_timeout` | `BEYLA_KUBE_INFORMERS_SYNC_TIMEOUT` | Duration | 30s     |

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -114,6 +114,7 @@ func buildCommonContextInfo(
 			DisabledInformers: config.Attributes.Kubernetes.DisableInformers,
 			MetaCacheAddr:     config.Attributes.Kubernetes.MetaCacheAddress,
 			MetaSourceLabels:  config.Attributes.Kubernetes.MetaSourceLabels,
+			RestrictLocalNode: config.Attributes.Kubernetes.MetaRestrictLocalNode,
 		}),
 	}
 	switch {

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -49,6 +49,10 @@ type KubernetesDecorator struct {
 	// MetaCacheAddress is the host:port address of the beyla-k8s-cache service instance
 	MetaCacheAddress string `yaml:"meta_cache_address" env:"BEYLA_KUBE_META_CACHE_ADDRESS"`
 
+	// MetaRestrictLocalNode will download only the metadata from the Pods that are located in the same
+	// node as the Beyla instance. It will also restrict the Node information to the local node.
+	MetaRestrictLocalNode bool `yaml:"meta_restrict_local_node" env:"BEYLA_KUBE_META_RESTRICT_LOCAL_NODE"`
+
 	// MetaSourceLabels allows Beyla overriding the service name and namespace of an application from
 	// the given labels.
 	// TODO Beyla 2.0. Consider defaulting to (and report as a breaking change):

--- a/test/integration/k8s/manifests/02-prometheus-otelscrape.yml
+++ b/test/integration/k8s/manifests/02-prometheus-otelscrape.yml
@@ -25,7 +25,7 @@ spec:
     - name: prometheus
       image: quay.io/prometheus/prometheus:v2.53.0
       args:
-        - --storage.tsdb.retention.time=1m
+        - --storage.tsdb.retention.time=10m
         - --config.file=/etc/prometheus/prometheus-config.yml
         - --storage.tsdb.path=/prometheus
         - --web.enable-lifecycle

--- a/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
@@ -1,0 +1,112 @@
+# this file depends in the annotations and 00-kind-multi-node.yml to deploy a otherinstance
+# and a client in different nodes.
+# Beyla will instrument both, but restricting the metadata only to the local node,
+# so network flows between client and otherinstance would be incomplete
+apiVersion: v1
+kind: Pod
+metadata:
+  name: httppinger
+  labels:
+    component: httppinger
+    # this label will trigger a deletion of beyla pods before tearing down
+    # kind, to force Beyla writing the coverage data
+    teardown: delete
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: deployment/zone
+                operator: In
+                values:
+                  - other-progs
+  volumes:
+    - name: configs
+      persistentVolumeClaim:
+        claimName: configs
+    - name: testoutput
+      persistentVolumeClaim:
+        claimName: testoutput
+    - name: maincode
+      configMap:
+        name: maincode
+  containers:
+    - name: httppinger
+      image: httppinger:dev
+      env:
+        - name: TARGET_URL
+          value: "http://otherinstance:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otherinstance
+spec:
+  selector:
+    app: otherinstance
+  ports:
+    - port: 8080
+      name: http0
+      targetPort: http0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherinstance
+  labels:
+    app: otherinstance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otherinstance
+  template:
+    metadata:
+      name: otherinstance
+      labels:
+        app: otherinstance
+        # this label will trigger a deletion of beyla pods before tearing down
+        # kind, to force Beyla writing the coverage data
+        teardown: delete
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: deployment/zone
+                    operator: In
+                    values:
+                      - otel
+      volumes:
+        - name: configs
+          persistentVolumeClaim:
+            claimName: configs
+        - name: testoutput
+          persistentVolumeClaim:
+            claimName: testoutput
+      containers:
+        - name: otherinstance
+          image: testserver:dev
+          imagePullPolicy: Never # loaded into Kind from localhost
+          ports:
+            # exposing hostports to enable operation from tests
+            - containerPort: 8080
+              hostPort: 8080
+              name: http0
+            - containerPort: 8081
+              hostPort: 8081
+              name: http1
+            - containerPort: 8082
+              hostPort: 8082
+              name: http2
+            - containerPort: 8083
+              hostPort: 8083
+              name: http3
+            - containerPort: 5051
+              hostPort: 5051
+              name: grpc
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"

--- a/test/integration/k8s/manifests/06-beyla-netolly.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly.yml
@@ -80,3 +80,7 @@ spec:
               value: "10ms"
             - name: BEYLA_BPF_BATCH_TIMEOUT
               value: "10ms"
+            # in tests not running on multi-node Kind setups, this property
+            # should have no effect
+            - name: BEYLA_KUBE_META_RESTRICT_LOCAL_NODE
+              value: "true"

--- a/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -22,7 +22,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -35,7 +34,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
 		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
 		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),

--- a/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -1,0 +1,88 @@
+//go:build integration_k8s
+
+package otel
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/beyla/test/integration/components/docker"
+	"github.com/grafana/beyla/test/integration/components/kube"
+	"github.com/grafana/beyla/test/integration/components/prom"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/tools"
+)
+
+const (
+	prometheusHostPort = "localhost:39090"
+	testTimeout        = 3 * time.Minute
+)
+
+var cluster *kube.Kind
+
+func TestMain(m *testing.M) {
+	if err := docker.Build(os.Stdout, tools.ProjectDir(),
+		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
+		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
+		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
+		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
+		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
+	); err != nil {
+		slog.Error("can't build docker images", "error", err)
+		os.Exit(-1)
+	}
+
+	cluster = kube.NewKind("test-kind-cluster-otel-multi",
+		kube.ExportLogs(k8s.PathKindLogs),
+		kube.KindConfig(k8s.PathManifests+"/00-kind-multi-node.yml"),
+		kube.LocalImage("testserver:dev"),
+		kube.LocalImage("httppinger:dev"),
+		kube.LocalImage("beyla:dev"),
+		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
+		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
+		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
+		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
+		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape-multi-node.yml"),
+		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
+		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-server-client-different-nodes.yml"),
+		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly.yml"),
+	)
+
+	cluster.Run(m)
+}
+
+func TestNoSourceAndDestAvailable(t *testing.T) {
+	// Wait for some metrics available at Prometheus
+	pq := prom.Client{HostPort: prometheusHostPort}
+	for _, args := range []string{
+		`k8s_dst_name="httppinger"`,
+		`k8s_src_name="httppinger"`,
+		`k8s_dst_name=~"otherinstance.*"`,
+		`k8s_src_name=~"otherinstance.*"`,
+	} {
+		t.Run("check "+args, func(t *testing.T) {
+			test.Eventually(t, testTimeout, func(t require.TestingT) {
+				var err error
+				results, err := pq.Query(`beyla_network_flow_bytes_total{` + args + `}`)
+				require.NoError(t, err)
+				require.NotEmpty(t, results)
+			})
+		})
+	}
+
+	// Verify that HTTP pinger/testserver metrics can't have both source and destination labels,
+	// as the test client and server are in different nodes, and Beyla is only getting information
+	// from its local node
+	results, err := pq.Query(`beyla_network_flow_bytes_total{k8s_dst_name="httppinger",k8s_src_name=~"otherinstance.*",k8s_src_kind="Pod"}`)
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	results, err = pq.Query(`beyla_network_flow_bytes_total{k8s_src_name="httppinger",k8s_dst_name=~"otherinstance.*",k8s_dst_kind="Pod"}`)
+	require.NoError(t, err)
+	require.Empty(t, results)
+}


### PR DESCRIPTION
* allow restricting Kube metadata to local node only

* integration tests

* increase number of cores for test runners

* document new option

* added extra logging

* increased prometheus TSDB retention

* restore lower git action machines

(cherry picked from commit 3b31c2e0be030243e4f8ca73a61fcefbb0387ecd)