### PR TITLE
Add note about preventing self-instrumentation

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -204,6 +204,13 @@ config:
     #     cloud_zone: prod-eu-west-0
     #     cloud_instance_id: 123456
     #     cloud_api_key:
+    ## when supplying a custom discovery configuration it is recommended to add
+    ## the below default excludes because they would be overwritten otherwise.
+    ## these default excludes prevent Beyla from instrumenting itself.
+    ## if omitted, self-instrumentation will be enabled.
+    # discovery:
+    #   exclude_services:
+    #     - exe_path: ".*alloy.*|.*otelcol.*|.*beyla.*"
     attributes:
       kubernetes:
         enable: true
@@ -219,13 +226,13 @@ config:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
         k8s_src_owner_name:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
-    # to enable network metrics
+    ## to enable network metrics
     # network:
     #   enable: true
     prometheus_export:
       port: 9090
       path: /metrics
-    # to enable internal metrics
+    ## to enable internal metrics
     # internal_metrics:
     #   prometheus:
     #     port: 6060


### PR DESCRIPTION
This adds a note to the Helm chart values to be careful around supplying a custom `discovery` configuration. It points the user towards needing to add the default excludes back in, at least currently while the application itself does not have these excludes in a separate configuration property.

Related to #1454 but does not close it - it will be closed by a subsequent PR.