### PR TITLE
Dump metrics and traces on file after integration tests

### DIFF
--- a/test/integration/k8s/common/k8s_common.go
+++ b/test/integration/k8s/common/k8s_common.go
@@ -1,28 +1,25 @@
 package k8s
 
-import "path"
+import (
+	"path"
+
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
+)
 
 var (
-	PathRoot            = path.Join("..", "..", "..", "..")
-	PathOutput          = path.Join(PathRoot, "testoutput")
-	PathKindLogs        = path.Join(PathOutput, "kind")
-	PathIntegrationTest = path.Join(PathRoot, "test", "integration")
-	PathComponents      = path.Join(PathIntegrationTest, "components")
-	PathManifests       = path.Join(PathIntegrationTest, "k8s", "manifests")
+	DockerfileTestServer       = path.Join(testpath.Components, "testserver", "Dockerfile")
+	DockerfileBeyla            = path.Join(testpath.Components, "beyla", "Dockerfile")
+	DockerfileBeylaK8sCache    = path.Join(testpath.Components, "beyla-k8s-cache", "Dockerfile")
+	DockerfilePinger           = path.Join(testpath.Components, "grpcpinger", "Dockerfile")
+	DockerfilePythonTestServer = path.Join(testpath.Components, "pythonserver", "Dockerfile_8083")
+	DockerfileHTTPPinger       = path.Join(testpath.Components, "httppinger", "Dockerfile")
 
-	DockerfileTestServer       = path.Join(PathComponents, "testserver", "Dockerfile")
-	DockerfileBeyla            = path.Join(PathComponents, "beyla", "Dockerfile")
-	DockerfileBeylaK8sCache    = path.Join(PathComponents, "beyla-k8s-cache", "Dockerfile")
-	DockerfilePinger           = path.Join(PathComponents, "grpcpinger", "Dockerfile")
-	DockerfilePythonTestServer = path.Join(PathComponents, "pythonserver", "Dockerfile_8083")
-	DockerfileHTTPPinger       = path.Join(PathComponents, "httppinger", "Dockerfile")
-
-	PingerManifest               = path.Join(PathManifests, "/06-instrumented-client.template.yml")
-	GrpcPingerManifest           = path.Join(PathManifests, "/06-instrumented-grpc-client.template.yml")
-	UninstrumentedPingerManifest = path.Join(PathManifests, "/06-uninstrumented-client.template.yml")
-	UninstrumentedAppManifest    = path.Join(PathManifests, "/05-uninstrumented-service.yml")
-	PingerManifestProm           = path.Join(PathManifests, "/06-instrumented-client-prom.template.yml")
-	GrpcPingerManifestProm       = path.Join(PathManifests, "/06-instrumented-grpc-client-prom.template.yml")
+	PingerManifest               = path.Join(testpath.Manifests, "/06-instrumented-client.template.yml")
+	GrpcPingerManifest           = path.Join(testpath.Manifests, "/06-instrumented-grpc-client.template.yml")
+	UninstrumentedPingerManifest = path.Join(testpath.Manifests, "/06-uninstrumented-client.template.yml")
+	UninstrumentedAppManifest    = path.Join(testpath.Manifests, "/05-uninstrumented-service.yml")
+	PingerManifestProm           = path.Join(testpath.Manifests, "/06-instrumented-client-prom.template.yml")
+	GrpcPingerManifestProm       = path.Join(testpath.Manifests, "/06-instrumented-grpc-client-prom.template.yml")
 )
 
 // Pinger stores the configuration data of a local pod that will be used to

--- a/test/integration/k8s/common/testpath/testpath.go
+++ b/test/integration/k8s/common/testpath/testpath.go
@@ -1,0 +1,12 @@
+package testpath
+
+import "path"
+
+var (
+	Root            = path.Join("..", "..", "..", "..")
+	Output          = path.Join(Root, "testoutput")
+	KindLogs        = path.Join(Output, "kind")
+	IntegrationTest = path.Join(Root, "test", "integration")
+	Components      = path.Join(IntegrationTest, "components")
+	Manifests       = path.Join(IntegrationTest, "k8s", "manifests")
+)

--- a/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -37,21 +38,20 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-daemonset",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/jaeger"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 )
 
 // For the DaemonSet scenario, we only check that Beyla is able to instrument any
