### PR TITLE
Fix system services pattern

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -239,7 +239,7 @@ Prometheus.
 
 | YAML                      | Environment variable            | Type    | Default                           |
 | ------------------------- | ------------------------------- | ------- | --------------------------------- |
-| `exclude_system_services` | `BEYLA_EXCLUDE_SYSTEM_SERVICES` | string  | `.*alloy.*|.*otelcol.*|.*beyla.*` |
+| `default_exclude_services` | N/A | list of objects  | Path: `(?:^\|\/)(beyla$\|alloy$\|otelcol[^\/]*$)` |
 
 Disables instrumentation of Beyla itself (self-instrumentation), as well as Grafana Alloy and the
 OpenTelemetry Collector. Set to empty to allow Beyla to instrument itself as well as these other components.

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"time"
 
 	"github.com/caarlos0/env/v9"
@@ -132,7 +133,11 @@ var DefaultConfig = Config{
 	},
 	Discovery: services.DiscoveryConfig{
 		ExcludeOTelInstrumentedServices: true,
-		ExcludeSystemServices:           `(?:^|\/)(beyla$|alloy$|otelcol[^\/]*$)`,
+		DefaultExcludeServices: services.DefinitionCriteria{
+			services.Attributes{
+				Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
+			},
+		},
 	},
 }
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -132,7 +132,7 @@ var DefaultConfig = Config{
 	},
 	Discovery: services.DiscoveryConfig{
 		ExcludeOTelInstrumentedServices: true,
-		ExcludeSystemServices:           `.*alloy.*|.*otelcol.*|.*beyla.*`,
+		ExcludeSystemServices:           `(?:^|\/)(beyla$|alloy$|otelcol[^\/]*$)`,
 	},
 }
 

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -217,7 +217,7 @@ network:
 		},
 		Discovery: services.DiscoveryConfig{
 			ExcludeOTelInstrumentedServices: true,
-			ExcludeSystemServices:           `.*alloy.*|.*otelcol.*|.*beyla.*`,
+			ExcludeSystemServices:           `(?:^|\/)(beyla$|alloy$|otelcol[^\/]*$)`,
 		},
 	}, cfg)
 }

--- a/pkg/internal/discover/matcher.go
+++ b/pkg/internal/discover/matcher.go
@@ -21,16 +21,8 @@ func CriteriaMatcherProvider(cfg *beyla.Config) pipe.MiddleProvider[[]Event[proc
 		m := &matcher{
 			log:             slog.With("component", "discover.CriteriaMatcher"),
 			criteria:        FindingCriteria(cfg),
-			excludeCriteria: cfg.Discovery.ExcludeServices,
+			excludeCriteria: append(cfg.Discovery.ExcludeServices, cfg.Discovery.DefaultExcludeServices...),
 			processHistory:  map[PID]*services.ProcessInfo{},
-		}
-
-		if cfg.Discovery.ExcludeSystemServices != "" {
-			r := regexp.MustCompile(cfg.Discovery.ExcludeSystemServices)
-
-			m.excludeCriteria = append(m.excludeCriteria, services.Attributes{
-				Path: services.NewPathRegexp(r),
-			})
 		}
 
 		return m.run, nil

--- a/pkg/internal/netolly/ebpf/net_arm64_bpfel.o
+++ b/pkg/internal/netolly/ebpf/net_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aac80f3a9bbcd9747fbdca6978a12ddbab631199022f4ab70f3095d4fc692b68
+oid sha256:e1e3c72b43e44b518a0604fcf2ed976514b5d336910f324d04a88eddd53b7530
 size 31264

--- a/pkg/internal/netolly/ebpf/netsk_x86_bpfel.o
+++ b/pkg/internal/netolly/ebpf/netsk_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16b7f04caeda4508b3feae3389d29628540f4d03f80c0f22f5a8135803a94b96
+oid sha256:e44f7e55277d6095dcec27a7f1c63c71fa9f9279dd1af2a377ed8c54c8abcc08
 size 28384

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -51,9 +51,9 @@ type DiscoveryConfig struct {
 	// even if they match the Services selection.
 	ExcludeServices DefinitionCriteria `yaml:"exclude_services"`
 
-	// ExcludeSystemServices by default prevents self-instrumentation of Beyla as well as related services (Alloy and OpenTelemetry collector)
+	// DefaultExcludeServices by default prevents self-instrumentation of Beyla as well as related services (Alloy and OpenTelemetry collector)
 	// It must be set to an empty string or a different value if self-instrumentation is desired.
-	ExcludeSystemServices string `yaml:"exclude_system_services" env:"BEYLA_EXCLUDE_SYSTEM_SERVICES"`
+	DefaultExcludeServices DefinitionCriteria `yaml:"default_exclude_services"`
 
 	// PollInterval specifies, for the poll service watcher, the interval time between
 	// process inspections


### PR DESCRIPTION
The existing pattern we used in our Chart.yaml for Beyla/Alloy/OTelCol could accidentally exclude services because it didn't match the executable name but anywhere in the path. We noticed this since the chart defaults became part of the 'system services'.

I've changed the pattern to match the executable, but I made some more adjustments. I renamed the field to say default_exclude_services instead of system_services and I made the field use the DiscoveryCriteria in case we want to extend in the future the use of k8s defaults we should exclude.