### PR TITLE
prevent cilium high priority from aborting Beyla start

### DIFF
--- a/pkg/internal/ebpf/tcmanager/cilium_support.go
+++ b/pkg/internal/ebpf/tcmanager/cilium_support.go
@@ -165,5 +165,6 @@ func EnsureCiliumCompatibility(backend TCBackend) error {
 
 	// minPrio == maxPrio == 1 -> cilium should be reconfigured with
 	// bpf-filter-priority >= 2
-	return fmt.Errorf("detected Cilium TC with priority 1 - Cilium may clobber Beyla")
+	slog.Warn("Detected Cilium TC with with priority 1 - Cilium may clobber Beyla. Cilium should be reconfigured with bpf-filter-priority >= 2")
+	return nil
 }


### PR DESCRIPTION
Some configurations that worked with Beyla 1.9 now fail due to Cilium priority check. From a user:
```
I read the Cilium compatibility documentation and I’m wondering if there’s another solution besides changing the Cilium configuration. Since Cilium is managed by GKE, I’d prefer not to alter the configuration.
```