### PR TITLE
support app.kubernetes.io/version label by default

### DIFF
--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -61,6 +61,7 @@ var DefaultResourceLabels = ResourceLabels{
 	// OTEL operator to provide empty values for this.
 	"service.name":      []string{"app.kubernetes.io/name"},
 	"service.namespace": []string{"app.kubernetes.io/part-of"},
+	"service.version":   []string{"app.kubernetes.io/version"},
 }
 
 // Store aggregates Kubernetes information from multiple sources:

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -119,6 +119,7 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 		"host_name":                "testserver",
 		"host_id":                  HostIDRegex,
 		"deployment_environment":   "integration-test",
+		"service_version":          "3.2.1",
 	}
 	// if service_instance_id is overridden to be empty, we will check that value for target_info{instance} instead
 	if overrideAttrs != nil {
@@ -208,6 +209,7 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 		"k8s_replicaset_name":    "^testserver-",
 		"service_instance_id":    "^default\\.testserver-.+\\.testserver",
 		"deployment_environment": "integration-test",
+		"service_version":        "3.2.1",
 	}
 	// if service_instance_id is overridden to be empty, we will check that value for target_info{instance} instead
 	targetInfoInstance := ""

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -75,7 +75,7 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test"
+              value: "deployment.environment=integration-test,service.version=3.2.1"
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -88,7 +88,7 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test"
+              value: "deployment.environment=integration-test,service.version=3.2.1"
         - name: beyla
           image: beyla:dev
           imagePullPolicy: Never # loaded into Kind from localhost

--- a/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
@@ -27,6 +27,7 @@ spec:
         app: dsservice
       annotations:
         resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:
         - name: dsservice

--- a/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
@@ -51,9 +51,9 @@ spec:
       name: pytestserver
       labels:
         app: pytestserver
-        deployment.environment: 'integration-test'
+        deployment.environment: 'to-be-ignored-in-favor-of-annotation'
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-label'
+        resource.opentelemetry.io/deployment.environment: 'integration-test'
     spec:
       affinity:
           nodeAffinity:

--- a/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
@@ -38,7 +38,7 @@ spec:
         - name: TARGET_URL
           value: "http://otherinstance:8080"
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: "deployment.environment=integration-test"
+          value: "deployment.environment=integration-test,service.version=3.2.1"
 ---
 apiVersion: v1
 kind: Service
@@ -113,4 +113,4 @@ spec:
             - name: LOG_LEVEL
               value: "DEBUG"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "deployment.environment=integration-test"
+              value: "deployment.environment=integration-test,service.version=3.2.1"

--- a/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service-python.yml
@@ -16,8 +16,6 @@ metadata:
   name: pytestserver
   labels:
     app: pytestserver
-  annotations:
-    resource.opentelemetry.io/service.name: 'this-will-be-ignored-due-to-otel-attrs-env'
 spec:
   replicas: 1
   selector:
@@ -28,9 +26,11 @@ spec:
       name: pytestserver
       labels:
         app: pytestserver
-        deployment.environment: 'integration-test'
+        deployment.environment: 'to-be-ignored-in-favor-of-annotatoin'
       annotations:
-        resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-label'
+        resource.opentelemetry.io/service.name: 'this-will-be-ignored-due-to-otel-attrs-env'
+        resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:
         - name: pytestserver

--- a/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -43,10 +43,12 @@ spec:
       name: testserver
       annotations:
         resource.opentelemetry.io/service.name: 'testserver'
+        resource.opentelemetry.io/service.version: '3.2.1'
       labels:
         app: testserver
         app.kubernetes.io/name: 'ignored-testserver-name'
         app.kubernetes.io/part-of: 'overridden-testserver-namespace'
+        app.kubernetes.io/version: 'ignored-version'
     spec:
       containers:
         - name: testserver

--- a/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
@@ -28,6 +28,7 @@ spec:
         app: statefulservice
       annotations:
         resource.opentelemetry.io/deployment.environment: 'integration-test'
+        resource.opentelemetry.io/service.version: '3.2.1'
     spec:
       containers:
         - name: statefulservice

--- a/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -23,6 +23,7 @@ metadata:
     teardown: delete
   annotations:
     resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
   serviceAccountName: beyla
@@ -47,7 +48,7 @@ spec:
       imagePullPolicy: Never # loaded into Kind from localhost
       securityContext:
         privileged: true
-      args: ["--config=/configs/instrumenter-config-promscrape.yml" ]
+      args: [ "--config=/configs/instrumenter-config-promscrape.yml" ]
       ports:
         - containerPort: 8999
       volumeMounts:

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -23,6 +23,7 @@ metadata:
     teardown: delete
   annotations:
     resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
   serviceAccountName: beyla

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
@@ -24,6 +24,7 @@ metadata:
     teardown: delete
   annotations:
     resource.opentelemetry.io/deployment.environment: 'integration-test'
+    resource.opentelemetry.io/service.version: '3.2.1'
 spec:
   shareProcessNamespace: true
   serviceAccountName: beyla

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -23,6 +23,7 @@ metadata:
     # kind, to force Beyla writing the coverage data
     teardown: delete
     deployment.environment: integration-test
+    app.kubernetes.io/version: '3.2.1'
   annotations:
     resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-annotation'
 spec:

--- a/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
@@ -37,4 +37,4 @@ spec:
         - name: TARGET_URL
           value: "{{.TargetURL}}"
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: "deployment.environment=integration-test"
+          value: "deployment.environment=integration-test,service.version=3.2.1"

--- a/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
+++ b/test/integration/k8s/manifests/07-instrumented-service-otel-kprobes.yml
@@ -65,7 +65,7 @@ metadata:
     teardown: delete
     deployment.environment: integration-test
   annotations:
-    resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-annotation'
+    resource.opentelemetry.io/deployment.environment: 'to-be-ignored-in-favor-of-env'
 spec:
   shareProcessNamespace: true
   serviceAccountName: beyla
@@ -89,7 +89,7 @@ spec:
         - name: LOG_LEVEL
           value: "DEBUG"
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: "service.name=mypythonapp"          
+          value: "service.name=mypythonapp,service.version=3.2.1"
     - name: beyla
       image: beyla:dev
       imagePullPolicy: Never # loaded into Kind from localhost


### PR DESCRIPTION
For consistence with the OTEL operator specification, this PR adds default support for `app.kubernetes.io/version` as a source label for `service.version` metadata.

https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md#configure-resource-attributes-with-labels