### PR TITLE
Make go context propagation error message more explicit

### DIFF
--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -147,26 +147,26 @@ const (
 	KernelLockdownOther
 )
 
-func SupportsContextPropagation(log *slog.Logger) bool {
+func SupportsContextPropagationWithProbe(log *slog.Logger) bool {
 	kernelMajor, kernelMinor := KernelVersion()
 	log.Debug("Linux kernel version", "major", kernelMajor, "minor", kernelMinor)
 
 	if kernelMajor < 5 || (kernelMajor == 5 && kernelMinor < 10) {
-		log.Debug("Found Linux kernel earlier than 5.10, trace context propagation is supported", "major", kernelMajor, "minor", kernelMinor)
+		log.Debug("Found Linux kernel earlier than 5.10, Go trace context propagation at library level is supported", "major", kernelMajor, "minor", kernelMinor)
 		return true
 	}
 
 	// bpf_probe_write_user(), used to inject the context, requires CAP_SYS_ADMIN
 
 	if !hasCapSysAdmin() {
-		log.Info("trace context propagation disabled due to missing capability CAP_SYS_ADMIN")
+		log.Info("Go context propagation at library level disabled due to missing capability CAP_SYS_ADMIN")
 		return false
 	}
 
 	lockdown := KernelLockdownMode()
 
 	if lockdown == KernelLockdownNone {
-		log.Debug("Kernel not in lockdown mode, trace context propagation is supported.")
+		log.Debug("Kernel not in lockdown mode, Go trace context propagation at library level is supported.")
 		return true
 	}
 

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -65,7 +65,7 @@ func (p *Tracer) BlockPID(pid, ns uint32) {
 }
 
 func (p *Tracer) supportsContextPropagation() bool {
-	return !ebpfcommon.IntegrityModeOverride && ebpfcommon.SupportsContextPropagation(p.log)
+	return !ebpfcommon.IntegrityModeOverride && ebpfcommon.SupportsContextPropagationWithProbe(p.log)
 }
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {


### PR DESCRIPTION
With the introduction of general HTTP context propagation via tc programs, context propagation is no longer constrained by `CAP_SYS_ADMIN` and Go.
Rename the function and reword the error message accordingly and use the terminology [from our own docs](https://github.com/grafana/beyla/blob/main/docs/sources/distributed-traces.md#go-context-propagation-by-instrumenting-at-library-level) to avoid any confusions at source and log levels.