### PR TITLE
Disable context propagation by default for 2.0

### DIFF
--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -74,9 +74,9 @@ When a metric name matches multiple definitions using wildcards, exact matches h
 
 ## Distributed traces and context propagation
 
-| YAML                         | Environment variable                   | Type    | Default |
-| ---------------------------- | -------------------------------------- | ------- | ------- |
-| `enable_context_propagation` | `BEYLA_BPF_ENABLE_CONTEXT_PROPAGATION` | boolean | (true)  |
+| YAML                         | Environment variable                   | Type    | Default  |
+| ---------------------------- | -------------------------------------- | ------- | -------- |
+| `enable_context_propagation` | `BEYLA_BPF_ENABLE_CONTEXT_PROPAGATION` | boolean | (false)  |
 
 Enables injecting of the `Traceparent` header value for outgoing HTTP requests, allowing
 Beyla to propagate any incoming context to downstream services. This context propagation

--- a/docs/sources/distributed-traces.md
+++ b/docs/sources/distributed-traces.md
@@ -32,6 +32,15 @@ We use these multiple approaches to implement context propagation, because writi
 configuration and the Linux system capabilities granted to Beyla. For more details on this topic, see our KubeCon NA 2024
 talk [So You Want to Write Memory with eBPF?](https://www.youtube.com/watch?v=TUiVX-44S9s).
 
+The context propagation at **network level** is **disabled** by default and can be enabled by setting the environment variable
+`BEYLA_BPF_ENABLE_CONTEXT_PROPAGATION=true` or by modifying the Beyla configuration file:
+
+```yaml
+ebpf:
+  enable_context_propagation: true
+
+```
+
 ### Context propagation at network level
 
 The context propagation at network level is implemented by writing the trace context information in the outgoing HTTP headers as well at the TCP/IP packet level.

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -51,7 +51,7 @@ var DefaultConfig = Config{
 		BatchTimeout:              time.Second,
 		HTTPRequestTimeout:        30 * time.Second,
 		TCBackend:                 tcmanager.TCBackendAuto,
-		ContextPropagationEnabled: true,
+		ContextPropagationEnabled: false,
 	},
 	Grafana: otel.GrafanaConfig{
 		OTLP: otel.GrafanaOTLP{

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -126,7 +126,7 @@ network:
 			BatchTimeout:              time.Second,
 			HTTPRequestTimeout:        30 * time.Second,
 			TCBackend:                 tcmanager.TCBackendAuto,
-			ContextPropagationEnabled: true,
+			ContextPropagationEnabled: false,
 		},
 		Grafana: otel.GrafanaConfig{
 			OTLP: otel.GrafanaOTLP{


### PR DESCRIPTION
Since we are preparing for release 2.0 we should disable the new network based context propagation, until we've tested the support more extensively and let people try it on their own terms for a bit. 

After some careful consideration I think we need to do couple of more checks before we can enable this by default at all times:
1. We should only enable this if the customer is exporting traces, for metrics this option only adds overhead and doesn't have any useful impact.
2. We need to ensure the TC is working correctly before we can enable this. The main challenge is our header injection at L7, which relies on two components. The sock_msg filter is extending the packet, while TC writes the data. If for various reasons, mainly because of improper chaining of TC we fail to run our TC program, the extension of the header value will break the HTTP protocol.
3. We should test how this behaves with sidecars, which is not a test we currently have. Namely, what happens if each individual sidecar registers a TC for it's interface and the sock message is done at the default host cgroup.