### PR TITLE
Increase timeout for ARM tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ run-integration-test-vm:
 run-integration-test-arm:
 	@echo "### Running integration tests"
 	go clean -testcache
-	go test -p 1 -failfast -v -timeout 60m -mod vendor -a ./test/integration/... --tags=integration -run "^TestMultiProcess"
+	go test -p 1 -failfast -v -timeout 90m -mod vendor -a ./test/integration/... --tags=integration -run "^TestMultiProcess"
 
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test


### PR DESCRIPTION
This is a temporary change to deal with abnormally slow GitHub ARM runners.