### PR TITLE
Default metrics expiration TTL to 70 minutes

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	defaultMetricsTTL = 5 * time.Minute
+	defaultMetricsTTL = 70 * time.Minute
 )
 
 var DefaultConfig = Config{
@@ -75,8 +75,6 @@ var DefaultConfig = Config{
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},
-		// TODO: keep OTEL expiration disabled by default until we address
-		// this issue: https://github.com/grafana/beyla/issues/1065
 		TTL: defaultMetricsTTL,
 	},
 	Traces: otel.TracesConfig{

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -148,7 +148,7 @@ network:
 				instrumentations.InstrumentationALL,
 			},
 			HistogramAggregation: "base2_exponential_bucket_histogram",
-			TTL:                  defaultMetricsTTL,
+			TTL:                  5 * time.Minute,
 		},
 		Traces: otel.TracesConfig{
 			Protocol:           otel.ProtocolUnset,


### PR DESCRIPTION
Alleviates (but doesn't fix) https://github.com/grafana/beyla/issues/1388