### PR TITLE
Integration tests: increase TSDB retention time of prometheus

### DIFF
--- a/test/integration/docker-compose-1.16.yml
+++ b/test/integration/docker-compose-1.16.yml
@@ -71,9 +71,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-1.17.yml
+++ b/test/integration/docker-compose-1.17.yml
@@ -76,9 +76,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-client.yml
+++ b/test/integration/docker-compose-client.yml
@@ -72,9 +72,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-dotnet.yml
+++ b/test/integration/docker-compose-dotnet.yml
@@ -74,9 +74,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-elixir.yml
+++ b/test/integration/docker-compose-elixir.yml
@@ -70,9 +70,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-go-otel-grpc.yml
+++ b/test/integration/docker-compose-go-otel-grpc.yml
@@ -76,9 +76,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config-promscrape.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-go-otel.yml
+++ b/test/integration/docker-compose-go-otel.yml
@@ -77,9 +77,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-grpc-http2-mux.yml
+++ b/test/integration/docker-compose-grpc-http2-mux.yml
@@ -92,9 +92,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config-promscrape.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-http2.yml
+++ b/test/integration/docker-compose-http2.yml
@@ -92,9 +92,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config-promscrape.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-java-host.yml
+++ b/test/integration/docker-compose-java-host.yml
@@ -68,9 +68,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-java-pid.yml
+++ b/test/integration/docker-compose-java-pid.yml
@@ -70,9 +70,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-java-system-wide.yml
+++ b/test/integration/docker-compose-java-system-wide.yml
@@ -83,9 +83,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-java.yml
+++ b/test/integration/docker-compose-java.yml
@@ -71,9 +71,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-multiexec-host.yml
+++ b/test/integration/docker-compose-multiexec-host.yml
@@ -176,9 +176,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
       - --log.level=debug

--- a/test/integration/docker-compose-multiexec.yml
+++ b/test/integration/docker-compose-multiexec.yml
@@ -174,9 +174,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
       - --log.level=debug

--- a/test/integration/docker-compose-netolly-direction.yml
+++ b/test/integration/docker-compose-netolly-direction.yml
@@ -75,9 +75,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-netolly.yml
+++ b/test/integration/docker-compose-netolly.yml
@@ -66,9 +66,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-nodeclient.yml
+++ b/test/integration/docker-compose-nodeclient.yml
@@ -77,9 +77,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-nodejs.yml
+++ b/test/integration/docker-compose-nodejs.yml
@@ -76,9 +76,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-other-grpc.yml
+++ b/test/integration/docker-compose-other-grpc.yml
@@ -91,9 +91,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-php-fpm-sock.yml
+++ b/test/integration/docker-compose-php-fpm-sock.yml
@@ -104,9 +104,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
       - --log.level=debug

--- a/test/integration/docker-compose-php-fpm.yml
+++ b/test/integration/docker-compose-php-fpm.yml
@@ -92,9 +92,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
       - --log.level=debug

--- a/test/integration/docker-compose-python-sql.yml
+++ b/test/integration/docker-compose-python-sql.yml
@@ -87,9 +87,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-python.yml
+++ b/test/integration/docker-compose-python.yml
@@ -73,9 +73,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-ruby.yml
+++ b/test/integration/docker-compose-ruby.yml
@@ -71,9 +71,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose-rust.yml
+++ b/test/integration/docker-compose-rust.yml
@@ -72,9 +72,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -82,9 +82,7 @@ services:
     image: quay.io/prometheus/prometheus:v2.53.0
     container_name: prometheus
     command:
-      - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
-      - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:

--- a/test/integration/k8s/manifests/02-prometheus-otelscrape-multi-node.yml
+++ b/test/integration/k8s/manifests/02-prometheus-otelscrape-multi-node.yml
@@ -34,9 +34,7 @@ spec:
     - name: prometheus
       image: quay.io/prometheus/prometheus:v2.53.0
       args:
-        - --storage.tsdb.retention.time=1m
         - --config.file=/etc/prometheus/prometheus-config.yml
-        - --storage.tsdb.path=/prometheus
         - --web.enable-lifecycle
         - --web.route-prefix=/
       volumeMounts:

--- a/test/integration/k8s/manifests/02-prometheus-otelscrape.yml
+++ b/test/integration/k8s/manifests/02-prometheus-otelscrape.yml
@@ -25,9 +25,7 @@ spec:
     - name: prometheus
       image: quay.io/prometheus/prometheus:v2.53.0
       args:
-        - --storage.tsdb.retention.time=10m
         - --config.file=/etc/prometheus/prometheus-config.yml
-        - --storage.tsdb.path=/prometheus
         - --web.enable-lifecycle
         - --web.route-prefix=/
       volumeMounts:

--- a/test/integration/k8s/manifests/02-prometheus-promscrape.yml
+++ b/test/integration/k8s/manifests/02-prometheus-promscrape.yml
@@ -25,9 +25,7 @@ spec:
     - name: prometheus
       image: quay.io/prometheus/prometheus:v2.53.0
       args:
-        - --storage.tsdb.retention.time=1m
         - --config.file=/etc/prometheus/prometheus-config-promscrape-k8s-test.yml
-        - --storage.tsdb.path=/prometheus
         - --web.enable-lifecycle
         - --web.route-prefix=/
       volumeMounts:


### PR DESCRIPTION
I can't remember under which assumption we set the tsdb retention time to 1m, but this causes some tests to be flaky (metrics disappear before the tests check them).

TSDB retention time doesn't save any actual resource usage, as the TSDB is internal to the container, and the data is wiped out when the container is destroyed.