### PR TITLE
Improve cuda module discovery

### DIFF
--- a/pkg/internal/exec/procmaps.go
+++ b/pkg/internal/exec/procmaps.go
@@ -26,3 +26,13 @@ func LibPath(name string, maps []*procfs.ProcMap) *procfs.ProcMap {
 
 	return nil
 }
+
+func LibPathPlain(name string, maps []*procfs.ProcMap) *procfs.ProcMap {
+	for _, m := range maps {
+		if strings.Contains(m.Pathname, name) && m.Perms.Execute {
+			return m
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Our previous implementation of the CUDA kernel monitoring code assumed there will be only one module where the kernels would be found, the executable or libtorch_cuda.so. However after experimenting with VLLM we realized that it can be multiple modules, VLLM specific  + libtorch_cuda. 

With this PR I'm reworking how symbols resolution is done to support multiple modules for the kernels. I've also simplified and cleaned up the code.