### PR TITLE
Remove BEYLA_PRINT_TRACES deprecated option

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -98,7 +98,6 @@ var DefaultConfig = Config{
 		TTL:                         defaultMetricsTTL,
 		SpanMetricsServiceCacheSize: 10000,
 	},
-	Printer:      false, // Deprecated: use TracePrinter instead
 	TracePrinter: debug.TracePrinterDisabled,
 	InternalMetrics: imetrics.Config{
 		Exporter: imetrics.InternalMetricsExporterDisabled,
@@ -159,7 +158,6 @@ type Config struct {
 	Metrics      otel.MetricsConfig            `yaml:"otel_metrics_export"`
 	Traces       otel.TracesConfig             `yaml:"otel_traces_export"`
 	Prometheus   prom.PrometheusConfig         `yaml:"prometheus_export"`
-	Printer      debug.PrintEnabled            `yaml:"print_traces" env:"BEYLA_PRINT_TRACES"`
 	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"BEYLA_TRACE_PRINTER"`
 
 	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
@@ -275,18 +273,7 @@ func (c *Config) Validate() error {
 		return ConfigError(fmt.Sprintf("invalid value for trace_printer: '%s'", c.TracePrinter))
 	}
 
-	if c.Printer.Enabled() && c.TracePrinter.Enabled() {
-		return ConfigError("print_traces and trace_printer are mutually exclusive, use trace_printer instead")
-	}
-
-	// TODO Printer is deprecated, remove
-	if c.Printer.Enabled() {
-		slog.Warn("'print_traces' configuration option has been deprecated and will be removed" +
-			" in the future - use 'trace_printer' instead")
-		c.TracePrinter = debug.TracePrinterText
-	}
-
-	if c.Enabled(FeatureAppO11y) && !c.Printer.Enabled() &&
+	if c.Enabled(FeatureAppO11y) && !c.TracePrinter.Enabled() &&
 		!c.Grafana.OTLP.MetricsEnabled() && !c.Grafana.OTLP.TracesEnabled() &&
 		!c.Metrics.Enabled() && !c.Traces.Enabled() &&
 		!c.Prometheus.Enabled() && !c.TracePrinter.Enabled() {

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -116,7 +116,6 @@ network:
 		ChannelBufferLen: 33,
 		LogLevel:         "INFO",
 		EnforceSysCaps:   false,
-		Printer:          false,
 		TracePrinter:     "json",
 		EBPF: config.EBPFTracer{
 			BatchLength:               100,
@@ -238,10 +237,6 @@ func TestConfigValidate(t *testing.T) {
 		{"OTEL_EXPORTER_OTLP_ENDPOINT": "localhost:1234", "BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
 		{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "localhost:1234", "BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
 		{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "localhost:1234", "BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
-		{"BEYLA_PRINT_TRACES": "true", "BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar"},
-		{"BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "disabled", "BEYLA_EXECUTABLE_NAME": "foo"},
-		{"BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "", "BEYLA_EXECUTABLE_NAME": "foo"},
-		{"BEYLA_PRINT_TRACES": "false", "BEYLA_TRACE_PRINTER": "text", "BEYLA_EXECUTABLE_NAME": "foo"},
 		{"BEYLA_TRACE_PRINTER": "text", "BEYLA_EXECUTABLE_NAME": "foo"},
 		{"BEYLA_TRACE_PRINTER": "json", "BEYLA_EXECUTABLE_NAME": "foo"},
 		{"BEYLA_TRACE_PRINTER": "json_indent", "BEYLA_EXECUTABLE_NAME": "foo"},
@@ -260,11 +255,9 @@ func TestConfigValidate(t *testing.T) {
 func TestConfigValidate_error(t *testing.T) {
 	testCases := []envMap{
 		{"OTEL_EXPORTER_OTLP_ENDPOINT": "localhost:1234", "INSTRUMENT_FUNC_NAME": "bar"},
-		{"BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar", "BEYLA_PRINT_TRACES": "false"},
-		{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "text"},
-		{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "json"},
-		{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "json_indent"},
-		{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_PRINT_TRACES": "true", "BEYLA_TRACE_PRINTER": "counter"},
+		{"BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar", "BEYLA_TRACE_PRINTER": "disabled"},
+		{"BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar", "BEYLA_TRACE_PRINTER": ""},
+		{"BEYLA_EXECUTABLE_NAME": "foo", "INSTRUMENT_FUNC_NAME": "bar", "BEYLA_TRACE_PRINTER": "invalid"},
 	}
 	for n, tc := range testCases {
 		t.Run(fmt.Sprint("case", n), func(t *testing.T) {
@@ -341,10 +334,6 @@ func TestConfigValidate_TracePrinter(t *testing.T) {
 			errorMsg: "invalid value for trace_printer: 'invalid_printer'",
 		},
 		{
-			env:      envMap{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_TRACE_PRINTER": "json", "BEYLA_PRINT_TRACES": "true"},
-			errorMsg: "print_traces and trace_printer are mutually exclusive, use trace_printer instead",
-		},
-		{
 			env:      envMap{"BEYLA_EXECUTABLE_NAME": "foo"},
 			errorMsg: "you need to define at least one exporter: trace_printer, grafana, otel_metrics_export, otel_traces_export or prometheus_export",
 		},
@@ -361,7 +350,7 @@ func TestConfigValidate_TracePrinter(t *testing.T) {
 }
 
 func TestConfigValidate_TracePrinterFallback(t *testing.T) {
-	env := envMap{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_PRINT_TRACES": "true"}
+	env := envMap{"BEYLA_EXECUTABLE_NAME": "foo", "BEYLA_TRACE_PRINTER": "text"}
 
 	cfg := loadConfig(t, env)
 
@@ -369,7 +358,6 @@ func TestConfigValidate_TracePrinterFallback(t *testing.T) {
 
 	err := cfg.Validate()
 	require.NoError(t, err)
-	assert.True(t, cfg.Printer.Enabled())
 	assert.Equal(t, cfg.TracePrinter, debug.TracePrinterText)
 }
 

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -12,13 +12,6 @@ import (
 	"github.com/grafana/beyla/pkg/internal/request"
 )
 
-// TODO deprecated (REMOVE) - use TracePrinter instead
-type PrintEnabled bool
-
-func (p PrintEnabled) Enabled() bool {
-	return bool(p)
-}
-
 type TracePrinter string
 
 const (

--- a/test/integration/docker-compose-grpc-http2-mux.yml
+++ b/test/integration/docker-compose-grpc-http2-mux.yml
@@ -41,7 +41,7 @@ services:
     pid: "host"
     environment:
       GOCOVERDIR: "/coverage"
-      BEYLA_PRINT_TRACES: "true"
+      BEYLA_TRACE_PRINTER: "text"
       BEYLA_METRICS_INTERVAL: "10ms"
       BEYLA_BPF_BATCH_TIMEOUT: "10ms"
       BEYLA_LOG_LEVEL: "DEBUG"


### PR DESCRIPTION
This option has been deprecated  since Beyla 1.7, and will now be removed for Beyla 2.0.