### PR TITLE
Light refactoring of the TC attachment code

### DIFF
--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -43,6 +43,16 @@ var IntegrityModeOverride = false
 
 var ActiveNamespaces = make(map[uint32]uint32)
 
+// These represent unique traffic control (tc) handles to be supplied as
+// arguments to RegisterIngress, RegisterEgress or RegisterTC. They all start
+// from the 0xb310 offset in simplistic attempt to avoid collisions with
+// 3rdparty handles.
+const (
+	NetollyTCHandle = 0xb310 + iota
+	HTTPTracerTCHandle
+	TCTracerTCHandle
+)
+
 // ProbeDesc holds the information of the instrumentation points of a given
 // function/symbol
 type ProbeDesc struct {

--- a/pkg/internal/ebpf/common/tc_linux.go
+++ b/pkg/internal/ebpf/common/tc_linux.go
@@ -22,7 +22,7 @@ type TCLinks struct {
 	IngressFilter *netlink.BpfFilter
 }
 
-func StartTCMonitorLoop(ctx context.Context, registerer *ifaces.Registerer, channelBufferLen int, register func(iface ifaces.Interface), log *slog.Logger) {
+func StartTCMonitorLoop(ctx context.Context, registerer *ifaces.Registerer, register func(iface ifaces.Interface), log *slog.Logger) {
 	log.Debug("subscribing for network interface events")
 	ifaceEvents, err := registerer.Subscribe(ctx)
 	if err != nil {
@@ -58,7 +58,7 @@ func WatchAndRegisterTC(ctx context.Context, channelBufferLen int, register func
 
 	informer := ifaces.NewWatcher(channelBufferLen)
 	registerer := ifaces.NewRegisterer(informer, channelBufferLen)
-	StartTCMonitorLoop(ctx, registerer, channelBufferLen, register, log)
+	StartTCMonitorLoop(ctx, registerer, register, log)
 }
 
 // Convenience function
@@ -67,13 +67,10 @@ func PollAndRegisterTC(ctx context.Context, channelBufferLen int, register func(
 
 	informer := ifaces.NewPoller(period, channelBufferLen)
 	registerer := ifaces.NewRegisterer(informer, channelBufferLen)
-	StartTCMonitorLoop(ctx, registerer, channelBufferLen, register, log)
+	StartTCMonitorLoop(ctx, registerer, register, log)
 }
 
-func RegisterTC(iface ifaces.Interface, egressFD, ingressFD int, log *slog.Logger) *TCLinks {
-	links := TCLinks{}
-
-	// Load pre-compiled programs and maps into the kernel, and rewrites the configuration
+func GetClsactQdisc(iface ifaces.Interface, log *slog.Logger) *netlink.GenericQdisc {
 	ipvlan, err := netlink.LinkByIndex(iface.Index)
 	if err != nil {
 		log.Error("failed to lookup ipvlan device", "index", iface.Index, "name", iface.Name, "error", err)
@@ -96,15 +93,29 @@ func RegisterTC(iface ifaces.Interface, egressFD, ingressFD int, log *slog.Logge
 			return nil
 		}
 	}
-	links.Qdisc = qdisc
 
-	egressFilter, err := registerEgress(ipvlan, egressFD)
+	return qdisc
+}
+
+func RegisterTC(iface ifaces.Interface, egressFD int, egressHandle uint32, egressName string,
+	ingressFD int, ingressHandle uint32, ingressName string, log *slog.Logger) *TCLinks {
+	links := TCLinks{
+		Qdisc: GetClsactQdisc(iface, log),
+	}
+
+	if links.Qdisc == nil {
+		return nil
+	}
+
+	linkIndex := links.Qdisc.QdiscAttrs.LinkIndex
+
+	egressFilter, err := RegisterEgress(linkIndex, egressFD, egressHandle, egressName)
 	if err != nil {
 		log.Error("failed to install egress filters", "error", err)
 	}
 	links.EgressFilter = egressFilter
 
-	ingressFilter, err := registerIngress(ipvlan, ingressFD)
+	ingressFilter, err := RegisterIngress(linkIndex, ingressFD, ingressHandle, ingressName)
 	if err != nil {
 		log.Error("failed to install ingres filters", "error", err)
 	}
@@ -113,62 +124,44 @@ func RegisterTC(iface ifaces.Interface, egressFD, ingressFD int, log *slog.Logge
 	return &links
 }
 
-func registerEgress(ipvlan netlink.Link, egressFD int) (*netlink.BpfFilter, error) {
-	// Fetch events on egress
-	egressAttrs := netlink.FilterAttrs{
-		LinkIndex: ipvlan.Attrs().Index,
-		Parent:    netlink.HANDLE_MIN_EGRESS,
-		Handle:    netlink.MakeHandle(0, 1),
-		Protocol:  unix.ETH_P_ALL,
-		Priority:  1,
-	}
-	egressFilter := &netlink.BpfFilter{
-		FilterAttrs:  egressAttrs,
-		Fd:           egressFD,
-		Name:         "tc/tc_http_egress",
-		DirectAction: true,
-	}
-	if err := netlink.FilterDel(egressFilter); err == nil {
-		log.Warn("egress filter already existed. Deleted it")
-	}
-	if err := netlink.FilterAdd(egressFilter); err != nil {
-		if errors.Is(err, fs.ErrExist) {
-			log.Warn("egress filter already exists. Ignoring", "error", err)
-		} else {
-			return nil, fmt.Errorf("failed to create egress filter: %w", err)
-		}
-	}
-
-	return egressFilter, nil
+func RegisterEgress(linkIndex int, egressFD int, handle uint32, name string) (*netlink.BpfFilter, error) {
+	return registerFilter(linkIndex, egressFD, handle, netlink.HANDLE_MIN_EGRESS, name)
 }
 
-func registerIngress(ipvlan netlink.Link, ingressFD int) (*netlink.BpfFilter, error) {
+func RegisterIngress(linkIndex int, ingressFD int, handle uint32, name string) (*netlink.BpfFilter, error) {
+	return registerFilter(linkIndex, ingressFD, handle, netlink.HANDLE_MIN_INGRESS, name)
+}
+
+func registerFilter(linkIndex int, fd int, handle uint32, parent uint32, name string) (*netlink.BpfFilter, error) {
 	// Fetch events on ingress
-	ingressAttrs := netlink.FilterAttrs{
-		LinkIndex: ipvlan.Attrs().Index,
-		Parent:    netlink.HANDLE_MIN_INGRESS,
-		Handle:    netlink.MakeHandle(0, 1),
+	attrs := netlink.FilterAttrs{
+		LinkIndex: linkIndex,
+		Parent:    parent,
+		Handle:    handle,
 		Protocol:  unix.ETH_P_ALL,
 		Priority:  1,
 	}
-	ingressFilter := &netlink.BpfFilter{
-		FilterAttrs:  ingressAttrs,
-		Fd:           ingressFD,
-		Name:         "tc/tc_http_ingress",
+
+	filter := &netlink.BpfFilter{
+		FilterAttrs:  attrs,
+		Fd:           fd,
+		Name:         name,
 		DirectAction: true,
 	}
-	if err := netlink.FilterDel(ingressFilter); err == nil {
-		log.Warn("ingress filter already existed. Deleted it")
+
+	if err := netlink.FilterDel(filter); err == nil {
+		log.Warn("filter already existed. Deleted it", "filter", name, "iface", linkIndex)
 	}
-	if err := netlink.FilterAdd(ingressFilter); err != nil {
+
+	if err := netlink.FilterAdd(filter); err != nil {
 		if errors.Is(err, fs.ErrExist) {
-			log.Warn("ingress filter already exists. Ignoring", "error", err)
+			log.Warn("filter already exists. Ignoring", "error", err)
 		} else {
-			return nil, fmt.Errorf("failed to create ingress filter: %w", err)
+			return nil, fmt.Errorf("failed to create filter: %w", err)
 		}
 	}
 
-	return ingressFilter, nil
+	return filter, nil
 }
 
 // doIgnoreNoDev runs the provided syscall over the provided device and ignores the error

--- a/pkg/internal/ebpf/httptracer/httptracer.go
+++ b/pkg/internal/ebpf/httptracer/httptracer.go
@@ -22,10 +22,6 @@ import (
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/tc_http_tp.c -- -I../../../../bpf/headers
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf_debug ../../../../bpf/tc_http_tp.c -- -I../../../../bpf/headers -DBPF_DEBUG
 
-const (
-	httpTracerTCHandle = 0xb311
-)
-
 type Tracer struct {
 	cfg            *beyla.Config
 	bpfObjects     bpfObjects
@@ -148,8 +144,8 @@ func (p *Tracer) Run(ctx context.Context, _ chan<- []request.Span) {
 
 func (p *Tracer) registerTC(iface ifaces.Interface) {
 	links := ebpfcommon.RegisterTC(iface,
-		p.bpfObjects.BeylaTcHttpEgress.FD(), httpTracerTCHandle, "tc/tc_http_egress",
-		p.bpfObjects.BeylaTcHttpIngress.FD(), httpTracerTCHandle, "tc/tc_http_ingress",
+		p.bpfObjects.BeylaTcHttpEgress.FD(), ebpfcommon.HTTPTracerTCHandle, "tc/tc_http_egress",
+		p.bpfObjects.BeylaTcHttpIngress.FD(), ebpfcommon.HTTPTracerTCHandle, "tc/tc_http_ingress",
 		p.log)
 
 	if links == nil {

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -23,10 +23,6 @@ import (
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/tc_tracer.c -- -I../../../../bpf/headers
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf_debug ../../../../bpf/tc_tracer.c -- -I../../../../bpf/headers -DBPF_DEBUG -DBPF_DEBUG_TC
 
-const (
-	tcTracerTCHandle = 0xb312
-)
-
 type Tracer struct {
 	cfg            *beyla.Config
 	bpfObjects     bpfObjects
@@ -159,8 +155,8 @@ func (p *Tracer) Run(ctx context.Context, _ chan<- []request.Span) {
 
 func (p *Tracer) registerTC(iface ifaces.Interface) {
 	links := ebpfcommon.RegisterTC(iface,
-		p.bpfObjects.BeylaAppEgress.FD(), tcTracerTCHandle, "tc/tc_egress",
-		p.bpfObjects.BeylaAppIngress.FD(), tcTracerTCHandle, "tc/tc_ingress",
+		p.bpfObjects.BeylaAppEgress.FD(), ebpfcommon.TCTracerTCHandle, "tc/tc_egress",
+		p.bpfObjects.BeylaAppIngress.FD(), ebpfcommon.TCTracerTCHandle, "tc/tc_ingress",
 		p.log)
 
 	if links == nil {

--- a/pkg/internal/netolly/agent/agent.go
+++ b/pkg/internal/netolly/agent/agent.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 
 	"github.com/grafana/beyla/pkg/beyla"
-	"github.com/grafana/beyla/pkg/internal/ebpf/common"
+	ebpfcommon "github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow"
 	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
@@ -260,8 +260,7 @@ func (f *Flows) Status() Status {
 func (f *Flows) interfacesManager(ctx context.Context) error {
 	slog := alog().With("function", "interfacesManager")
 
-	ebpfcommon.StartTCMonitorLoop(ctx, f.registerer, f.cfg.ChannelBufferLen,
-		f.onInterfaceAdded, slog)
+	ebpfcommon.StartTCMonitorLoop(ctx, f.registerer, f.onInterfaceAdded, slog)
 
 	return nil
 }

--- a/pkg/internal/netolly/agent/agent.go
+++ b/pkg/internal/netolly/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 
 	"github.com/grafana/beyla/pkg/beyla"
+	"github.com/grafana/beyla/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow"
 	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
@@ -89,7 +90,7 @@ type Flows struct {
 	ctxInfo *global.ContextInfo
 
 	// input data providers
-	interfaces ifaces.Informer
+	registerer *ifaces.Registerer
 	filter     interfaceFilter
 	ebpf       ebpfFlowFetcher
 
@@ -193,7 +194,7 @@ func flowsAgent(
 	return &Flows{
 		ctxInfo:        ctxInfo,
 		ebpf:           fetcher,
-		interfaces:     registerer,
+		registerer:     registerer,
 		filter:         filter,
 		cfg:            cfg,
 		mapTracer:      mapTracer,
@@ -259,32 +260,8 @@ func (f *Flows) Status() Status {
 func (f *Flows) interfacesManager(ctx context.Context) error {
 	slog := alog().With("function", "interfacesManager")
 
-	slog.Debug("subscribing for network interface events")
-	ifaceEvents, err := f.interfaces.Subscribe(ctx)
-	if err != nil {
-		return fmt.Errorf("instantiating interfaces' informer: %w", err)
-	}
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				slog.Debug("stopping interfaces' listener")
-				return
-			case event := <-ifaceEvents:
-				slog.Debug("received event", "event", event)
-				switch event.Type {
-				case ifaces.EventAdded:
-					f.onInterfaceAdded(event.Interface)
-				case ifaces.EventDeleted:
-					// qdiscs, ingress and egress filters are automatically deleted so we don't need to
-					// specifically detach them from the ebpfFetcher
-				default:
-					slog.Warn("unknown event type", "event", event)
-				}
-			}
-		}
-	}()
+	ebpfcommon.StartTCMonitorLoop(ctx, f.registerer, f.cfg.ChannelBufferLen,
+		f.onInterfaceAdded, slog)
 
 	return nil
 }

--- a/pkg/internal/netolly/agent/pipeline_test.go
+++ b/pkg/internal/netolly/agent/pipeline_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/grafana/beyla/pkg/internal/connector"
 	"github.com/grafana/beyla/pkg/internal/filter"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
-	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow/transport"
+	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	prom2 "github.com/grafana/beyla/test/integration/components/prom"
 )

--- a/pkg/internal/netolly/agent/pipeline_test.go
+++ b/pkg/internal/netolly/agent/pipeline_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/beyla/pkg/internal/filter"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow/transport"
-	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	prom2 "github.com/grafana/beyla/test/integration/components/prom"
 )
@@ -56,7 +55,7 @@ func TestFilter(t *testing.T) {
 				},
 			}},
 		},
-		interfaces:     fakeInterfacesInformer{},
+		registerer:     nil,
 		interfaceNamer: func(_ int) string { return "fakeiface" },
 	}
 
@@ -113,10 +112,4 @@ func fakeRecord(protocol transport.Protocol, srcPort, dstPort uint16) *ebpf.Reco
 			SrcPort: srcPort, DstPort: dstPort, TransportProtocol: uint8(protocol),
 		},
 	}}
-}
-
-type fakeInterfacesInformer struct{}
-
-func (f fakeInterfacesInformer) Subscribe(_ context.Context) (<-chan ifaces.Event, error) {
-	return make(<-chan ifaces.Event), nil
 }

--- a/pkg/internal/netolly/agent/pipeline_test.go
+++ b/pkg/internal/netolly/agent/pipeline_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/beyla/pkg/internal/connector"
 	"github.com/grafana/beyla/pkg/internal/filter"
 	"github.com/grafana/beyla/pkg/internal/netolly/ebpf"
+	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 	"github.com/grafana/beyla/pkg/internal/netolly/flow/transport"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	prom2 "github.com/grafana/beyla/test/integration/components/prom"
@@ -55,7 +56,7 @@ func TestFilter(t *testing.T) {
 				},
 			}},
 		},
-		registerer:     nil,
+		registerer:     ifaces.NewRegisterer(fakeInterfacesInformer{}, 10),
 		interfaceNamer: func(_ int) string { return "fakeiface" },
 	}
 
@@ -112,4 +113,10 @@ func fakeRecord(protocol transport.Protocol, srcPort, dstPort uint16) *ebpf.Reco
 			SrcPort: srcPort, DstPort: dstPort, TransportProtocol: uint8(protocol),
 		},
 	}}
+}
+
+type fakeInterfacesInformer struct{}
+
+func (f fakeInterfacesInformer) Subscribe(_ context.Context) (<-chan ifaces.Event, error) {
+	return make(<-chan ifaces.Event), nil
 }

--- a/pkg/internal/netolly/ebpf/tracer.go
+++ b/pkg/internal/netolly/ebpf/tracer.go
@@ -45,7 +45,6 @@ const (
 	aggregatedFlowsMap = "aggregated_flows"
 	connInitiatorsMap  = "conn_initiators"
 	flowDirectionsMap  = "flow_directions"
-	netollyTCHandle    = 0xb310
 )
 
 func tlog() *slog.Logger {
@@ -143,7 +142,7 @@ func (m *FlowFetcher) Register(iface ifaces.Interface) error {
 
 	if m.enableEgress {
 		filter, err := ebpfcommon.RegisterEgress(linkIndex,
-			m.objects.BeylaEgressFlowParse.FD(), netollyTCHandle, "tc/egress_flow_parse")
+			m.objects.BeylaEgressFlowParse.FD(), ebpfcommon.NetollyTCHandle, "tc/egress_flow_parse")
 
 		if err != nil {
 			return fmt.Errorf("failed to install egress filters: %w", err)
@@ -156,7 +155,7 @@ func (m *FlowFetcher) Register(iface ifaces.Interface) error {
 
 	if m.enableIngress {
 		filter, err := ebpfcommon.RegisterIngress(linkIndex,
-			m.objects.BeylaIngressFlowParse.FD(), netollyTCHandle, "tc/ingress_flow_parse")
+			m.objects.BeylaIngressFlowParse.FD(), ebpfcommon.NetollyTCHandle, "tc/ingress_flow_parse")
 
 		if err != nil {
 			return fmt.Errorf("failed to install ingress filters: %w", err)


### PR DESCRIPTION
This PR introduces a light refactoring of the TC attachment code, in order to enable it to be reused between the tracers and netolly. The key changes are:

- Break `WatchAndRegisterTC` into multiple atomic functions, that allow them to be used by the netolly flow tracer
- Parameterise the TC attachment handles and names
- Use unique handles for different classes of TC programs, in order to avoid collisions with ourselves or third parties (such as cilium) - the handles follow the format `0xb31N`.

Ideally I would have liked to collapse the code gap between the tracers and netolly even more, but that would entail a larger refactoring that requires further discussion, involving sharing the interface informers and registers, so that the interface name cache inside the registerer can be shared. I've thus opted for the pragmatic approach, which translates on sharing the core attachment, qdisc creation and  cleanup code, as well as the main watcher loop.