### PR TITLE
Fixes panic on Go instrumentation

### DIFF
--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -443,7 +443,7 @@ func structMemberOffsetsFromDwarf(data *dwarf.Data) (FieldOffsets, map[GoOffset]
 		log.Debug("inspecting fields for struct type", "type", typeName)
 		if err := readMembers(reader, structMember.fields, expectedReturns, fieldOffsets); err != nil {
 			log.Debug("error reading DWARF info", "type", typeName, "error", err)
-			return nil, expectedReturns
+			return fieldOffsets, expectedReturns
 		}
 	}
 }


### PR DESCRIPTION
 On ELF parse error, we return the list of missing fields, assuming that we would stop the instrumentation. There is an edge case error on which the missing fields set is empty so Beyla keeps with the instrumentation, but the returned list of fields is nil