### PR TITLE
Src and Dst zone attributes for Kubernetes

### DIFF
--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -93,6 +93,7 @@ In order to configure which attributes to show or which attributes to hide, chec
 | `beyla.network.flow.bytes`     | `dst.cidr`                   | shown if the `cidrs` configuration section exists |
 | `beyla.network.flow.bytes`     | `dst.name`                   | hidden                                            |
 | `beyla.network.flow.bytes`     | `dst.port`                   | hidden                                            |
+| `beyla.network.flow.bytes`     | `dst.zone` (only Kubernetes) | hidden                                            |
 | `beyla.network.flow.bytes`     | `iface`                      | hidden                                            |
 | `beyla.network.flow.bytes`     | `k8s.cluster.name`           | shown if network metrics are enabled              |
 | `beyla.network.flow.bytes`     | `k8s.dst.name`               | hidden                                            |
@@ -113,6 +114,7 @@ In order to configure which attributes to show or which attributes to hide, chec
 | `beyla.network.flow.bytes`     | `src.cidr`                   | shown if the `cidrs` configuration section exists |
 | `beyla.network.flow.bytes`     | `src.name`                   | hidden                                            |
 | `beyla.network.flow.bytes`     | `src.port`                   | hidden                                            |
+| `beyla.network.flow.bytes`     | `src.zone` (only Kubernetes) | hidden                                            |
 | `beyla.network.flow.bytes`     | `transport`                  | hidden                                            |
 | Traces (SQL, Redis)            | `db.query.text`              | hidden                                            |
 

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -201,6 +201,8 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 				attr.DstName:        false,
 				attr.ServerPort:     false,
 				attr.ClientPort:     false,
