### PR TITLE
Helm: do not override default exclusions from 'discovery' 

### DIFF
--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -24,8 +24,8 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | used for scheduling of pods based on affinity rules |
-| config.create | bool | `true` | set to true, to use the below default configurations |
-| config.data | object | `{"attributes":{"kubernetes":{"enable":true},"select":{"beyla_network_flow_bytes":{"include":["k8s.src.owner.type","k8s.dst.owner.type","direction"]}}},"filter":{"network":{"k8s_dst_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"},"k8s_src_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"}}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
+| config.create | bool | `true` | set to true, to use default configurations |
+| config.data | string | `nil` | default value of beyla configuration |
 | config.name | string | `""` |  |
 | config.skipConfigMapCheck | bool | `false` | set to true, to skip the check around the ConfigMap creation |
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` | Determines how DNS resolution is handled for that pod. If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Beyla requires `hostNetwork` access, causing cluster service DNS resolution to fail. It is recommended not to change this if Beyla sends traces and metrics to Grafana components via k8s service. |

--- a/charts/beyla/templates/_config.tpl
+++ b/charts/beyla/templates/_config.tpl
@@ -1,0 +1,42 @@
+{{/*
+Define the default configuration.
+*/}}
+{{- define "beyla.defaultConfig" }}
+{{- if eq .Values.preset "network" }}
+network:
+  enable: true
+{{- end }}
+{{- if eq .Values.preset "application" }}
+discovery:
+  services:
+    - k8s_namespace: .
+  exclude_services:
+    - exe_path: ".*alloy.*|.*otelcol.*|.*beyla.*"
+{{- end }}
+prometheus_export:
+  port: 9090
+  path: /metrics
+attributes:
+  kubernetes:
+    enable: true
+  select:
+    beyla_network_flow_bytes:
+      include:
+        - 'k8s.src.owner.type'
+        - 'k8s.dst.owner.type'
+        - 'direction'
+filter:
+  network:
+    k8s_dst_owner_name:
+      not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    k8s_src_owner_name:
+      not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+{{- end }}
+
+{{/*
+Merge default configuration with user configuration from values.
+*/}}
+{{- define "beyla.config" }}
+{{- $defaultConfig := fromYaml (include "beyla.defaultConfig" . ) }}
+{{- mergeOverwrite $defaultConfig .Values.config.data | default $defaultConfig  | toYaml | nindent 4}}
+{{- end }}

--- a/charts/beyla/templates/_config.tpl
+++ b/charts/beyla/templates/_config.tpl
@@ -38,5 +38,5 @@ Merge default configuration with user configuration from values.
 */}}
 {{- define "beyla.config" }}
 {{- $defaultConfig := fromYaml (include "beyla.defaultConfig" . ) }}
-{{- mergeOverwrite $defaultConfig .Values.config.data | default $defaultConfig  | toYaml | nindent 4}}
+{{- mergeOverwrite $defaultConfig .Values.config.data | default $defaultConfig | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/beyla/templates/configmap.yaml
+++ b/charts/beyla/templates/configmap.yaml
@@ -18,20 +18,5 @@ metadata:
   {{- end }}
 data:
   beyla-config.yml: |
-    {{- if eq .Values.preset "network" }}
-    {{- if not .Values.config.data.network }}
-    network:
-      enable: true
-    {{- end }}
-    {{- end }}
-    {{- if eq .Values.preset "application" }}
-    {{- if not .Values.config.data.discovery }}
-    discovery:
-      services:
-        - k8s_namespace: .
-      exclude_services:
-        - exe_path: ".*alloy.*|.*otelcol.*|.*beyla.*"
-    {{- end }}
-    {{- end }}
-  {{- toYaml .Values.config.data | nindent 4}}
+    {{- include "beyla.config" . }}
 {{- end }}

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -182,12 +182,12 @@ dnsPolicy: ClusterFirstWithHostNet
 config:
   # -- set to true, to skip the check around the ConfigMap creation
   skipConfigMapCheck: false
-  # -- set to true, to use the below default configurations
+  # -- set to true, to use default configurations
   create: true
   ## -- Provide the name of the external configmap containing the beyla configuration.
   ## To create configmap from configuration file, user can use the below command. Note: The name 'beyla-config.yaml' is important.
   ## `kubectl create cm --from-file=beyla-config.yaml=<name-of-config-file> -n <namespace>`
-  ## If empty, default configuration below is used.
+  ## If empty, default configuration from _config.tpl is used.
   name: ""
   # -- default value of beyla configuration
   data:
@@ -204,27 +204,27 @@ config:
     #     cloud_zone: prod-eu-west-0
     #     cloud_instance_id: 123456
     #     cloud_api_key:
-    attributes:
-      kubernetes:
-        enable: true
-      select:
-        beyla_network_flow_bytes:
-          include:
-            - 'k8s.src.owner.type'
-            - 'k8s.dst.owner.type'
-            - 'direction'
-    filter:
-      network:
-        k8s_dst_owner_name:
-          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
-        k8s_src_owner_name:
-          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    # attributes:
+    #   kubernetes:
+    #     enable: true
+    #   select:
+    #     beyla_network_flow_bytes:
+    #       include:
+    #         - 'k8s.src.owner.type'
+    #         - 'k8s.dst.owner.type'
+    #         - 'direction'
+    # filter:
+    #   network:
+    #     k8s_dst_owner_name:
+    #       not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    #     k8s_src_owner_name:
+    #       not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
     # to enable network metrics
     # network:
     #   enable: true
-    prometheus_export:
-      port: 9090
-      path: /metrics
+    # prometheus_export:
+    #   port: 9090
+    #   path: /metrics
     # to enable internal metrics
     # internal_metrics:
     #   prometheus:


### PR DESCRIPTION
Closes #1454 

This changes how the ConfigMap contents are generated. I'm not 100% happy with how it works, but it is the best solution that I could come up with without introducing breaking changes.

- Moves the default configuration from `config.data` to a new template in `templates/_config.tpl`
- The `beyla.defaultConfig` template in that file define the original default configuration, retaining those `preset` values
- A subsequent `beyla.config` template merges `config.data` with the output of `beyla.defaultConfig`, giving precedence to `config.data`

Caveats are:
- As the single source of truth for the default configuration is now in `templates/_config.tpl`, while I could technically leave the same default configurations in `config.data` as well, but that could be confusing
- With mergeOverwrite, empty values are ignored so passing something like `discovery: {}` would not actually clear the discovery configuration as the default configuration is set. The only way to remove it in this case is to set it to null.

I think the logical problem here stems mostly from the `preset` configuration (network or application) intersecting with just taking all values from `config.data`. It might be advisable to change/remove that, but that will of course be a breaking change.