### PR TITLE
report Beyla version in OTEL traces and metrics

### DIFF
--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -19,6 +19,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/grafana/beyla/pkg/buildinfo"
 	"github.com/grafana/beyla/pkg/export/attributes"
 	"github.com/grafana/beyla/pkg/export/expire"
 	"github.com/grafana/beyla/pkg/internal/svc"
@@ -76,6 +77,7 @@ func getResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
 		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
 		semconv.TelemetrySDKNameKey.String("beyla"),
+		semconv.TelemetrySDKVersion(buildinfo.Version),
 		semconv.HostName(service.HostName),
 		semconv.HostID(hostID),
 	}

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
+	"github.com/grafana/beyla/pkg/buildinfo"
 	"github.com/grafana/beyla/pkg/export/attributes"
 	"github.com/grafana/beyla/pkg/export/expire"
 	"github.com/grafana/beyla/pkg/export/otel/metric"
@@ -47,6 +48,7 @@ func newResource(hostID string) *resource.Resource {
 		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
 		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
 		semconv.TelemetrySDKNameKey.String("beyla"),
+		semconv.TelemetrySDKVersion(buildinfo.Version),
 		semconv.HostID(hostID),
 	}
 

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -95,6 +95,9 @@ func TestBasicPipeline(t *testing.T) {
 	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.MetricRecord{
 		Name: "http.server.request.duration",
 		Unit: "s",
@@ -303,6 +306,8 @@ func TestRouteConsolidation(t *testing.T) {
 	for _, event := range events {
 		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 		delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
+		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+		delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	}
 	assert.Equal(t, collector.MetricRecord{
 		Name: "http.server.request.duration",
@@ -415,6 +420,9 @@ func TestGRPCPipeline(t *testing.T) {
 	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.MetricRecord{
 		Name: "rpc.server.duration",
 		Unit: "s",
@@ -509,6 +517,9 @@ func TestBasicPipelineInfo(t *testing.T) {
 	event := testutil.ReadChannel(t, tc.Records(), testTimeout)
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.MetricRecord{
 		Name: "http.server.request.duration",
 		Unit: "s",
@@ -688,6 +699,9 @@ func getHostname() string {
 }
 
 func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecord) {
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.NotEmpty(t, event.Attributes["span_id"])
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
@@ -716,6 +730,9 @@ func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecor
 }
 
 func matchInnerTraceEvent(t require.TestingT, name string, event collector.TraceRecord) {
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.NotEmpty(t, event.Attributes["span_id"])
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
@@ -737,6 +754,9 @@ func matchInnerTraceEvent(t require.TestingT, name string, event collector.Trace
 }
 
 func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
 		Attributes: map[string]string{
@@ -762,6 +782,9 @@ func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord)
 }
 
 func matchInnerGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
 		Attributes: map[string]string{
@@ -809,6 +832,9 @@ func newHTTPInfo(method, path, peer string, status int) []request.Span {
 }
 
 func matchInfoEvent(t *testing.T, name string, event collector.TraceRecord) {
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
 		Attributes: map[string]string{


### PR DESCRIPTION
Prometheus metrics already report the Beyla version in `beyla_build_info`, but we were lacking such information in the OTEL exporters.

Having the Beyla version as resource attribute would simplify users' troubleshooting.