### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*       @grcevski @mariomac @marctc @rafaelroquetto
+* @grafana/beyla
 
 # `make docs` procedure is owned by @jdbaldry of @grafana/docs-squad.
 /.github/workflows/update-make-docs.yml @jdbaldry


### PR DESCRIPTION
Use `@grafana/beyla` as CODEOWNERS instead of list of individuals.