### PR TITLE
Tweak capabilities detection

### DIFF
--- a/pkg/beyla/os.go
+++ b/pkg/beyla/os.go
@@ -82,7 +82,10 @@ func testAndSet(caps *helpers.OSCapabilities, capError *osCapabilitiesError, c h
 func checkCapabilitiesForSetOptions(config *Config, caps *helpers.OSCapabilities, capError *osCapabilitiesError) {
 	if config.Enabled(FeatureAppO11y) {
 		testAndSet(caps, capError, unix.CAP_CHECKPOINT_RESTORE)
+		testAndSet(caps, capError, unix.CAP_DAC_READ_SEARCH)
 		testAndSet(caps, capError, unix.CAP_SYS_PTRACE)
+		testAndSet(caps, capError, unix.CAP_PERFMON)
+		testAndSet(caps, capError, unix.CAP_NET_RAW)
 
 		if config.EBPF.ContextPropagationEnabled || config.EBPF.UseTCForL7CP {
 			testAndSet(caps, capError, unix.CAP_NET_ADMIN)
@@ -90,9 +93,11 @@ func checkCapabilitiesForSetOptions(config *Config, caps *helpers.OSCapabilities
 	}
 
 	if config.Enabled(FeatureNetO11y) {
-		// test for net raw only if we don't have net admin
-		if !caps.Has(unix.CAP_NET_ADMIN) {
+		if config.NetworkFlows.Source == EbpfSourceSock {
 			testAndSet(caps, capError, unix.CAP_NET_RAW)
+		} else if config.NetworkFlows.Source == EbpfSourceTC {
+			testAndSet(caps, capError, unix.CAP_PERFMON)
+			testAndSet(caps, capError, unix.CAP_NET_ADMIN)
 		}
 	}
 }
@@ -126,8 +131,6 @@ func CheckOSCapabilities(config *Config) error {
 
 	// core capabilities
 	testAndSet(caps, &capError, unix.CAP_BPF)
-	testAndSet(caps, &capError, unix.CAP_PERFMON)
-	testAndSet(caps, &capError, unix.CAP_DAC_READ_SEARCH)
 
 	// CAP_SYS_RESOURCE is only required on kernels < 5.11
 	if (major == 5 && minor < 11) || (major < 5) {

--- a/pkg/beyla/os_test.go
+++ b/pkg/beyla/os_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 
+	"github.com/grafana/beyla/pkg/config"
 	"github.com/grafana/beyla/pkg/internal/helpers"
 	"github.com/grafana/beyla/pkg/services"
 )
@@ -102,17 +103,25 @@ type capTestData struct {
 	class   capClass
 	kernMaj int
 	kernMin int
+	useTC   bool
 }
 
 var capTests = []capTestData{
-	{osCap: unix.CAP_BPF, class: capCore, kernMaj: 6, kernMin: 10},
-	{osCap: unix.CAP_PERFMON, class: capCore, kernMaj: 6, kernMin: 10},
-	{osCap: unix.CAP_DAC_READ_SEARCH, class: capCore, kernMaj: 6, kernMin: 10},
-	{osCap: unix.CAP_SYS_RESOURCE, class: capCore, kernMaj: 5, kernMin: 10},
-	{osCap: unix.CAP_SYS_ADMIN, class: capCore, kernMaj: 4, kernMin: 11},
-	{osCap: unix.CAP_CHECKPOINT_RESTORE, class: capApp, kernMaj: 6, kernMin: 10},
-	{osCap: unix.CAP_SYS_PTRACE, class: capApp, kernMaj: 6, kernMin: 10},
-	{osCap: unix.CAP_NET_RAW, class: capNet, kernMaj: 6, kernMin: 10},
+	// core
+	{osCap: unix.CAP_BPF, class: capCore, kernMaj: 6, kernMin: 10, useTC: false},
+
+	// app o11y
+	{osCap: unix.CAP_CHECKPOINT_RESTORE, class: capApp, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_DAC_READ_SEARCH, class: capApp, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_SYS_PTRACE, class: capApp, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_PERFMON, class: capApp, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_NET_RAW, class: capApp, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_NET_ADMIN, class: capApp, kernMaj: 6, kernMin: 10, useTC: true},
+
+	// net o11y
+	{osCap: unix.CAP_NET_RAW, class: capNet, kernMaj: 6, kernMin: 10, useTC: false},
+	{osCap: unix.CAP_PERFMON, class: capNet, kernMaj: 6, kernMin: 10, useTC: true},
+	{osCap: unix.CAP_NET_ADMIN, class: capNet, kernMaj: 6, kernMin: 10, useTC: true},
 }
 
 func TestCheckOSCapabilities(t *testing.T) {
@@ -129,9 +138,18 @@ func TestCheckOSCapabilities(t *testing.T) {
 	test := func(data *capTestData) {
 		overrideKernelVersion(testCase{data.kernMaj, data.kernMin})
 
+		netSource := func(useTC bool) string {
+			if useTC {
+				return EbpfSourceTC
+			}
+
+			return EbpfSourceSock
+		}
+
 		cfg := Config{
-			NetworkFlows: NetworkConfig{Enable: data.class == capNet},
+			NetworkFlows: NetworkConfig{Enable: data.class == capNet, Source: netSource(data.useTC)},
 			Discovery:    services.DiscoveryConfig{SystemWide: data.class == capApp},
+			EBPF:         config.EBPFTracer{ContextPropagationEnabled: data.useTC},
 		}
 
 		err := CheckOSCapabilities(&cfg)


### PR DESCRIPTION
This PR reshuffles the capability detection flow after an analysis performed. In a nutshell, we don't need anything but `CAP_BPF` and `CAP_NET_RAW` for network observability using socket filters.

Also, `CAP_NET_ADMIN` does not imply `CAP_NET_RAW`, so that is fixed as well.

The entire list of capabilities per tracer is as follow:
### Socket flow fetcher
- `CAP_BPF` -> for `BPF_PROG_TYPE_SOCK_FILTER`
- `CAP_NET_RAW` -> for creating `AF_PACKET` socket

### Flow fetcher (tc)
- `CAP_BPF` 
- `CAP_NET_ADMIN` -> for `PROG_TYPE_SCHED_CLS`
- `CAP_PERFMON` -> direct access to `struct __sk_buff::data` and pointer arithmetic

### Watcher
- `CAP_BPF`
- `CAP_CHECKPOINT_RESTORE`
- `CAP_DAC_READ_SEARCH` -> access to `/proc/self/mem` to determine kernel version
- `CAP_PERFMON` -> for `BPF_PROG_TYPE_KPROBE`

### Generic tracer
- `CAP_BPF`
- `CAP_DAC_READ_SEARCH`
- `CAP_CHECKPOINT_RESTORE`
- `CAP_PERFMON`
- `CAP_NET_RAW` -> for creating `AF_PACKET` socket used by `beyla_socket__http_filter`
- `CAP_SYS_PTRACE` -> access to `/proc/pid/exe` and other nodes in `/proc`

### TC tracers
* `CAP_BPF`
* `CAP_DAC_READ_SEARCH`
* `CAP_PERFMON`
* `CAP_NET_ADMIN` -> for `BPF_PROG_TYPE_SCHED_CLS`, `BPF_PROG_TYPE_SOCK_OPS` and `BPF_PROG_TYPE_SK_MSG`

### GO tracer
- `CAP_BPF`
- `CAP_DAC_READ_SEARCH`
- `CAP_CHECKPOINT_RESTORE`
- `CAP_PERFMON`
- `CAP_NET_RAW` -> for creating `AF_PACKET` socket used by `beyla_socket__http_filter`
- `CAP_SYS_PTRACE` -> access to `/proc/pid/exe` and other nodes in `/proc`
- `CAP_SYS_ADMIN` -> for probe based (`bpf_probe_write_user()`) library level context propagation