### PR TITLE
Fixed: Service name must be less than 15 chars

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -117,7 +117,7 @@ service:
     # from the Beyla configuration file.
     targetPort: null
     # -- name of the port for internal metrics.
-    portName: internal-metrics
+    portName: int-metrics
     # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
     appProtocol: ""
 


### PR DESCRIPTION
The service name can not be more than 15 characters.

[RelatedIssue](https://github.com/grafana/helm-charts/issues/3338)
