### PR TITLE
Fix library discovery bug

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -241,7 +241,7 @@ func (ta *TraceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 	}
 
 	if err := tracer.NewExecutable(exe, ie); err != nil {
-		return false
+		ta.log.Debug("Failed to attach uprobes for new executable", "pid", ie.FileInfo.Pid, "error", err)
 	}
 
 	ta.log.Debug("reusing Generic tracer for",
@@ -258,7 +258,7 @@ func (ta *TraceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 
 func (ta *TraceAttacher) updateTracerProbes(tracer *ebpf.ProcessTracer, ie *ebpf.Instrumentable) bool {
 	if err := tracer.NewExecutableInstance(ie); err != nil {
-		return false
+		ta.log.Debug("Failed to attach uprobes", "pid", ie.FileInfo.Pid, "error", err)
 	}
 
 	ta.log.Debug("reusing Generic tracer for",

--- a/pkg/internal/ebpf/instrumenter.go
+++ b/pkg/internal/ebpf/instrumenter.go
@@ -232,7 +232,8 @@ func (i *instrumenter) uprobes(pid int32, p Tracer) error {
 		libExe, err := link.OpenExecutable(m.instrPath)
 
 		if err != nil {
-			return err
+			log.Debug("can't open executable for inspection", "error", err)
+			continue
 		}
 
 		for j := range m.probes {

--- a/pkg/internal/exec/procmaps.go
+++ b/pkg/internal/exec/procmaps.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/prometheus/procfs"
@@ -18,7 +19,7 @@ func FindLibMaps(pid int32) ([]*procfs.ProcMap, error) {
 
 func LibPath(name string, maps []*procfs.ProcMap) *procfs.ProcMap {
 	for _, m := range maps {
-		if strings.Contains(m.Pathname, name) {
+		if strings.Contains(m.Pathname, string(filepath.Separator)+name) {
 			return m
 		}
 	}

--- a/pkg/internal/exec/procmaps_test.go
+++ b/pkg/internal/exec/procmaps_test.go
@@ -1,0 +1,36 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/prometheus/procfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModulePathMatching(t *testing.T) {
+
+	maps := makeProcFSMaps([]string{"/something/something/libssl.so.3", "anon_inode:[io_uring]"})
+
+	assert.Nil(t, LibPath("node", maps))
+	assert.Equal(t, procPSFromPath("/something/something/libssl.so.3"), LibPath("libssl.so", maps))
+
+	maps = makeProcFSMaps([]string{"libssl.so", "/node"})
+
+	assert.Equal(t, procPSFromPath("/node"), LibPath("node", maps))
+	assert.Nil(t, LibPath("libssl.so", maps))
+}
+
+func makeProcFSMaps(paths []string) []*procfs.ProcMap {
+	res := []*procfs.ProcMap{}
+
+	for _, path := range paths {
+		p := procfs.ProcMap{Pathname: path}
+		res = append(res, &p)
+	}
+
+	return res
+}
+
+func procPSFromPath(path string) *procfs.ProcMap {
+	return &procfs.ProcMap{Pathname: path}
+}


### PR DESCRIPTION
While looking for a library to attach our uprobes in the generic instrumenter we try to investigate if we have the symbols as part of the main executable or as part of shared library. The shared library code was simply doing strings.Contains, which can potentially look into libraries that don't quite match. This is typically not a problem, since we won't find related symbols, however it's possible that the module is something we can't look into. For example, `anon_inode:[io_uring]` would match for `node` and we'd fail the loop currently.

I've fixed this in two ways:
- I made the name matching for modules require a `/` prefix. This is always going to be the case for any real file module found in the maps for a process.
- We still monitor the process if we failed to attach any uprobes. 
- Failing to open a module is not fatal, we continue the loop instead of exit.

Fixes https://github.com/grafana/beyla/issues/1486