### PR TITLE
Defaults OTEL metrics interval to 60s

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -948,10 +948,11 @@ and any host name in that certificate. In this mode, TLS is susceptible to a man
 attacks. This option should be used only for testing and development purposes.
 
 | YAML       | Environment variable                  | Type     | Default |
-| ---------- | ------------------------ | -------- | ------- |
-| `interval` | `BEYLA_METRICS_INTERVAL` | Duration | `5s`    |
+| ---------- | ------------------------ | -------- |---------|
+| `interval` | `BEYLA_METRICS_INTERVAL` | Duration | `60s`   |
 
-Configures the intervening time between exports.
+Configures the intervening time between metric exports. This value overrides the `OTEL_METRIC_EXPORT_INTERVAL`
+configuration from the OpenTelemetry specification, which is also supported.
 
 | YAML       | Environment variable          | Type            | Default                      |
 |------------|-------------------------------|-----------------|------------------------------|

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -63,9 +63,10 @@ var DefaultConfig = Config{
 		CacheTTL: 5 * time.Minute,
 	},
 	Metrics: otel.MetricsConfig{
-		Protocol:             otel.ProtocolUnset,
-		MetricsProtocol:      otel.ProtocolUnset,
-		Interval:             5 * time.Second,
+		Protocol:        otel.ProtocolUnset,
+		MetricsProtocol: otel.ProtocolUnset,
+		// Matches Alloy and Grafana recommended scrape interval
+		OTELIntervalMS:       60_000,
 		Buckets:              otel.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -134,7 +134,7 @@ network:
 		},
 		NetworkFlows: nc,
 		Metrics: otel.MetricsConfig{
-			Interval:          5 * time.Second,
+			OTELIntervalMS:    60_000,
 			CommonEndpoint:    "localhost:3131",
 			MetricsEndpoint:   "localhost:3030",
 			Protocol:          otel.ProtocolUnset,

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -63,6 +63,9 @@ const (
 
 type MetricsConfig struct {
 	Interval time.Duration `yaml:"interval" env:"BEYLA_METRICS_INTERVAL"`
+	// OTELIntervalMS supports metric intervals as specified by the standard OTEL definition.
+	// BEYLA_METRICS_INTERVAL takes precedence over it.
+	OTELIntervalMS int `env:"OTEL_METRIC_EXPORT_INTERVAL"`
 
 	CommonEndpoint  string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
@@ -115,6 +118,13 @@ func (m *MetricsConfig) GetProtocol() Protocol {
 		return m.Protocol
 	}
 	return m.GuessProtocol()
+}
+
+func (m *MetricsConfig) GetInterval() time.Duration {
+	if m.Interval == 0 {
+		return time.Duration(m.OTELIntervalMS) * time.Millisecond
+	}
+	return m.Interval
 }
 
 func (m *MetricsConfig) GuessProtocol() Protocol {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -616,6 +616,19 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	}
 }
 
+func TestMetricsInterval(t *testing.T) {
+	cfg := MetricsConfig{
+		OTELIntervalMS: 60_000,
+	}
+	t.Run("If only OTEL is defined, it uses that value", func(t *testing.T) {
+		assert.Equal(t, 60*time.Second, cfg.GetInterval())
+	})
+	cfg.Interval = 5 * time.Second
+	t.Run("Beyla interval takes precedence over OTEL", func(t *testing.T) {
+		assert.Equal(t, 5*time.Second, cfg.GetInterval())
+	})
+}
+
 func (f *fakeInternalMetrics) OTELMetricExport(len int) {
 	fakeMux.Lock()
 	defer fakeMux.Unlock()

--- a/pkg/internal/ebpf/tcmanager/tcmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcmanager.go
@@ -1,3 +1,5 @@
+// line below avoids linter errors on Mac
+// nolint:unused
 package tcmanager
 
 import (

--- a/pkg/internal/ebpf/tcmanager/tcmanager_test.go
+++ b/pkg/internal/ebpf/tcmanager/tcmanager_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package tcmanager
 
 import (

--- a/pkg/internal/ebpf/tcmanager/util.go
+++ b/pkg/internal/ebpf/tcmanager/util.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package tcmanager
 
 func removeIf[T any](s []T, pred func(T) bool) []T {

--- a/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
@@ -4,8 +4,6 @@ package ebpf
 
 import (
 	"github.com/cilium/ebpf/ringbuf"
-
-	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
 )
 
 type SockFlowFetcher struct{}

--- a/pkg/internal/netolly/ebpf/tracer_nonlinux.go
+++ b/pkg/internal/netolly/ebpf/tracer_nonlinux.go
@@ -5,13 +5,13 @@ package ebpf
 import (
 	"github.com/cilium/ebpf/ringbuf"
 
-	"github.com/grafana/beyla/pkg/internal/netolly/ifaces"
+	"github.com/grafana/beyla/pkg/internal/ebpf/tcmanager"
 )
 
 type FlowFetcher struct {
 }
 
-func NewFlowFetcher(_, _ int, _, _ bool) (*FlowFetcher, error) {
+func NewFlowFetcher(_, _ int, _, _ bool, _ tcmanager.TCManager) (*FlowFetcher, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Grafana cloud documentation says it's "best practice" to have a scrape interval / push interval of `60s`. Previous value was `5s`

https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/adjust-data-points-per-minute/

This would reduce Grafana cloud datapoints.

Also:
* Adds support to `OTEL_METRIC_EXPORT_INTERVAL` configuration variable.
* Fixes Mac tests