### PR TITLE
Documenting service name and namespace configuration. Deprecating name/namespace discovery properties.

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -106,9 +106,9 @@ restrict the instrumentation only to the methods exposed through a specific port
 If the specified port range is wide (e.g. `1-65535`) Beyla will try to execute all the processes
 owning one of the ports in the range.
 
-| YAML           | Environment variable                                     | Type   | Default                                               |
-|----------------| ------------------------------------------- | ------ | ----------------------------------------------------- |
-| `service_name` | `BEYLA_SERVICE_NAME` | string | (see [service discovery]({{< relref "./service-discovery.md" >}}) section) |
+| YAML           | Environment variable                                     | Type   | Default                                                                         |
+|----------------| ------------------------------------------- | ------ |---------------------------------------------------------------------------------|
+| `service_name` | `BEYLA_SERVICE_NAME` | string | (refer to [service discovery]({{< relref "./service-discovery.md" >}}) section) |
 
 **Deprecated**.
 
@@ -122,9 +122,9 @@ single instance of Beyla report different service names, follow the instructions
 [_overriding service name and namespace_ section of the service discovery documentation]({{< relref "./service-discovery.md" >}})
 to enable automatic configuration of service name and namespace from diverse metadata sources.
 
-| YAML                | Environment variable                   | Type   | Default                                               |
-| ------------------- | ------------------------- | ------ | ----------------------------------------------------- |
-| `service_namespace` | `BEYLA_SERVICE_NAMESPACE` | string | (see [service discovery]({{< relref "./service-discovery.md" >}}) section) |
+| YAML                | Environment variable                   | Type   | Default                                                                         |
+| ------------------- | ------------------------- | ------ |---------------------------------------------------------------------------------|
+| `service_namespace` | `BEYLA_SERVICE_NAMESPACE` | string | (refer to [service discovery]({{< relref "./service-discovery.md" >}}) section) |
 
 **Deprecated**.
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -107,21 +107,26 @@ If the specified port range is wide (e.g. `1-65535`) Beyla will try to execute a
 owning one of the ports in the range.
 
 | YAML           | Environment variable                                     | Type   | Default                                               |
-| -------------- | ------------------------------------------- | ------ | ----------------------------------------------------- |
-| `service_name` | `BEYLA_SERVICE_NAME` or `OTEL_SERVICE_NAME` | string | (see [service discovery]({{< relref "./service-discovery.md" >}}) section) |
+|----------------| ------------------------------------------- | ------ | ----------------------------------------------------- |
+| `service_name` | `BEYLA_SERVICE_NAME` | string | (see [service discovery]({{< relref "./service-discovery.md" >}}) section) |
+
+**Deprecated**.
 
 Overrides the name of the instrumented service to be reported by the metrics exporter.
 Defining this property is equivalent to add a `name` entry into the [`discovery.services` YAML
 section]({{< relref "./service-discovery.md" >}}).
 
-If a single instance of Beyla is instrumenting multiple instances of different processes,
+This configuration option is deprecated. If a single instance of Beyla is instrumenting multiple instances of different processes,
 they will share the same service name even if they are different. If you need that a
 single instance of Beyla report different service names, follow the instructions in the
-[service discovery section]({{< relref "./service-discovery.md" >}}).
+[_overriding service name and namespace_ section of the service discovery documentation]({{< relref "./service-discovery.md" >}})
+to enable automatic configuration of service name and namespace from diverse metadata sources.
 
 | YAML                | Environment variable                   | Type   | Default                                               |
 | ------------------- | ------------------------- | ------ | ----------------------------------------------------- |
 | `service_namespace` | `BEYLA_SERVICE_NAMESPACE` | string | (see [service discovery]({{< relref "./service-discovery.md" >}}) section) |
+
+**Deprecated**.
 
 Optionally, allows assigning a namespace for the service selected from the `executable_name`
 or `open_port` properties.
@@ -129,14 +134,11 @@ or `open_port` properties.
 Defining this property is equivalent to add a `name` entry into the [`discovery.services` YAML
 section]({{< relref "./service-discovery.md" >}}).
 
-This will assume a single namespace for all the services instrumented
+This configuration option is deprecated, as it assumes a single namespace for all the services instrumented
 by Beyla. If you need that a single instance of Beyla groups multiple services
 into different namespaces, follow the instructions in the
-[service discovery section]({{< relref "./service-discovery.md" >}}).
-
-It is important to notice that this namespace is not a selector for Kubernetes namespaces. Its
-value will be use to set the value of standard telemetry attributes. For example, the
-[OpenTelemetry `service.namespace` attribute](https://opentelemetry.io/docs/specs/otel/common/attribute-naming/).
+[_overriding service name and namespace_ section of the service discovery documentation]({{< relref "./service-discovery.md" >}})
+to enable automatic configuration of service name and namespace from diverse metadata sources.
 
 | YAML        | Environment variable           | Type   | Default |
 | ----------- | ----------------- | ------ | ------- |

--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -122,7 +122,7 @@ OTEL property and the `service_name` Prometheus property in the exported metrics
 
 This option is deprecated, as multiple matches for the same `services` entry would involve
 multiple services sharing the same name.
-Check the [overriding service name and namespace](#overriding-service-name-and-namespace) section
+Check the [override service name and namespace](#override-service-name-and-namespace) section
 to enable automatic configuration of service name and namespace from diverse metadata sources. 
 
 If the property is not set, it will default to any of the following properties, in order of
@@ -301,7 +301,7 @@ discovery:
 The preceding example discovers all Pods in the `frontend` namespace that have a label
 `instrument` with a value that matches the regular expression `beyla`.
 
-## Overriding service name and namespace
+## Override service name and namespace
 
 Either if the instrumentation data is exported via OpenTelemetry or via Prometheus, Beyla follows the
 [service naming conventions from the OpenTelemetry operator](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md#how-resource-attributes-are-calculated-from-the-pods-metadata)

--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -153,7 +153,7 @@ If the property is not set, it will be defaulted to the Kubernetes namespace of
 that runs the instrumented process, if Kubernetes is available, or empty when
 Kubernetes is not available.
 
-This option is deprecated. Check the [overriding service name and namespace](#overriding-service-name-and-namespace) section
+This option is deprecated. Check the [overriding service name and namespace](#override-service-name-and-namespace) section
 to enable automatic configuration of service name and namespace from diverse metadata sources.
 
 It is important to notice that this namespace is not a selector for Kubernetes namespaces. Its


### PR DESCRIPTION
It also deprecates the explicit service name/namespace properties that had to be specified as Beyla discovery properties, by the reasons argued in the docs.