### PR TITLE
Update attributes semantic conventions OTEL v1.30.0

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -236,9 +236,9 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		DBClientDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes},
 			Attributes: map[attr.Name]Default{
-				attr.DBOperation: true,
-				attr.DBSystem:    true,
-				attr.ErrorType:   true,
+				attr.DBOperation:  true,
+				attr.DBSystemName: true,
+				attr.ErrorType:    true,
 			},
 		},
 		MessagingPublishDuration.Section: {

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -44,7 +44,7 @@ const (
 	ConnectionType         = Name("connection_type")
 	DBOperation            = Name("db.operation.name")
 	DBCollectionName       = Name("db.collection.name")
-	DBSystem               = Name(semconv.DBSystemKey)
+	DBSystemName           = Name("db.system.name")
 	ErrorType              = Name("error.type")
 	RPCMethod              = Name(semconv.RPCMethodKey)
 	RPCSystem              = Name(semconv.RPCSystemKey)

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -574,6 +574,9 @@ func (tr *tracesOTELReceiver) acceptSpan(span *request.Span) bool {
 	return false
 }
 
+// TODO use semconv.DBSystemRedis when we update to OTEL semantic conventions library 1.30
+var dbSystemRedis = attribute.String(string(attr.DBSystemName), semconv.DBSystemRedis.Value.AsString())
+
 // nolint:cyclop
 func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
@@ -630,7 +633,7 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
-			span.DBSystem(), // We can distinguish in the future for MySQL, Postgres etc
+			span.DBSystemName(), // We can distinguish in the future for MySQL, Postgres etc
 		}
 		if _, ok := optionalAttrs[attr.DBQueryText]; ok {
 			attrs = append(attrs, request.DBQueryText(span.Statement))
@@ -647,7 +650,7 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
-			semconv.DBSystemRedis,
+			dbSystemRedis,
 		}
 		operation := span.Method
 		if operation != "" {

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -527,7 +527,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.Equal(t, 5, attrs.Len())
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBOperation), "SELECT")
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBCollectionName), "credentials")
-		ensureTraceStrAttr(t, attrs, semconv.DBSystemKey, "other_sql")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBSystemName), "other_sql")
 		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.DBQueryText))
 	})
 
@@ -548,7 +548,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.Equal(t, 5, attrs.Len())
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBOperation), "SELECT")
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBCollectionName), "credentials")
-		ensureTraceStrAttr(t, attrs, semconv.DBSystemKey, "other_sql")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBSystemName), "other_sql")
 		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.DBQueryText))
 	})
 
