### PR TITLE
Adding defaults for metadata source labels

### DIFF
--- a/pkg/internal/ebpf/tcmanager/cilium_support.go
+++ b/pkg/internal/ebpf/tcmanager/cilium_support.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package tcmanager
 
 import (

--- a/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
+++ b/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
@@ -21,3 +21,5 @@ func (d *dummyManager) AddProgram(_ string, _ *ebpf.Program, _ AttachmentType) {
 func (d *dummyManager) RemoveProgram(_ string)                                 {}
 func (d *dummyManager) InterfaceName(_ int) (string, bool)                     { return "", false }
 func (d *dummyManager) SetInterfaceManager(_ *InterfaceManager)                {}
+
+func EnsureCiliumCompatibility(_ TCBackend) error { return nil }

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -57,11 +57,12 @@ var DefaultMetadataSources = MetadataSources{
 		ServiceName:      []string{"resource.opentelemetry.io/service.name"},
 		ServiceNamespace: []string{"resource.opentelemetry.io/service.namespace"},
 	},
-	// empty by default. If a user sets useLabelsForResourceAttributes: true it its OTEL operator, also
-	// the values below should be populated so:
-	//   - `app.kubernetes.io/name` becomes `service.name`
-	//   - `app.kubernetes.io/part-of` becomes `service.namespace`
-	Labels: LabelSources{},
+	// If a user sets useLabelsForResourceAttributes: false it its OTEL operator, is the task of the
+	// OTEL operator to provide empty values for this.
+	Labels: LabelSources{
+		ServiceName:      []string{"app.kubernetes.io/name"},
+		ServiceNamespace: []string{"app.kubernetes.io/part-of"},
+	},
 }
 
 // Store aggregates Kubernetes information from multiple sources:


### PR DESCRIPTION
This way we will still be compliant with the OTEL operator way of working, but still on relying on the operator setting the values, we rely on it removing them.

This would also minimize the chance of breaking changes for Beyla 1.9 customers that already set the old `meta_source_labels` configuration option to `app.kubernetes.io/*`.

Also fixes compilation on Mac.