@@ -27,7 +28,6 @@ func TestBasicTracing(t *testing.T) {
 	feat := features.New("Beyla is able to instrument an arbitrary process").
 		Assess("it sends traces for that service",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				defer k8s.DumpTracesAfterFail(t, jaegerHost)
 				var podID string
 				test.Eventually(t, testTimeout, func(t require.TestingT) {
 					// Invoking both service instances, but we will expect that only one
@@ -97,10 +97,10 @@ func TestBasicTracing(t *testing.T) {
 				assert.Empty(t, tq.Data)
 
 				// Let's take down our services, keeping Beyla alive and then redeploy them
-				err = kube.DeleteExistingManifestFile(cfg, k8s.PathManifests+"/05-uninstrumented-service.yml")
+				err = kube.DeleteExistingManifestFile(cfg, testpath.Manifests+"/05-uninstrumented-service.yml")
 				assert.NoError(t, err, "we should see no error when deleting the uninstrumented service manifest file")
 
-				err = kube.DeployManifestFile(cfg, k8s.PathManifests+"/05-uninstrumented-service.yml")
+				err = kube.DeployManifestFile(cfg, testpath.Manifests+"/05-uninstrumented-service.yml")
 				assert.NoError(t, err, "we should see no error when re-deploying the uninstrumented service manifest file")
 
 				// We now use a different API, this ensures that after undeploying and redeploying the application we

--- a/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
+++ b/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -36,20 +37,19 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-otel-multi",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind-multi-node.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol-multi-node.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger-multi-node.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-few-services.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-few-services.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset-multi-node.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/daemonset_multi_node_l7/k8s_daemonset_multi_node_main_test.go
+++ b/test/integration/k8s/daemonset_multi_node_l7/k8s_daemonset_multi_node_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -36,20 +37,19 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-otel-multi",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind-multi-node.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol-multi-node.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger-multi-node.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-few-services.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset-multi-node-l7.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-few-services.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset-multi-node-l7.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -35,19 +36,18 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-otel-python",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service-python.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset-python.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service-python.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset-python.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/jaeger"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 )
 
 // For the DaemonSet scenario, we only check that Beyla is able to instrument any
@@ -80,10 +81,10 @@ func TestPythonBasicTracing(t *testing.T) {
 				}, test.Interval(100*time.Millisecond))
 
 				// Let's take down our services, keeping Beyla alive and then redeploy them
-				err := kube.DeleteExistingManifestFile(cfg, k8s.PathManifests+"/05-uninstrumented-service-python.yml")
+				err := kube.DeleteExistingManifestFile(cfg, testpath.Manifests+"/05-uninstrumented-service-python.yml")
 				assert.NoError(t, err, "we should see no error when deleting the uninstrumented service manifest file")
 
-				err = kube.DeployManifestFile(cfg, k8s.PathManifests+"/05-uninstrumented-service-python.yml")
+				err = kube.DeployManifestFile(cfg, testpath.Manifests+"/05-uninstrumented-service-python.yml")
 				assert.NoError(t, err, "we should see no error when re-deploying the uninstrumented service manifest file")
 
 				// We now use /smoke instead of /greeting to ensure we see those APIs after a restart

--- a/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
+++ b/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -29,21 +30,20 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-daemonset",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset-disable-informers.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset-disable-informers.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/kube"
 	"github.com/grafana/beyla/test/integration/components/prom"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	otel "github.com/grafana/beyla/test/integration/k8s/netolly"
 	"github.com/grafana/beyla/test/tools"
 )
@@ -38,18 +39,17 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-external-cache",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("beyla-k8s-cache:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-external-informer.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-external-informer.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -28,19 +29,18 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-netolly",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -46,8 +46,6 @@ func FeatureNetworkFlowBytes() features.Feature {
 }
 
 func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-	defer k8s.DumpMetricsAfterFail(t, prometheusHostPort)
-
 	pq := prom.Client{HostPort: prometheusHostPort}
 	// testing request flows (to testserver as Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {

--- a/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/kube"
 	"github.com/grafana/beyla/test/integration/components/prom"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -41,18 +42,17 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-dropexternal",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly-dropexternal.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-dropexternal.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	otel "github.com/grafana/beyla/test/integration/k8s/netolly"
 	"github.com/grafana/beyla/test/tools"
 )
@@ -28,17 +29,16 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-promexport",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly-promexport.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-promexport.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
+++ b/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	otel "github.com/grafana/beyla/test/integration/k8s/netolly"
 	"github.com/grafana/beyla/test/tools"
 )
@@ -29,18 +30,17 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-sk-promexport",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly-tc-promexport.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-tc-promexport.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/otel/k8s_main_test.go
+++ b/test/integration/k8s/otel/k8s_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -39,8 +40,7 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-otel",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("grpcpinger:dev"),
@@ -48,12 +48,12 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-instrumented-service-otel.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
+		kube.Deploy(testpath.Manifests+"/05-instrumented-service-otel.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -37,21 +38,20 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-owners",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.LocalImage("jaegertracing/all-in-one:1.57"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/04-jaeger.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-statefulset.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-daemonset.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-daemonset.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/04-jaeger.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-statefulset.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-daemonset.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-daemonset.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/process_notraces/k8s_process_notraces_test.go
+++ b/test/integration/k8s/process_notraces/k8s_process_notraces_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/kube"
 	"github.com/grafana/beyla/test/integration/components/prom"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -38,16 +39,15 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-process-notraces",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-service.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-all-processes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-all-processes.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/prom/k8s_prom_main_test.go
+++ b/test/integration/k8s/prom/k8s_prom_main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/docker"
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -30,17 +31,16 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-prom",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-promscrape.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-instrumented-service-prometheus.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
+		kube.Deploy(testpath.Manifests+"/05-instrumented-service-prometheus.yml"),
 	)
 
 	cluster.Run(m)

--- a/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/kube"
 	"github.com/grafana/beyla/test/integration/components/prom"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -38,19 +39,18 @@ func TestMain(m *testing.M) {
 	}
 
 	cluster = kube.NewKind("test-kind-cluster-otel-multi",
-		kube.ExportLogs(k8s.PathKindLogs),
-		kube.KindConfig(k8s.PathManifests+"/00-kind-multi-node.yml"),
+		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
 		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
-		kube.Deploy(k8s.PathManifests+"/01-volumes.yml"),
-		kube.Deploy(k8s.PathManifests+"/01-serviceaccount.yml"),
-		kube.Deploy(k8s.PathManifests+"/02-prometheus-otelscrape-multi-node.yml"),
-		kube.Deploy(k8s.PathManifests+"/03-otelcol.yml"),
-		kube.Deploy(k8s.PathManifests+"/05-uninstrumented-server-client-different-nodes.yml"),
-		kube.Deploy(k8s.PathManifests+"/06-beyla-netolly.yml"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-server-client-different-nodes.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly.yml"),
 	)
 
 	cluster.Run(m)


### PR DESCRIPTION
There are some flaky tests that are difficult to debug because they seem impossible to reproduce locally.

This PR dumps the contents of the prometheus and jaeger storages before a cluster is being shutdown. This way we can diagnose better what is missing in the metrics or traces, if a test fail.