### PR TITLE
Add marevers to team members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -50,6 +50,7 @@ The current team members are, in alphabetical order:
 
 - Marc Tudurí - [@marctc](https://github.com/marctc) ([Grafana Labs](https://grafana.com/))
 - Mario Macías - [@mariomac](https://github.com/mariomac) ([Grafana Labs](https://grafana.com/))
+- Martijn Evers - [@marevers](https://github.com/marevers) ([GK Software SE](https://www.gk-software.com/de/))
 - Nikola Grcevski - [@grcevski](https://github.com/grcevski) ([Grafana Labs](https://grafana.com/))
 - Rafael Roquetto - [@rafaelroquetto]((https://github.com/rafaelroquetto)) ([Grafana Labs](https://grafana.com/))
 


### PR DESCRIPTION
Adding @marevers to the list of team members in lieu of becoming an approver. I've already granted the triager role in Github.

Congratulations @marevers and thank you so much for all the contributions so far!