### PR TITLE
Change the way resource attributes are populated (unbreaks a 2.0 change)

### DIFF
--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -321,39 +321,20 @@ Beyla uses the following criteria in this order to automatically set the service
     - `k8s.container.name`
 5. The executable name of the instrumented process.
 
-The Kubernetes annotations and labels from the previous bullets 2 and 3 can be overridden and via
-configuration.
+The Kubernetes labels from the previous bullet 3 can be overridden via configuration.
 
 In YAML:
 ```yaml
 kubernetes:
-  meta_naming_sources:
-      annotations:
-        service_name:
-          # gets service name from the first existing Pod annotation
-          - my.domain.com/override-service-name
-          - resource.opentelemetry.io/service.name
-        service_namespace:
-          # gets service namespace from the first existing Pod annotation
-          - my.domain.com/override-service-namespace
-          - resource.opentelemetry.io/service.namespace
-      labels:
-        service_name:
-          # gets service name from the first existing Pod label
-          - override-svc-name
-          - app.kubernetes.io/name
-        service_namespace:
-          # gets service namespace from the first existing Pod label
-          - override-svc-ns
-          - app.kubernetes.io/part-of
+  resource_labels:
+    service.name:
+      # gets service name from the first existing Pod label
+      - override-svc-name
+      - app.kubernetes.io/name
+    service.namespace:
+      # gets service namespace from the first existing Pod label
+      - override-svc-ns
+      - app.kubernetes.io/part-of
 ```
-
-The equivalent environment variables for the labels and annotation overriding
-properties are:
-
-* `BEYLA_KUBE_ANNOTATIONS_SERVICE_NAME`
-* `BEYLA_KUBE_ANNOTATIONS_SERVICE_NAMESPACE`
-* `BEYLA_KUBE_LABELS_SERVICE_NAME`
-* `BEYLA_KUBE_LABELS_SERVICE_NAMESPACE`
 
 They accept a comma-separated list of annotation and label names.

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -115,7 +115,7 @@ var DefaultConfig = Config{
 			Enable:                kubeflags.EnabledDefault,
 			InformersSyncTimeout:  30 * time.Second,
 			InformersResyncPeriod: 30 * time.Minute,
-			MetadataSources:       kube.DefaultMetadataSources,
+			ResourceLabels:        kube.DefaultResourceLabels,
 		},
 		HostID: HostIDConfig{
 			FetchTimeout: 500 * time.Millisecond,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"regexp"
 	"strings"
@@ -55,11 +56,8 @@ attributes:
     kubeconfig_path: /foo/bar
     enable: true
     informers_sync_timeout: 30s
-    meta_naming_sources:
-      annotations:
-        service_namespace: ["huha.com/yeah"]
-      labels:
-        service_name: ["titi.com/lala"]
+    resource_labels:
+      service.namespace: ["huha.com/yeah"]
   instance_id:
     dns: true
   host_id:
@@ -108,9 +106,8 @@ network:
 	nc.AgentIP = "1.2.3.4"
 	nc.CIDRs = cidr.Definitions{"10.244.0.0/16"}
 
-	metaSources := kube.DefaultMetadataSources
-	metaSources.Annotations.ServiceNamespace = []string{"huha.com/yeah"}
-	metaSources.Labels.ServiceName = []string{"titi.com/lala"}
+	metaSources := maps.Clone(kube.DefaultResourceLabels)
+	metaSources["service.namespace"] = []string{"huha.com/yeah"}
 
 	assert.Equal(t, &Config{
 		Exec:             cfg.Exec,
@@ -190,7 +187,7 @@ network:
 				Enable:                kubeflags.EnabledTrue,
 				InformersSyncTimeout:  30 * time.Second,
 				InformersResyncPeriod: 30 * time.Minute,
-				MetadataSources:       metaSources,
+				ResourceLabels:        metaSources,
 			},
 			HostID: HostIDConfig{
 				Override:     "the-host-id",

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -67,7 +67,7 @@ func TestWatcherKubeEnricher(t *testing.T) {
 
 			// Setup a fake K8s API connected to the watcherKubeEnricher
 			fInformer := &fakeInformer{}
-			store := kube.NewStore(fInformer, kube.MetadataSources{})
+			store := kube.NewStore(fInformer, kube.ResourceLabels{})
 			wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &fakeMetadataProvider{store: store})()
 			require.NoError(t, err)
 			inputCh, outputCh := make(chan []Event[processAttrs], 10), make(chan []Event[processAttrs], 10)
@@ -107,7 +107,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 	processInfo = fakeProcessInfo
 	// Setup a fake K8s API connected to the watcherKubeEnricher
 	fInformer := &fakeInformer{}
-	store := kube.NewStore(fInformer, kube.MetadataSources{})
+	store := kube.NewStore(fInformer, kube.ResourceLabels{})
 	wkeNodeFunc, err := WatcherKubeEnricherProvider(context.TODO(), &fakeMetadataProvider{store: store})()
 	require.NoError(t, err)
 	pipeConfig := beyla.Config{}

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -34,7 +34,7 @@ type MetadataConfig struct {
 	SyncTimeout       time.Duration
 	ResyncPeriod      time.Duration
 	MetaCacheAddr     string
-	MetadataSources   MetadataSources
+	ResourceLabels    ResourceLabels
 	RestrictLocalNode bool
 }
 
@@ -107,7 +107,7 @@ func (mp *MetadataProvider) Get(ctx context.Context) (*Store, error) {
 		return nil, err
 	}
 
-	mp.metadata = NewStore(informer, mp.cfg.MetadataSources)
+	mp.metadata = NewStore(informer, mp.cfg.ResourceLabels)
 
 	return mp.metadata, nil
 }

--- a/pkg/internal/kube/store_test.go
+++ b/pkg/internal/kube/store_test.go
@@ -90,7 +90,7 @@ func TestContainerInfo(t *testing.T) {
 
 	fInformer := &fakeInformer{}
 
-	store := NewStore(fInformer, MetadataSources{})
+	store := NewStore(fInformer, ResourceLabels{})
 
 	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
 	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
@@ -257,7 +257,7 @@ func TestMemoryCleanedUp(t *testing.T) {
 
 	fInformer := &fakeInformer{}
 
-	store := NewStore(fInformer, MetadataSources{})
+	store := NewStore(fInformer, ResourceLabels{})
 
 	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &service})
 	_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &podMetaA})
