### PR TITLE
Fixing tests for annotation/label-based service name and namespace

### DIFF
--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -114,6 +114,7 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 		"k8s_replicaset_name":      "^testserver-",
 		"k8s_cluster_name":         "^beyla$",
 		"server_service_namespace": "integration-test",
+		"server":                   "testserver",
 		"source":                   "beyla",
 		"host_name":                "testserver",
 		"host_id":                  HostIDRegex,
@@ -124,6 +125,9 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 			allAttributes["instance"] = sid
 		}
 	}
+	overriddenNameNS := attributeMap(allAttributes, overrideAttrs, "server", "server_service_namespace")
+	expectedServer := overriddenNameNS["server"]
+	expectedJob := overriddenNameNS["server_service_namespace"] + "/" + expectedServer
 
 	return features.New("Decoration of Pod-to-Service communications").
 		Setup(pinger.Deploy()).
@@ -150,12 +154,12 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 					"k8s_cluster_name",
 				))).
 		Assess("all the span graph metrics exist",
-			testMetricsDecoration(spanGraphMetrics, `{server="testserver",client="internal-pinger"}`,
+			testMetricsDecoration(spanGraphMetrics, `{server="`+expectedServer+`",client="internal-pinger"}`,
 				attributeMap(allAttributes, overrideAttrs,
 					"server_service_namespace",
 					"source",
 				))).Assess("target_info metrics exist",
-		testMetricsDecoration([]string{"target_info"}, `{job=~".*testserver"}`,
+		testMetricsDecoration([]string{"target_info"}, `{job="`+expectedJob+`"}`,
 			attributeMap(allAttributes, overrideAttrs,
 				"host_name",
 				"host_id",

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -64,7 +64,8 @@ func TestInformersCache_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
 func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.UninstrumentedPingerManifest,
 		map[string]string{
-			"server_service_namespace": "default",
+			"server":                   "overridden-testserver-name",
+			"server_service_namespace": "overridden-testserver-namespace",
 			"k8s_cluster_name":         "my-kube",
 			"service_name":             "overridden-testserver-name",
 			"service_namespace":        "overridden-testserver-namespace",

--- a/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -31,12 +31,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: testserver
-  annotations:
-    my.custom/name: 'overridden-testserver-name'
   labels:
     app: testserver
-    app.kubernetes.io/name: 'ignored-testserver-name'
-    app.kubernetes.io/part-of: 'overridden-testserver-namespace'
 spec:
   replicas: 1
   selector:
@@ -45,8 +41,12 @@ spec:
   template:
     metadata:
       name: testserver
+      annotations:
+        my.custom/name: 'overridden-testserver-name'
       labels:
         app: testserver
+        app.kubernetes.io/name: 'ignored-testserver-name'
+        app.kubernetes.io/part-of: 'overridden-testserver-namespace'
     spec:
       containers:
         - name: testserver


### PR DESCRIPTION
Some integration tests lead to some confusion, as Beyla can be configured to take service name/namespace from **Pod** annotations while the tests were configuring Beyla to set those annotations at the Deployment level.

This also lead to some inconsistencies in the tests.