### PR TITLE
TCManager: split code to InterfaceManager

### DIFF
--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -75,7 +75,7 @@ func main() {
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	if err := components.RunBeyla(ctx, config); err != nil {
-		slog.Error("Beyla can't start", "error", err)
+		slog.Error("Beyla ran with errors", "error", err)
 		os.Exit(-1)
 	}
 

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -66,9 +66,11 @@ func setupAppO11y(ctx context.Context, ctxInfo *global.ContextInfo, config *beyl
 
 	instr := appolly.New(ctx, ctxInfo, config)
 	if err := instr.FindAndInstrument(&wg); err != nil {
+		slog.Error("can't find  target process", "error", err)
 		return fmt.Errorf("can't find target process: %w", err)
 	}
 	if err := instr.ReadAndForward(); err != nil {
+		slog.Error("can't start read and forwarding", "error", err)
 		return fmt.Errorf("can't start read and forwarding: %w", err)
 	}
 	return nil
@@ -82,9 +84,11 @@ func setupNetO11y(ctx context.Context, ctxInfo *global.ContextInfo, cfg *beyla.C
 	slog.Info("starting Beyla in Network metrics mode")
 	flowsAgent, err := agent.FlowsAgent(ctxInfo, cfg)
 	if err != nil {
+		slog.Error("can't start network metrics capture", "error", err)
 		return fmt.Errorf("can't start network metrics capture: %w", err)
 	}
 	if err := flowsAgent.Run(ctx); err != nil {
+		slog.Error("can't start network metrics capture", "error", err)
 		return fmt.Errorf("can't start network metrics capture: %w", err)
 	}
 	return nil

--- a/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
+++ b/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
@@ -3,9 +3,6 @@
 package tcmanager
 
 import (
-	"context"
-	"time"
-
 	"github.com/cilium/ebpf"
 )
 
@@ -19,12 +16,8 @@ func NewNetlinkManager() TCManager {
 	return &dummyManager{}
 }
 
-func (d *dummyManager) Start(_ context.Context)                                {}
-func (d *dummyManager) Stop()                                                  {}
+func (d *dummyManager) Shutdown()                                              {}
 func (d *dummyManager) AddProgram(_ string, _ *ebpf.Program, _ AttachmentType) {}
 func (d *dummyManager) RemoveProgram(_ string)                                 {}
 func (d *dummyManager) InterfaceName(_ int) (string, bool)                     { return "", false }
-func (d *dummyManager) SetInterfaceFilter(_ *InterfaceFilter)                  {}
-func (d *dummyManager) SetMonitorMode(_ MonitorMode)                           {}
-func (d *dummyManager) SetChannelBufferLen(_ int)                              {}
-func (d *dummyManager) SetPollPeriod(_ time.Duration)                          {}
+func (d *dummyManager) SetInterfaceManager(_ *InterfaceManager)                {}

--- a/pkg/internal/ebpf/tcmanager/ifacemanager.go
+++ b/pkg/internal/ebpf/tcmanager/ifacemanager.go
@@ -1,0 +1,225 @@
+package tcmanager
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
+)
+
+type IMIfaceMap map[int]*ifaces.Interface
+
+type InterfaceManagerCB func(iface *ifaces.Interface)
+type interfaceManagerCBMap map[uint64]InterfaceManagerCB
+
+type InterfaceManager struct {
+	filter                *InterfaceFilter
+	monitorMode           MonitorMode
+	channelBufferLen      int
+	pollPeriod            time.Duration
+	registerer            *ifaces.Registerer
+	log                   *slog.Logger
+	mutex                 sync.Mutex
+	wg                    sync.WaitGroup
+	interfaces            IMIfaceMap
+	ifaceAddedCallbacks   interfaceManagerCBMap
+	ifaceRemovedCallbacks interfaceManagerCBMap
+	nextCallbackID        uint64
+}
+
+func NewInterfaceManager() *InterfaceManager {
+	return &InterfaceManager{
+		filter:                nil,
+		monitorMode:           DefaultMonitorMode,
+		channelBufferLen:      DefaultChannelBufferLen,
+		pollPeriod:            DefaultPollPeriod,
+		registerer:            nil,
+		log:                   slog.With("component", "interface_manager"),
+		mutex:                 sync.Mutex{},
+		wg:                    sync.WaitGroup{},
+		interfaces:            IMIfaceMap{},
+		ifaceAddedCallbacks:   interfaceManagerCBMap{},
+		ifaceRemovedCallbacks: interfaceManagerCBMap{},
+		nextCallbackID:        0,
+	}
+}
+
+func (im *InterfaceManager) Start(ctx context.Context) {
+	if im.registerer != nil {
+		return
+	}
+
+	var informer ifaces.Informer
+
+	if im.monitorMode == MonitorPoll {
+		informer = ifaces.NewPoller(im.pollPeriod, im.channelBufferLen)
+	} else {
+		informer = ifaces.NewWatcher(im.channelBufferLen)
+	}
+
+	registerer := ifaces.NewRegisterer(informer, im.channelBufferLen)
+
+	ifaceEvents, err := registerer.Subscribe(ctx)
+
+	if err != nil {
+		im.log.Error("instantiating interfaces' informer", "error", err)
+		return
+	}
+
+	im.registerer = registerer
+
+	im.wg.Add(1)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				im.shutdown()
+				im.wg.Done()
+				return
+			case event := <-ifaceEvents:
+				im.log.Debug("received event", "event", event)
+				switch event.Type {
+				case ifaces.EventAdded:
+					im.onInterfaceAdded(&event.Interface)
+				case ifaces.EventDeleted:
+					im.onInterfaceRemoved(&event.Interface)
+				default:
+					im.log.Warn("unknown event type", "event", event)
+				}
+			}
+		}
+	}()
+}
+
+func (im *InterfaceManager) Wait() {
+	im.wg.Wait()
+}
+
+func (im *InterfaceManager) shutdown() {
+	im.log.Debug("TC initiated shutdown")
+
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.interfaces = IMIfaceMap{}
+	im.registerer = nil
+
+	im.log.Debug("TC completed shutdown")
+}
+
+func (im *InterfaceManager) onInterfaceAdded(i *ifaces.Interface) {
+	cbMap := interfaceManagerCBMap{}
+
+	func() {
+		im.mutex.Lock()
+		defer im.mutex.Unlock()
+
+		if im.filter != nil && !im.filter.IsAllowed(i.Name) {
+			im.log.Debug("Interface now allowed", "interface", i.Name)
+			return
+		}
+
+		im.interfaces[i.Index] = i
+
+		cbMap = maps.Clone(im.ifaceAddedCallbacks)
+	}()
+
+	for _, cb := range cbMap {
+		cb(i)
+	}
+}
+
+func (im *InterfaceManager) onInterfaceRemoved(i *ifaces.Interface) {
+	cbMap := interfaceManagerCBMap{}
+
+	func() {
+		im.mutex.Lock()
+		defer im.mutex.Unlock()
+
+		delete(im.interfaces, i.Index)
+
+		cbMap = maps.Clone(im.ifaceRemovedCallbacks)
+	}()
+
+	for _, cb := range cbMap {
+		cb(i)
+	}
+}
+
+func (im *InterfaceManager) InterfaceName(ifaceIndex int) (string, bool) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	if iface, ok := im.interfaces[ifaceIndex]; ok {
+		return iface.Name, true
+	}
+
+	return "", false
+}
+
+func (im *InterfaceManager) SetInterfaceFilter(filter *InterfaceFilter) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.filter = filter
+}
+
+func (im *InterfaceManager) SetMonitorMode(mode MonitorMode) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.monitorMode = mode
+}
+
+func (im *InterfaceManager) SetChannelBufferLen(channelBufferLen int) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.channelBufferLen = channelBufferLen
+}
+
+func (im *InterfaceManager) SetPollPeriod(period time.Duration) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.pollPeriod = period
+}
+
+func (im *InterfaceManager) AddInterfaceAddedCallback(cb InterfaceManagerCB) uint64 {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.nextCallbackID++
+	im.ifaceAddedCallbacks[im.nextCallbackID] = cb
+
+	return im.nextCallbackID
+}
+
+func (im *InterfaceManager) AddInterfaceRemovedCallback(cb InterfaceManagerCB) uint64 {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	im.nextCallbackID++
+	im.ifaceRemovedCallbacks[im.nextCallbackID] = cb
+
+	return im.nextCallbackID
+}
+
+func (im *InterfaceManager) RemoveCallback(id uint64) {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	delete(im.ifaceAddedCallbacks, id)
+	delete(im.ifaceRemovedCallbacks, id)
+}
+
+func (im *InterfaceManager) Interfaces() IMIfaceMap {
+	im.mutex.Lock()
+	defer im.mutex.Unlock()
+
+	return maps.Clone(im.interfaces)
+}