@@ -569,7 +569,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.Equal(t, 6, attrs.Len())
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBOperation), "SELECT")
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBCollectionName), "credentials")
-		ensureTraceStrAttr(t, attrs, semconv.DBSystemKey, "other_sql")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBSystemName), "other_sql")
 		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBQueryText), "SELECT password FROM credentials WHERE username=\"bill\"")
 	})
 	t.Run("test Kafka trace generation", func(t *testing.T) {

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	attr "github.com/grafana/beyla/pkg/export/attributes/names"
 )
@@ -93,8 +92,9 @@ func DBOperationName(val string) attribute.KeyValue {
 	return attribute.Key(attr.DBOperation).String(val)
 }
 
-func DBSystem(val string) attribute.KeyValue {
-	return attribute.Key(semconv.DBSystemKey).String(val)
+func DBSystemName(val string) attribute.KeyValue {
+	// TODO: replace by semconv.DBSystemName when we update to OTEL semconv library 1.30
+	return attribute.Key(attr.DBSystemName).String(val)
 }
 
 func ErrorType(val string) attribute.KeyValue {

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -14,6 +14,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	trace2 "go.opentelemetry.io/otel/trace"
 
+	attr "github.com/grafana/beyla/pkg/export/attributes/names"
 	"github.com/grafana/beyla/pkg/internal/svc"
 )
 
@@ -528,17 +529,25 @@ func (s *Span) IsSelfReferenceSpan() bool {
 	return s.Peer == s.Host && (s.Service.UID.Namespace == s.OtherNamespace || s.OtherNamespace == "")
 }
 
-func (s *Span) DBSystem() attribute.KeyValue {
+// TODO: replace by semconv.DBSystemPostgreSQL, semconv.DBSystemMySQL, semconv.DBSystemRedis when we
+// update semantic conventions library to 1.30.0
+var (
+	dbSystemPostgreSQL = attribute.String(string(attr.DBSystemName), semconv.DBSystemPostgreSQL.Value.AsString())
+	dbSystemMySQL      = attribute.String(string(attr.DBSystemName), semconv.DBSystemMySQL.Value.AsString())
+	dbSystemOtherSQL   = attribute.String(string(attr.DBSystemName), semconv.DBSystemOtherSQL.Value.AsString())
+)
+
+func (s *Span) DBSystemName() attribute.KeyValue {
 	if s.Type == EventTypeSQLClient {
 		switch s.SubType {
 		case int(DBPostgres):
-			return semconv.DBSystemPostgreSQL
+			return dbSystemPostgreSQL
 		case int(DBMySQL):
-			return semconv.DBSystemMySQL
+			return dbSystemMySQL
 		}
 	}
 
-	return semconv.DBSystemOtherSQL
+	return dbSystemOtherSQL
 }
 
 func (s *Span) HasOriginalHost() bool {

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -78,15 +78,15 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		getter = func(s *Span) attribute.KeyValue { return StatusCodeMetric(int(SpanStatusCode(s))) }
 	case attr.DBOperation:
 		getter = func(span *Span) attribute.KeyValue { return DBOperationName(span.Method) }
-	case attr.DBSystem:
+	case attr.DBSystemName:
 		getter = func(span *Span) attribute.KeyValue {
 			switch span.Type {
 			case EventTypeSQLClient:
-				return DBSystem(span.DBSystem().Value.AsString())
+				return DBSystemName(span.DBSystemName().Value.AsString())
 			case EventTypeRedisClient, EventTypeRedisServer:
-				return DBSystem(semconv.DBSystemRedis.Value.AsString())
+				return DBSystemName(semconv.DBSystemRedis.Value.AsString())
 			}
-			return DBSystem("unknown")
+			return DBSystemName("unknown")
 		}
 	case attr.ErrorType:
 		getter = func(span *Span) attribute.KeyValue {
@@ -157,11 +157,11 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 			}
 			return ""
 		}
-	case attr.DBSystem:
+	case attr.DBSystemName:
 		getter = func(span *Span) string {
 			switch span.Type {
 			case EventTypeSQLClient:
-				return span.DBSystem().Value.AsString()
+				return span.DBSystemName().Value.AsString()
 			case EventTypeRedisClient, EventTypeRedisServer:
 				return semconv.DBSystemRedis.Value.AsString()
 			}
@@ -170,7 +170,7 @@ func SpanPromGetters(attrName attr.Name) (attributes.Getter[*Span, string], bool
 	case attr.DBCollectionName:
 		getter = func(span *Span) string {
 			if span.Type == EventTypeSQLClient {
-				return span.DBSystem().Value.AsString()
+				return span.DBSystemName().Value.AsString()
 			}
 			return ""
 		}

--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -199,7 +199,7 @@ func waitForSQLTestComponentsWithDB(t *testing.T, url, subpath, db string) {
 		// now, verify that the metric has been reported.
 		// we don't really care that this metric could be from a previous
 		// test. Once one it is visible, it means that Otel and Prometheus are healthy
-		results, err := pq.Query(`db_client_operation_duration_seconds_count{db_system="` + db + `"}`)
+		results, err := pq.Query(`db_client_operation_duration_seconds_count{db_system_name="` + db + `"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))

--- a/test/oats/redis/yaml/oats_go_redis.yaml
+++ b/test/oats/redis/yaml/oats_go_redis.yaml
@@ -8,30 +8,30 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "set" && .db.system = "redis" }'
+    - traceql: '{ .db.operation.name = "set" && .db.system.name = "redis" }'
       spans:
         - name: 'set'
           attributes:
             db.operation.name: set
-            db.system: redis
+            db.system.name: redis
             server.port: 6379
             db.query.text: "set beyla rocks "
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_operation_name="get", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="get", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_operation_name="get", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_operation_name="get", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_operation_name="get", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_operation_name="get", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="get", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="get", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_sum{db_operation_name="set", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="set", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_operation_name="set", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_operation_name="set", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_operation_name="set", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_operation_name="set", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="set", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="set", db_system_name="redis"}'
       value: "> 0"
 
 

--- a/test/oats/redis/yaml/oats_go_redis_fails.yaml
+++ b/test/oats/redis/yaml/oats_go_redis_fails.yaml
@@ -11,20 +11,20 @@ expected:
   # It requires that a span name is unique, e.g. always expects the tempo response
   # to return one result only. 
   traces:
-    - traceql: '{ .db.system = "redis" }'
+    - traceql: '{ .db.system.name = "redis" }'
       spans:
         - name: 'REDIS'
           allow-duplicates: true
           status: '{Message: "", Code: 2}'
             
   metrics:
-    - promql: 'db_client_operation_duration_sum{error_type!="", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{error_type!="", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", error_type!="", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", error_type!="", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", error_type!="", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", error_type!="", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{error_type!="", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{error_type!="", db_system_name="redis"}'
       value: "> 0"
 
 

--- a/test/oats/redis/yaml/oats_redis.yaml
+++ b/test/oats/redis/yaml/oats_redis.yaml
@@ -8,46 +8,46 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SET" && .db.system = "redis" }'
+    - traceql: '{ .db.operation.name = "SET" && .db.system.name = "redis" }'
       spans:
         - name: 'SET'
           attributes:
             db.operation.name: SET
-            db.system: redis
+            db.system.name: redis
             server.port: 6379
             db.query.text: "SET beyla rocks "
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_operation_name="GET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="GET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="GET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="GET", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="GET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="GET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="GET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="GET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_sum{db_operation_name="SET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="SET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SET", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="SET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="SET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_sum{db_operation_name="HSET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="HSET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="HSET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="HSET", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="HSET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="HSET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="HSET", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="HSET", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_sum{db_operation_name="HGETALL", db_system="redis"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="HGETALL", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="HGETALL", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="HGETALL", db_system_name="redis"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="HGETALL", db_system="redis"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="HGETALL", db_system_name="redis"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="HGETALL", db_system="redis"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="HGETALL", db_system_name="redis"}'
       value: "> 0"
 
 

--- a/test/oats/sql/yaml/oats_sql.yaml
+++ b/test/oats/sql/yaml/oats_sql.yaml
@@ -9,34 +9,34 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "other_sql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql"}'
       spans:
         - name: 'SELECT students'
           attributes:
             db.operation.name: SELECT
             db.collection.name: students
-            db.system: other_sql
+            db.system.name: other_sql
     - traceql: '{ .db.operation.name = "UPDATE" }'
       spans:
         - name: 'UPDATE students'
           attributes:
             db.operation.name: UPDATE
             db.collection.name: students  
-            db.system: other_sql
+            db.system.name: other_sql
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_sum{db_operation_name="UPDATE", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="UPDATE", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="UPDATE", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="UPDATE", db_system_name="other_sql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="UPDATE", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="UPDATE", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="UPDATE", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="UPDATE", db_system_name="other_sql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_go_postgres.yaml
+++ b/test/oats/sql/yaml/oats_sql_go_postgres.yaml
@@ -8,19 +8,19 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "other_sql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql"}'
       spans:
         - name: 'SELECT accounting.contacts'
           attributes:
             db.operation.name: SELECT
             db.collection.name: accounting.contacts
-            db.system: other_sql
+            db.system.name: other_sql
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_sum{db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_operation_name="SELECT", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_count{db_operation_name="SELECT", db_system_name="other_sql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_other_langs.yaml
+++ b/test/oats/sql/yaml/oats_sql_other_langs.yaml
@@ -8,20 +8,20 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "postgresql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "postgresql"}'
       spans:
         - name: 'SELECT accounting.contacts'
           attributes:
             db.operation.name: SELECT
             db.collection.name: accounting.contacts
-            db.system: postgresql
+            db.system.name: postgresql
             db.query.text: "SELECT * from accounting.contacts WHERE id=1"
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="postgresql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="postgresql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_other_langs_args.yaml
+++ b/test/oats/sql/yaml/oats_sql_other_langs_args.yaml
@@ -8,19 +8,19 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "postgresql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "postgresql"}'
       spans:
         - name: 'SELECT accounting.contacts'
           attributes:
             db.operation.name: SELECT
             db.collection.name: accounting.contacts
-            db.system: postgresql
+            db.system.name: postgresql
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="postgresql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="postgresql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_other_langs_mysql.yaml
+++ b/test/oats/sql/yaml/oats_sql_other_langs_mysql.yaml
@@ -8,20 +8,20 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "mysql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "mysql"}'
       spans:
         - name: 'SELECT actor'
           attributes:
             db.operation.name: SELECT
             db.collection.name: actor
-            db.system: mysql
+            db.system.name: mysql
             db.query.text: "SELECT * from actor WHERE actor_id=1"
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="mysql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="mysql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="mysql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="mysql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="mysql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="mysql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="mysql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="mysql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_other_langs_prep.yaml
+++ b/test/oats/sql/yaml/oats_sql_other_langs_prep.yaml
@@ -8,19 +8,19 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "postgresql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "postgresql"}'
       spans:
         - name: 'SELECT accounting.contacts'
           attributes:
             db.operation.name: SELECT
             db.collection.name: accounting.contacts
-            db.system: postgresql
+            db.system.name: postgresql
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="postgresql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="postgresql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="postgresql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="postgresql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_other_langs_prep_mysql.yaml
+++ b/test/oats/sql/yaml/oats_sql_other_langs_prep_mysql.yaml
@@ -8,19 +8,19 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system = "mysql"}'
+    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "mysql"}'
       spans:
         - name: 'SELECT actor'
           attributes:
             db.operation.name: SELECT
             db.collection.name: actor
-            db.system: mysql
+            db.system.name: mysql
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="mysql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="mysql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="mysql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="mysql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="mysql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="mysql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="mysql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="mysql"}'
       value: "> 0"

--- a/test/oats/sql/yaml/oats_sql_statement.yaml
+++ b/test/oats/sql/yaml/oats_sql_statement.yaml
@@ -8,7 +8,7 @@ input:
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "UPDATE" && .db.system = "other_sql"}'
+    - traceql: '{ .db.operation.name = "UPDATE" && .db.system.name = "other_sql"}'
       spans:
         - name: 'UPDATE students'
           attributes:
@@ -16,11 +16,11 @@ expected:
             db.collection.name: students            
             db.query.text: "Update students SET name = 'Bob' WHERE id = '1'"
   metrics:
-    - promql: 'db_client_operation_duration_sum{db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_sum{db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_bucket{le="0", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="0", db_system_name="other_sql"}'
       value: "== 0"
-    - promql: 'db_client_operation_duration_bucket{le="10", db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_bucket{le="10", db_system_name="other_sql"}'
       value: "> 0"
-    - promql: 'db_client_operation_duration_count{db_system="other_sql"}'
+    - promql: 'db_client_operation_duration_count{db_system_name="other_sql"}'
       value: "> 0"


### PR DESCRIPTION
The OTEL attribute `db.system` has been renamed to `db.system.name`.

If you are using Prometheus exporter, `db_system` has been also renamed to `db_system_name`.