### PR TITLE
Update workflows to use actions that don't need organization secrets

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -5,35 +5,17 @@ on:
     branches:
       - main
     paths:
-      - docs/sources/**
+      - "docs/sources/**"
   workflow_dispatch:
 jobs:
   sync:
     if: github.repository == 'grafana/beyla'
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
-          lfs: true
-
-      - name: Clone website-sync Action
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
-
-      - name: Publish to website repository (next)
-        uses: ./.github/actions/website-sync
-        id: publish-next
-        with:
-          repository: grafana/website
-          branch: master
-          host: github.com
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
-          source_folder: docs/sources
-          target_folder: content/docs/beyla/next
+          website_directory: content/docs/beyla/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -12,67 +12,18 @@ on:
 jobs:
   sync:
     if: github.repository == 'grafana/beyla'
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Grafana repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
-
-      - name: Checkout Actions library
-        uses: actions/checkout@v4
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
-          repository: grafana/grafana-github-actions
-          path: ./actions
-
-      - name: Install Actions from library
-        run: npm install --production --prefix ./actions
-
-      - name: Determine if there is a matching release tag
-        id: has-matching-release-tag
-        uses: ./actions/has-matching-release-tag
-        with:
-          ref_name: ${{ github.ref_name }}
-          release_tag_regexp: '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
-          release_branch_regexp: '^release-(0|[1-9]\d*)\.(0|[1-9]\d*)$'
-
-      - name: Determine technical documentation version
-        if: steps.has-matching-release-tag.outputs.bool == 'true'
-        uses: ./actions/docs-target
-        id: target
-        with:
-          ref_name: ${{ github.ref_name }}
-
-      - name: Clone website-sync Action
-        if: steps.has-matching-release-tag.outputs.bool == 'true'
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
-
-      - name: Switch to HEAD of version branch for tags
-        # Tags aren't necessarily made to the HEAD of the version branch.
-        # The documentation to be published is always on the HEAD of the version branch.
-        if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
-        # Strip the 'v' prefix from docs-target output.
-        run: git switch --detach origin/release-${TARGET#v}
-        env:
-          TARGET: ${{ steps.target.outputs.target }}
-
-      - name: Publish to website repository (release)
-        if: steps.has-matching-release-tag.outputs.bool == 'true'
-        uses: ./.github/actions/website-sync
-        id: publish-release
-        with:
-          repository: grafana/website
-          branch: master
-          host: github.com
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
-          source_folder: docs/sources
-          target_folder: content/docs/beyla/${{ steps.target.outputs.target }}.x
+          release_tag_regexp: '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          release_branch_with_patch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          website_directory: content/docs/beyla


### PR DESCRIPTION
Until this is merged, no documentation can be published from this repository to the website.

Each repository can only have 100 organization secrets and there are now more than 100 in our organization which causes inconsistent behavior.

Some repositories don't have the secrets they need assigned.

These composite actions use secrets stored in Vault that are available to all repositories. There is some copy-paste involved in the creation of these workflows. Please check:

For `publish-technical-documentation-next.yml`:

- [ ] The `on.push` `branches` and `paths` filters are correct for your repository.
- [ ] The `jobs.sync.if` repository matches your repository.
- [ ] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.

For `publish-technical-documentation-release.yml`:

- [ ] The `on.push` `branches`, `tags`, and `paths` filters are correct for your repository.
- [ ] The `jobs.sync.if` repository matches your repository.
- [ ] The `jobs.sync.steps[1].with.release_tag_regexp` regular expression matches your tags and captures major, minor, and patch versions from those tags.
- [ ] The `jobs.sync.steps[1].with.release_branch_regexp` regular expression matches your release branch names and captures major and minor versions from those branch names.
- [ ] The `jobs.sync.steps[1].with.release_branch_with_patch_regexp` regular expression matches your release branch names if they were to include a patch version, and that it would capture major, minor, and patch versions from those branch names.
- [ ] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.

We'll also need to backport this to any branches where you are maintaining documentation that you want synced to the website.