--- a/pkg/internal/ebpf/tcmanager/tcmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcmanager.go
@@ -1,16 +1,11 @@
 package tcmanager
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/ebpf"
-
-	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 )
 
 type TCBackend uint8
@@ -39,39 +34,10 @@ const DefaultChannelBufferLen = 10
 const DefaultPollPeriod = 10 * time.Second
 
 type TCManager interface {
-	Start(ctx context.Context)
-	Stop()
+	Shutdown()
 	AddProgram(name string, prog *ebpf.Program, attachment AttachmentType)
 	RemoveProgram(name string)
-	InterfaceName(ifaceIndex int) (string, bool)
-	SetInterfaceFilter(filter *InterfaceFilter)
-	SetMonitorMode(mode MonitorMode)
-	SetChannelBufferLen(channelBufferLen int)
-	SetPollPeriod(period time.Duration)
-}
-
-type tcManagerBase struct {
-	filter           *InterfaceFilter
-	monitorMode      MonitorMode
-	channelBufferLen int
-	pollPeriod       time.Duration
-	registerer       *ifaces.Registerer
-	log              *slog.Logger
-	mutex            sync.Mutex
-	wg               sync.WaitGroup
-}
-
-func newTCManagerBase(component string) tcManagerBase {
-	return tcManagerBase{
-		filter:           nil,
-		monitorMode:      DefaultMonitorMode,
-		channelBufferLen: DefaultChannelBufferLen,
-		pollPeriod:       DefaultPollPeriod,
-		registerer:       nil,
-		log:              slog.With("component", component),
-		mutex:            sync.Mutex{},
-		wg:               sync.WaitGroup{},
-	}
+	SetInterfaceManager(im *InterfaceManager)
 }
 
 func NewTCManager(backend TCBackend) TCManager {

--- a/pkg/internal/ebpf/tcmanager/tcmanager_test.go
+++ b/pkg/internal/ebpf/tcmanager/tcmanager_test.go
@@ -136,12 +136,14 @@ func TestTCXManagerAddRemove(t *testing.T) {
 
 	progs := loadProgs(t)
 
+	ifaceManager := NewInterfaceManager()
 	tcx := NewTCXManager()
+	tcx.SetInterfaceManager(ifaceManager)
 	assert.NotNil(t, tcx)
 
 	ctx := context.Background()
 
-	tcx.Start(ctx)
+	ifaceManager.Start(ctx)
 
 	test := func(progName string, prog *ebpf.Program, attachType AttachmentType) {
 		tcx.AddProgram(progName, prog, attachType)
@@ -230,14 +232,16 @@ func TestNetlinkManagerAddRemove(t *testing.T) {
 
 	progs := loadProgs(t)
 
+	ifaceManager := NewInterfaceManager()
 	tc := NewNetlinkManager()
+	tc.SetInterfaceManager(ifaceManager)
 	assert.NotNil(t, tc)
 
 	netManager := tc.(*netlinkManager)
 
 	ctx := context.Background()
 
-	tc.Start(ctx)
+	ifaceManager.Start(ctx)
 
 	test := func(progName string, prog *ebpf.Program, attachType AttachmentType) {
 		tc.AddProgram(progName, prog, attachType)
@@ -267,7 +271,7 @@ func TestNetlinkManagerAddRemove(t *testing.T) {
 	test("beyla_ingress", progs.Ingress, AttachmentIngress)
 	test("beyla_egress", progs.Egress, AttachmentEgress)
 
-	netManager.shutdown()
+	netManager.Shutdown()
 }
 
 /*


### PR DESCRIPTION
This PR further merges the common code between `tcx_manager` and `netlink_manager` into a `InterfaceManager` struct. More than avoiding code duplication, the main motivation of this PR is to lay the ground work to  allow the netolly agent to instantiate its own private `InterfaceManager` (TBC on a future PR) for the "interface namer", allowing it to run with _reduced Linux capabilities_ when `tc` is not strictly required (for instance, when beyla is configured to use the probe based `SockFlowFetcher` rather than the tc based `FlowFetcher`).