### PR TITLE
Fix Docker release status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Open source zero-code automatic instrumentation with eBPF and OpenTelemetry.
 
-![status badge](https://github.com/grafana/beyla/actions/workflows/publish_dockerhub.yml/badge.svg)
+![status badge](https://github.com/grafana/beyla/actions/workflows/publish_dockerhub_release.yml/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
Fixes the Dockerhub release status badge in the README (the link was broken due to the Github action probably being renamed somewhere in the past).