+				attr.SrcZone:        false,
+				attr.DstZone:        false,
 				attr.IfaceDirection: Default(ifaceDirEnabled),
 				attr.Iface:          Default(ifaceDirEnabled),
 			},

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -27,7 +27,7 @@ func TestFor(t *testing.T) {
 	p, err := NewAttrSelector(GroupKubernetes, Selection{
 		"beyla_network_flow_bytes_total": InclusionLists{
 			Include: []string{"beyla_ip", "src.*", "k8s.*"},
-			Exclude: []string{"k8s_*_name", "k8s.*.type"},
+			Exclude: []string{"k8s_*_name", "k8s.*.type", "*zone"},
 		},
 	})
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestFor_GlobEntries(t *testing.T) {
 		},
 		"beyla_network_flow_bytes_total": InclusionLists{
 			Include: []string{"src.*", "k8s.*"},
-			Exclude: []string{"k8s.*.name"},
+			Exclude: []string{"k8s.*.name", "*zone"},
 		},
 	})
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestFor_GlobEntries_NoInclusion(t *testing.T) {
 			Exclude: []string{"*dst*"},
 		},
 		"beyla_network_flow_bytes_total": InclusionLists{
-			Exclude: []string{"k8s.*.namespace"},
+			Exclude: []string{"k8s.*.namespace", "*zone"},
 		},
 	})
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestFor_GlobEntries_Order(t *testing.T) {
 			Include: []string{"*"},
 		},
 		"beyla_network_*": InclusionLists{
-			Exclude: []string{"dst.*", "transport", "*direction", "iface"},
+			Exclude: []string{"dst.*", "transport", "*direction", "iface", "*zone"},
 		},
 		"beyla_network_flow_bytes_total": InclusionLists{
 			Include: []string{"dst.name"},
@@ -140,7 +140,7 @@ func TestFor_KubeDisabled(t *testing.T) {
 	p, err := NewAttrSelector(0, Selection{
 		"beyla_network_flow_bytes_total": InclusionLists{
 			Include: []string{"target.instance", "beyla_ip", "src.*", "k8s.*"},
-			Exclude: []string{"src.port"},
+			Exclude: []string{"src.port", "*zone"},
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -80,6 +80,8 @@ const (
 	Iface      = Name("iface")
 	SrcCIDR    = Name("src.cidr")
 	DstCIDR    = Name("dst.cidr")
+	SrcZone    = Name("src.zone")
+	DstZone    = Name("dst.zone")
 
 	ClientPort = Name("client.port")
 

--- a/pkg/internal/netolly/ebpf/record.go
+++ b/pkg/internal/netolly/ebpf/record.go
@@ -51,6 +51,10 @@ type RecordAttrs struct {
 	SrcName string
 	DstName string
 
+	// SrcZone and DstZone represent the Cloud availability zones of the source and destination
+	SrcZone string
+	DstZone string
+
 	Interface string
 	// BeylaIP provides information about the source of the flow (the Agent that traced it)
 	BeylaIP  string

--- a/pkg/internal/netolly/ebpf/record_getters.go
+++ b/pkg/internal/netolly/ebpf/record_getters.go
@@ -93,6 +93,10 @@ func RecordGetters(name attr.Name) (attributes.Getter[*Record, attribute.KeyValu
 			}
 			return attribute.Int(string(attr.ServerPort), int(serverPort))
 		}
+	case attr.SrcZone:
+		getter = func(r *Record) attribute.KeyValue { return attribute.String(string(attr.SrcZone), r.Attrs.SrcZone) }
+	case attr.DstZone:
+		getter = func(r *Record) attribute.KeyValue { return attribute.String(string(attr.DstZone), r.Attrs.DstZone) }
 	default:
 		getter = func(r *Record) attribute.KeyValue { return attribute.String(string(name), r.Attrs.Metadata[name]) }
 	}

--- a/test/integration/components/docker/build.go
+++ b/test/integration/components/docker/build.go
@@ -44,7 +44,6 @@ func pullDockerfile(logger io.WriteCloser, ilog *slog.Logger, img ImageBuild) er
 		return err
 	}
 	return nil
-
 }
 
 func buildDockerfile(logger io.WriteCloser, rootPath string, ilog *slog.Logger, img ImageBuild) error {

--- a/test/integration/k8s/manifests/00-kind-multi-zone.yml
+++ b/test/integration/k8s/manifests/00-kind-multi-zone.yml
@@ -1,0 +1,50 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+name: beyla
+nodes:
+  - role: control-plane
+    labels:
+      # faking a multi-zone cluster
+      topology.kubernetes.io/zone: control-plane-zone
+    extraMounts:
+      # configuration files that need to be mounted in the host
+      - hostPath: ../../configs
+        containerPath: /configs
+      # testoutput folder to store coverage data
+      - hostPath: ../../../../testoutput
+        containerPath: /testoutput
+  - role: worker
+    labels:
+      # faking a multi-zone cluster
+      topology.kubernetes.io/zone: server-zone
+    extraMounts:
+      # configuration files that need to be mounted in the host
+      - hostPath: ../../configs
+        containerPath: /configs
+      # testoutput folder to store coverage data
+      - hostPath: ../../../../testoutput
+        containerPath: /testoutput
+  - role: worker
+    labels:
+      # faking a multi-zone cluster
+      topology.kubernetes.io/zone: client-zone
+      # otel collector needs to be placed here, due to port mappings
+      deployment/zone: otel
+    extraMounts:
+      # configuration files that need to be mounted in the host
+      - hostPath: ../../configs
+        containerPath: /configs
+      # testoutput folder to store coverage data
+      - hostPath: ../../../../testoutput
+        containerPath: /testoutput
+    extraPortMappings:
+      # to avoid having to do port-forwarding from the Go client (a bit cumbersome process),
+      # we just make visible some container ports through host ports
+      # hostPorts need to be in range 30000-32767
+      # containerPort must be the "hostPort" value that needs to be
+      # exposed on each Pod container
+      - containerPort: 8999
+        hostPort: 38999
+      - containerPort: 9090
+        hostPort: 39090
+

--- a/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
@@ -1,0 +1,103 @@
+# this file depends in the annotations and 00-kind-multi-node.yml to deploy a testserver
+# and a client in different nodes.
+# Beyla will instrument both, but restricting the metadata only to the local node,
+# so network flows between client and testserver would be incomplete
+apiVersion: v1
+kind: Pod
+metadata:
+  name: httppinger
+  labels:
+    component: httppinger
+    # this label will trigger a deletion of beyla pods before tearing down
+    # kind, to force Beyla writing the coverage data
+    teardown: delete
+  annotations:
+    resource.opentelemetry.io/deployment.environment: integration-test
+    resource.opentelemetry.io/service.version: '3.2.1'
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          # force multi-zone traffic: server is in us-west-1b
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - client-zone
+  containers:
+    - name: httppinger
+      image: httppinger:dev
+      env:
+        - name: TARGET_URL
+          value: "http://testserver:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testserver
+spec:
+  selector:
+    app: testserver
+  ports:
+    - port: 8080
+      name: http0
+      targetPort: http0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testserver
+  labels:
+    app: testserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testserver
+  template:
+    metadata:
+      name: testserver
+      labels:
+        app: testserver
+        # this label will trigger a deletion of beyla pods before tearing down
+        # kind, to force Beyla writing the coverage data
+        teardown: delete
+      annotations:
+        resource.opentelemetry.io/deployment.environment: integration-test
+        resource.opentelemetry.io/service.version: '3.2.1'
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  # force multi-zone traffic: client is in us-west-1a
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - server-zone
+      containers:
+        - name: testserver
+          image: testserver:dev
+          imagePullPolicy: Never # loaded into Kind from localhost
+          ports:
+            # exposing hostports to enable operation from tests
+            - containerPort: 8080
+              hostPort: 8080
+              name: http0
+            - containerPort: 8081
+              hostPort: 8081
+              name: http1
+            - containerPort: 8082
+              hostPort: 8082
+              name: http2
+            - containerPort: 8083
+              hostPort: 8083
+              name: http3
+            - containerPort: 5051
+              hostPort: 5051
+              name: grpc
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"

--- a/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beyla-config
+data:
+  beyla-config.yml: |
+    log_level: debug
+    otel_metrics_export:
+      endpoint: http://otelcol.default:4317
+    network:
+      protocols:
+        - TCP
+      cidrs:
+        # default subnets of Kind Pods and services
+        - 10.244.0.0/16
+        - fd00:10:244::/56
+        - 10.96.0.0/16
+        - fd00:10:96::/112
+    attributes:
+      kubernetes:
+        enable: true
+        cluster_name: my-kube
+        resource_labels:
+          deployment.environment: ["deployment.environment"]
+      select:
+        beyla.network.flow.bytes:
+          # assured cardinality explosion. Don't try in production!
+          include: ["*"]
+          exclude: ["src_port"]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: beyla
+spec:
+  selector:
+    matchLabels:
+      instrumentation: beyla
+  template:
+    metadata:
+      labels:
+        instrumentation: beyla
+        # this label will trigger a deletion of beyla pods before tearing down
+        # kind, to force Beyla writing the coverage data
+        teardown: delete
+    spec:
+      hostPID: true  #important for appo11y!
+      hostNetwork: true #important for neto11y!
+      dnsPolicy: ClusterFirstWithHostNet # important to get connection to otelcollector from hostnetwork !!
+      serviceAccountName: beyla
+      volumes:
+        - name: beyla-config
+          configMap:
+            name: beyla-config
+        - name: testoutput
+          persistentVolumeClaim:
+            claimName: testoutput
+      containers:
+        - name: beyla
+          image: beyla:dev
+          imagePullPolicy: Never # loaded into Kind from localhost
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /config
+              name: beyla-config
+            - mountPath: /testoutput
+              name: testoutput
+          env:
+            - name: GOCOVERDIR
+              value: "/testoutput"
+            - name: BEYLA_CONFIG_PATH
+              value: /config/beyla-config.yml
+            - name: BEYLA_NETWORK_METRICS
+              value: "true"
+            - name: BEYLA_NETWORK_CACHE_ACTIVE_TIMEOUT
+              value: "100ms"
+            - name: BEYLA_NETWORK_CACHE_MAX_FLOWS
+              value: "20"
+            - name: BEYLA_METRICS_INTERVAL
+              value: "10ms"
+            - name: BEYLA_BPF_BATCH_TIMEOUT
+              value: "10ms"
+            - name: OTEL_METRIC_EXPORT_INTERVAL
+              value: "5000"

--- a/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
+++ b/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
@@ -1,0 +1,156 @@
+//go:build integration_k8s
+
+package otel
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/grafana/beyla/test/integration/components/docker"
+	"github.com/grafana/beyla/test/integration/components/kube"
+	"github.com/grafana/beyla/test/integration/components/prom"
+	k8s "github.com/grafana/beyla/test/integration/k8s/common"
+	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
+	"github.com/grafana/beyla/test/tools"
+)
+
+const (
+	testTimeout        = 3 * time.Minute
+	prometheusHostPort = "localhost:39090"
+)
+
+var cluster *kube.Kind
+
+func TestMain(m *testing.M) {
+	if err := docker.Build(os.Stdout, tools.ProjectDir(),
+		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
+		docker.ImageBuild{Tag: "beyla:dev", Dockerfile: k8s.DockerfileBeyla},
+		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
+		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.53.0"},
+		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
+	); err != nil {
+		slog.Error("can't build docker images", "error", err)
+		os.Exit(-1)
+	}
+
+	cluster = kube.NewKind("test-kind-cluster-netolly-multizone",
+		kube.KindConfig(testpath.Manifests+"/00-kind-multi-zone.yml"),
+		kube.LocalImage("testserver:dev"),
+		kube.LocalImage("beyla:dev"),
+		kube.LocalImage("httppinger:dev"),
+		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
+		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-multizone-client-server.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-multizone.yml"),
+	)
+
+	cluster.Run(m)
+}
+
+func TestMultizoneNetworkFlows(t *testing.T) {
+	cluster.TestEnv().Test(t, features.New("Multizone Network flows").
+		Assess("flows are decorated with zone", testFlowsDecoratedWithZone).Feature())
+}
+
+func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := prom.Client{HostPort: prometheusHostPort}
+
+	// checking pod-to-pod node communication (request)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`k8s_src_name="httppinger",k8s_dst_name=~"testserver.*",` +
+			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+		for _, res := range results {
+			assert.Equal(t, "client-zone", res.Metric["src_zone"])
+			assert.Equal(t, "server-zone", res.Metric["dst_zone"])
+		}
+	})
+	// checking pod-to-pod node communication (response)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`k8s_dst_name="httppinger",k8s_src_name=~"testserver.*",` +
+			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+		for _, res := range results {
+			assert.Equal(t, "server-zone", res.Metric["src_zone"])
+			assert.Equal(t, "client-zone", res.Metric["dst_zone"])
+		}
+	})
+
+	// checking node-to-node communication (e.g between control plane and workers)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`src_zone="server-zone",dst_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`dst_zone="server-zone",src_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`src_zone="client-zone",dst_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`dst_zone="client-zone",src_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	return ctx
+}


### PR DESCRIPTION
Adds the src_zone and dst_zone network metric attributes in Network metrics for Kubernetes.

This is enough to get basic visibility of inter-availability zone traffic, but a following PR would enable a new special network metric for this that would allow clients setting finer-grained visibility attributes for only inter-zone traffic without increasing the overall cardinality of the beyla_network_flow_bytes metric.