### PR TITLE
Add support for auto detecting TCX

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/vale-action@4b1248585248751e3b12fd020cf7ac91540ca09c # vale-action/v1.0.0
+      - uses: grafana/writers-toolkit/vale-action@13205961f20ad13843505a9b84fdf032f911a3f4 # vale-action/v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,3 +2,4 @@ MinAlertLevel = warning
 
 [*]
 BasedOnStyles = Grafana
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -510,8 +510,8 @@ deterministic way to chain probes). We recommend the usage of the tcx
 backend for kernels >= 6.6 for this reason. When set to `auto`, Beyla will
 pick the most suitable backend based on the underlying kernel.
 
-The accepted backends are `tc`, `tcx` and `auto. An empty or unset value
-defaults to `auto`.
+The accepted backends are `tc`, `tcx`, and `auto.
+An empty or unset value defaults to `auto`.
 
 | YAML                    | Environment variable               | Type    | Default |
 | ----------------------- | ---------------------------------- | ------- | ------- |

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -500,17 +500,18 @@ generation of Beyla metrics.
 
 | YAML                      | Environment variable              | Type    | Default |
 | ------------------------- | --------------------------------- | ------- | ------- |
-| `traffic_control_backend` | `BEYLA_BPF_TC_BACKEND`            | string  |  `tc`   |
+| `traffic_control_backend` | `BEYLA_BPF_TC_BACKEND`            | string  |  `auto` |
 
 Chooses which backend to use for the attachment of traffic control probes.
 Linux 6.6 has added support for a file-descriptor based traffic control
 attachment called TCX, providing a more robust way of attaching traffic
 control probes (it does not require explicit qdisc management, and provides a
-deterministic way to chain probes). We recommend the usage of the `tcx`
-backend for kernels >= 6.6 for this reason.
+deterministic way to chain probes). We recommend the usage of the tcx
+backend for kernels >= 6.6 for this reason. When set to `auto`, Beyla will
+pick the most suitable backend based on the underlying kernel.
 
-The accepted backends are `tc` and `tcx`. An empty or unset value defaults to
-`tc`.
+The accepted backends are `tc`, `tcx` and `auto. An empty or unset value
+defaults to `auto`.
 
 | YAML                    | Environment variable               | Type    | Default |
 | ----------------------- | ---------------------------------- | ------- | ------- |

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -506,9 +506,9 @@ Chooses which backend to use for the attachment of traffic control probes.
 Linux 6.6 has added support for a file-descriptor based traffic control
 attachment called TCX, providing a more robust way of attaching traffic
 control probes (it does not require explicit qdisc management, and provides a
-deterministic way to chain probes). We recommend the usage of the tcx
-backend for kernels >= 6.6 for this reason. When set to `auto`, Beyla will
-pick the most suitable backend based on the underlying kernel.
+deterministic way to chain probes).
+We recommend the usage of the `tcx` backend for kernels >= 6.6 for this reason.
+When set to `auto`, Beyla picks the most suitable backend based on the underlying kernel.
 
 The accepted backends are `tc`, `tcx`, and `auto.
 An empty or unset value defaults to `auto`.

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -49,7 +49,7 @@ var DefaultConfig = Config{
 		BatchLength:        100,
 		BatchTimeout:       time.Second,
 		HTTPRequestTimeout: 30 * time.Second,
-		TCBackend:          tcmanager.TCBackendTC,
+		TCBackend:          tcmanager.TCBackendAuto,
 	},
 	Grafana: otel.GrafanaConfig{
 		OTLP: otel.GrafanaOTLP{

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -125,7 +125,7 @@ network:
 			BatchLength:        100,
 			BatchTimeout:       time.Second,
 			HTTPRequestTimeout: 30 * time.Second,
-			TCBackend:          tcmanager.TCBackendTC,
+			TCBackend:          tcmanager.TCBackendAuto,
 		},
 		Grafana: otel.GrafanaConfig{
 			OTLP: otel.GrafanaOTLP{

--- a/pkg/internal/ebpf/tcmanager/ifacemanager.go
+++ b/pkg/internal/ebpf/tcmanager/ifacemanager.go
@@ -48,6 +48,8 @@ func NewInterfaceManager() *InterfaceManager {
 }
 
 func (im *InterfaceManager) Start(ctx context.Context) {
+	im.log.Debug("Starting InterfaceManager", "monitor_mode", im.monitorMode)
+
 	if im.registerer != nil {
 		return
 	}
@@ -61,6 +63,8 @@ func (im *InterfaceManager) Start(ctx context.Context) {
 	}
 
 	registerer := ifaces.NewRegisterer(informer, im.channelBufferLen)
+
+	im.log.Debug("Subscribing for events")
 
 	ifaceEvents, err := registerer.Subscribe(ctx)
 


### PR DESCRIPTION
Add a configuration option called `BEYLA_BPF_TC_BACKEND=auto`, which tells Beyla to query the underlying kernel for TCX support. If TCX is supported, Beyla will use that, falling back to TC/Netlink otherwise.