@@ -281,7 +281,7 @@ func TestMemoryCleanedUp(t *testing.T) {
 // Fixes a memory leak in the store where the objectMetaByIP map was not cleaned up
 func TestMetaByIPEntryRemovedIfIPGroupChanges(t *testing.T) {
 	// GIVEN a store with
-	store := NewStore(&fakeInformer{}, MetadataSources{})
+	store := NewStore(&fakeInformer{}, ResourceLabels{})
 	// WHEN an object is created with several IPs
 	_ = store.On(&informer.Event{
 		Type: informer.EventType_CREATED,
@@ -326,7 +326,7 @@ func TestMetaByIPEntryRemovedIfIPGroupChanges(t *testing.T) {
 }
 
 func TestNoLeakOnUpdateOrDeletion(t *testing.T) {
-	store := NewStore(&fakeInformer{}, MetadataSources{})
+	store := NewStore(&fakeInformer{}, ResourceLabels{})
 	topOwner := &informer.Owner{Name: "foo", Kind: "Deployment"}
 	require.NoError(t, store.On(&informer.Event{
 		Type: informer.EventType_CREATED,

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -53,9 +53,13 @@ type KubernetesDecorator struct {
 	// node as the Beyla instance. It will also restrict the Node information to the local node.
 	MetaRestrictLocalNode bool `yaml:"meta_restrict_local_node" env:"BEYLA_KUBE_META_RESTRICT_LOCAL_NODE"`
 
-	// MetadataSources allows Beyla overriding the service name and namespace of an application from
+	// MetaSourceLabels allows Beyla overriding the service name and namespace of an application from
 	// the given labels.
-	MetadataSources kube.MetadataSources `yaml:"meta_naming_sources"`
+	// Deprecated: kept for backwards-compatibility with Beyla 1.9
+	MetaSourceLabels kube.MetaSourceLabels `yaml:"meta_source_labels"`
+
+	// ResourceLabels allows Beyla overriding the OTEL Resource attributes from a map of user-defined labels.
+	ResourceLabels kube.ResourceLabels `yaml:"resource_labels"`
 }
 
 const (

--- a/pkg/transform/k8s_test.go
+++ b/pkg/transform/k8s_test.go
@@ -22,15 +22,9 @@ const timeout = 5 * time.Second
 
 func TestDecoration(t *testing.T) {
 	inf := &fakeInformer{}
-	store := kube.NewStore(inf, kube.MetadataSources{
-		Annotations: kube.AnnotationSources{
-			ServiceName:      []string{"resource.opentelemetry.io/service.name"},
-			ServiceNamespace: []string{"resource.opentelemetry.io/service.namespace"},
-		},
-		Labels: kube.LabelSources{
-			ServiceName:      []string{"app.kubernetes.io/name"},
-			ServiceNamespace: []string{"app.kubernetes.io/part-of"},
-		},
+	store := kube.NewStore(inf, kube.ResourceLabels{
+		"service.name":      []string{"app.kubernetes.io/name"},
+		"service.namespace": []string{"app.kubernetes.io/part-of"},
 	})
 	// pre-populated kubernetes metadata database
 	inf.Notify(&informer.Event{Type: informer.EventType_CREATED, Resource: &informer.ObjectMeta{

--- a/pkg/transform/name_resolver_test.go
+++ b/pkg/transform/name_resolver_test.go
@@ -32,7 +32,7 @@ func TestSuffixPrefix(t *testing.T) {
 
 func TestResolvePodsFromK8s(t *testing.T) {
 	inf := &fakeInformer{}
-	db := kube2.NewStore(inf, kube2.MetadataSources{})
+	db := kube2.NewStore(inf, kube2.ResourceLabels{})
 	pod1 := &informer.ObjectMeta{Name: "pod1", Kind: "Pod", Ips: []string{"10.0.0.1", "10.1.0.1"}}
 	pod2 := &informer.ObjectMeta{Name: "pod2", Namespace: "something", Kind: "Pod", Ips: []string{"10.0.0.2", "10.1.0.2"}}
 	pod3 := &informer.ObjectMeta{Name: "pod3", Kind: "Pod", Ips: []string{"10.0.0.3", "10.1.0.3"}}
@@ -104,7 +104,7 @@ func TestResolvePodsFromK8s(t *testing.T) {
 
 func TestResolveServiceFromK8s(t *testing.T) {
 	inf := &fakeInformer{}
-	db := kube2.NewStore(inf, kube2.MetadataSources{})
+	db := kube2.NewStore(inf, kube2.ResourceLabels{})
 	pod1 := &informer.ObjectMeta{Name: "pod1", Kind: "Service", Ips: []string{"10.0.0.1", "10.1.0.1"}}
 	pod2 := &informer.ObjectMeta{Name: "pod2", Namespace: "something", Kind: "Service", Ips: []string{"10.0.0.2", "10.1.0.2"}}
 	pod3 := &informer.ObjectMeta{Name: "pod3", Kind: "Service", Ips: []string{"10.0.0.3", "10.1.0.3"}}
@@ -196,7 +196,7 @@ func TestCleanName(t *testing.T) {
 
 func TestResolveNodesFromK8s(t *testing.T) {
 	inf := &fakeInformer{}
-	db := kube2.NewStore(inf, kube2.MetadataSources{})
+	db := kube2.NewStore(inf, kube2.ResourceLabels{})
 	node1 := &informer.ObjectMeta{Name: "node1", Kind: "Node", Ips: []string{"10.0.0.1", "10.1.0.1"}}
 	node2 := &informer.ObjectMeta{Name: "node2", Namespace: "something", Kind: "Node", Ips: []string{"10.0.0.2", "10.1.0.2"}}
 	node3 := &informer.ObjectMeta{Name: "node3", Kind: "Node", Ips: []string{"10.0.0.3", "10.1.0.3"}}

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -270,7 +270,7 @@ func FeatureDisableInformersAppMetricsDecoration() features.Feature {
 					"k8s_pod_name":        "^testserver-.*",
 					"k8s_pod_uid":         UUIDRegex,
 					"k8s_pod_start_time":  TimeRegex,
-					"k8s_deployment_name": "^testserver$",
+					"k8s_deployment_name": "^testserver-deployment$",
 					"k8s_replicaset_name": "^testserver-.*",
 					"k8s_cluster_name":    "^beyla$",
 					"service_instance_id": "^default\\.testserver-.+\\.testserver",

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -127,7 +127,8 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 	}
 	overriddenNameNS := attributeMap(allAttributes, overrideAttrs, "server", "server_service_namespace")
 	expectedServer := overriddenNameNS["server"]
-	expectedJob := overriddenNameNS["server_service_namespace"] + "/" + expectedServer
+	expectedNs := overriddenNameNS["server_service_namespace"]
+	expectedJob := expectedNs + "/" + expectedServer
 
 	return features.New("Decoration of Pod-to-Service communications").
 		Setup(pinger.Deploy()).
@@ -154,7 +155,7 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 					"k8s_cluster_name",
 				))).
 		Assess("all the span graph metrics exist",
-			testMetricsDecoration(spanGraphMetrics, `{server="`+expectedServer+`",client="internal-pinger"}`,
+			testMetricsDecoration(spanGraphMetrics, `{server="`+expectedServer+`",server_service_namespace="`+expectedNs+`",client="internal-pinger"}`,
 				attributeMap(allAttributes, overrideAttrs,
 					"server_service_namespace",
 					"source",
@@ -270,7 +271,7 @@ func FeatureDisableInformersAppMetricsDecoration() features.Feature {
 					"k8s_pod_name":        "^testserver-.*",
 					"k8s_pod_uid":         UUIDRegex,
 					"k8s_pod_start_time":  TimeRegex,
-					"k8s_deployment_name": "^testserver-deployment$",
+					"k8s_deployment_name": "^testserver$",
 					"k8s_replicaset_name": "^testserver-.*",
 					"k8s_cluster_name":    "^beyla$",
 					"service_instance_id": "^default\\.testserver-.+\\.testserver",

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -64,10 +64,12 @@ func TestInformersCache_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
 func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.UninstrumentedPingerManifest,
 		map[string]string{
-			"server":                   "overridden-testserver-name",
+			"server":                   "testserver",
 			"server_service_namespace": "overridden-testserver-namespace",
 			"k8s_cluster_name":         "my-kube",
-			"service_name":             "overridden-testserver-name",
+			"k8s_deployment_name":      "^testserver-deployment$",
+			"k8s_owner_name":           "^testserver-deployment$",
+			"service_name":             "^testserver$",
 			"service_namespace":        "overridden-testserver-namespace",
 			"service_instance_id":      "default.testserver-.+\\.testserver",
 		}))

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -64,12 +64,8 @@ func TestInformersCache_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
 func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.UninstrumentedPingerManifest,
 		map[string]string{
-			"server":                   "testserver",
 			"server_service_namespace": "overridden-testserver-namespace",
 			"k8s_cluster_name":         "my-kube",
-			"k8s_deployment_name":      "^testserver-deployment$",
-			"k8s_owner_name":           "^testserver-deployment$",
-			"service_name":             "^testserver$",
 			"service_namespace":        "overridden-testserver-namespace",
 			"service_instance_id":      "default.testserver-.+\\.testserver",
 		}))

--- a/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -30,7 +30,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: testserver
+  # this hostname will be ignored in favor of resource.opentelemetry.io/service.name
+  name: ignored-testserver
   labels:
     app: testserver
 spec:
@@ -42,7 +43,7 @@ spec:
     metadata:
       name: testserver
       annotations:
-        my.custom/name: 'overridden-testserver-name'
+        resource.opentelemetry.io/service.name: 'testserver'
       labels:
         app: testserver
         app.kubernetes.io/name: 'ignored-testserver-name'

--- a/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -30,8 +30,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # this hostname will be ignored in favor of resource.opentelemetry.io/service.name
-  name: testserver-deployment
+  name: testserver
   labels:
     app: testserver
 spec:

--- a/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -31,7 +31,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   # this hostname will be ignored in favor of resource.opentelemetry.io/service.name
-  name: ignored-testserver
+  name: testserver-deployment
   labels:
     app: testserver
 spec:

--- a/test/integration/k8s/manifests/06-beyla-external-informer.yml
+++ b/test/integration/k8s/manifests/06-beyla-external-informer.yml
@@ -17,12 +17,6 @@ data:
         enable: true
         cluster_name: my-kube
         meta_cache_address: k8s-cache:50055
-        meta_naming_sources:
-          annotations:
-            service_name: [ "my.custom/name" ]
-          labels:
-            service_name: [ "app.kubernetes.io/name" ]
-            service_namespace: [ "app.kubernetes.io/part-of" ]
       select:
         "*":
           include: [ "*" ]


### PR DESCRIPTION
After discussing internally with some users, there was a misinterpretation about the resource labels and attributes, so this PR:

* Restores the `meta_source_labels` from version 1.9, but deprecates it and shows a warning if a user is still using it. There are new users adopting this option in the past days and would not be nice that one week after configuring everything, Beyla 2.0 breaks it.

* Adds the `resource_labels` option as a map, allowing to specify any OTEL resource attribute (not only limited to service name and NS). Currently only name and namespace are considered, but in a following PR, any other attribute is going to be forwarded as a resource attribute.

* The `resource.opentelemetry.io/` annotations are not configurable anymore, as they are an opinionated and standard way to configure any resource attribute, not only service name and namespace (like OTEL_RESOURCE_ATTRIBUTES). In a following PR, we will handle any resource attribute specified in this format.