### PR TITLE
Add beyla_network_inter_zone_bytes metric

### DIFF
--- a/pkg/beyla/network_cfg.go
+++ b/pkg/beyla/network_cfg.go
@@ -33,6 +33,8 @@ const (
 type NetworkConfig struct {
 	// Enable network metrics.
 	// Default value is false (disabled)
+	// Deprecated: use BEYLA_OTEL_METRIC_FEATURES or BEYLA_PROMETHEUS_FEATURES
+	// TODO Beyla 3.0: remove
 	Enable bool `yaml:"enable" env:"BEYLA_NETWORK_METRICS"`
 
 	// Specify the source type for network events, e.g tc or socket_filter. The tc implementation

--- a/pkg/beyla/network_cfg.go
+++ b/pkg/beyla/network_cfg.go
@@ -33,7 +33,7 @@ const (
 type NetworkConfig struct {
 	// Enable network metrics.
 	// Default value is false (disabled)
-	// Deprecated: use BEYLA_OTEL_METRIC_FEATURES or BEYLA_PROMETHEUS_FEATURES
+	// Deprecated: add "network" to BEYLA_OTEL_METRIC_FEATURES or BEYLA_PROMETHEUS_FEATURES
 	// TODO Beyla 3.0: remove
 	Enable bool `yaml:"enable" env:"BEYLA_NETWORK_METRICS"`
 

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -113,6 +113,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 	// networkInterZone* supports the same attributes as
 	// network* counterpart, but all of them disabled by default, to keep cardinality low
 	networkInterZone := copyDisabled(networkAttributes)
+	networkInterZone.Attributes[attr.K8sClusterName] = true
 	networkInterZoneKube := copyDisabled(networkKubeAttributes)
 	networkInterZoneCIDR := copyDisabled(networkCIDR)
 	// only src and dst zone are enabled by default

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -56,6 +56,27 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 		},
 	}
 
+	// network metrics attributes
+	networkAttributes := AttrReportGroup{
+		Attributes: map[attr.Name]Default{
+			attr.Direction:      true,
+			attr.BeylaIP:        false,
+			attr.Transport:      false,
+			attr.SrcAddress:     false,
+			attr.DstAddres:      false,
+			attr.SrcPort:        false,
+			attr.DstPort:        false,
+			attr.SrcName:        false,
+			attr.DstName:        false,
+			attr.ServerPort:     false,
+			attr.ClientPort:     false,
+			attr.SrcZone:        false,
+			attr.DstZone:        false,
+			attr.IfaceDirection: Default(ifaceDirEnabled),
+			attr.Iface:          Default(ifaceDirEnabled),
+		},
+	}
+
 	// attributes to be reported exclusively for network metrics when
 	// kubernetes metadata is enabled
 	var networkKubeAttributes = AttrReportGroup{
@@ -88,6 +109,15 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			attr.SrcCIDR: true,
 		},
 	}
+
+	// networkInterZone* supports the same attributes as
+	// network* counterpart, but all of them disabled by default, to keep cardinality low
+	networkInterZone := copyDisabled(networkAttributes)
+	networkInterZoneKube := copyDisabled(networkKubeAttributes)
+	networkInterZoneCIDR := copyDisabled(networkCIDR)
+	// only src and dst zone are enabled by default
+	networkInterZone.Attributes[attr.SrcZone] = true
+	networkInterZone.Attributes[attr.DstZone] = true
 
 	// attributes to be reported exclusively for application metrics when
 	// kubernetes metadata is enabled
@@ -188,24 +218,10 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 
 	return map[Section]AttrReportGroup{
 		BeylaNetworkFlow.Section: {
-			SubGroups: []*AttrReportGroup{&networkCIDR, &networkKubeAttributes},
-			Attributes: map[attr.Name]Default{
-				attr.Direction:      true,
-				attr.BeylaIP:        false,
-				attr.Transport:      false,
-				attr.SrcAddress:     false,
-				attr.DstAddres:      false,
-				attr.SrcPort:        false,
-				attr.DstPort:        false,
-				attr.SrcName:        false,
-				attr.DstName:        false,
-				attr.ServerPort:     false,
-				attr.ClientPort:     false,
-				attr.SrcZone:        false,
-				attr.DstZone:        false,
-				attr.IfaceDirection: Default(ifaceDirEnabled),
-				attr.Iface:          Default(ifaceDirEnabled),
-			},
+			SubGroups: []*AttrReportGroup{&networkAttributes, &networkCIDR, &networkKubeAttributes},
+		},
+		BeylaNetworkInterZone.Section: {
+			SubGroups: []*AttrReportGroup{&networkInterZone, &networkInterZoneCIDR, &networkInterZoneKube},
 		},
 		HTTPServerDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes, &appKubeAttributes, &httpCommon, &serverInfo},
@@ -290,6 +306,17 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			},
 		},
 	}
+}
+
+func copyDisabled(src AttrReportGroup) AttrReportGroup {
+	var dst = AttrReportGroup{
+		Disabled:   src.Disabled,
+		Attributes: map[attr.Name]Default{},
+	}
+	for k := range src.Attributes {
+		dst.Attributes[k] = false
+	}
+	return dst
 }
 
 // AllAttributeNames returns a set with all the names in the attributes database

--- a/pkg/export/attributes/metric.go
+++ b/pkg/export/attributes/metric.go
@@ -26,6 +26,11 @@ var (
 		Prom:    "beyla_network_flow_bytes_total",
 		OTEL:    "beyla.network.flow.bytes",
 	}
+	BeylaNetworkInterZone = Name{
+		Section: "beyla.network.inter.zone",
+		Prom:    "beyla_network_inter_zone_bytes_total",
+		OTEL:    "beyla.network.inter.zone.bytes",
+	}
 	HTTPServerRequestSize = Name{
 		Section: "http.server.request.body.size",
 		Prom:    "http_server_request_body_size_bytes",

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -55,12 +55,13 @@ const (
 	AggregationExplicit    = "explicit_bucket_histogram"
 	AggregationExponential = "base2_exponential_bucket_histogram"
 
-	FeatureNetwork     = "network"
-	FeatureApplication = "application"
-	FeatureSpan        = "application_span"
-	FeatureGraph       = "application_service_graph"
-	FeatureProcess     = "application_process"
-	FeatureEBPF        = "ebpf"
+	FeatureNetwork          = "network"
+	FeatureNetworkInterZone = "network_inter_zone"
+	FeatureApplication      = "application"
+	FeatureSpan             = "application_span"
+	FeatureGraph            = "application_service_graph"
+	FeatureProcess          = "application_process"
+	FeatureEBPF             = "ebpf"
 )
 
 type MetricsConfig struct {
@@ -160,7 +161,15 @@ func (m *MetricsConfig) OTelMetricsEnabled() bool {
 }
 
 func (m *MetricsConfig) NetworkMetricsEnabled() bool {
+	return m.NetworkFlowBytesEnabled() || m.NetworkInterzoneMetricsEnabled()
+}
+
+func (m *MetricsConfig) NetworkFlowBytesEnabled() bool {
 	return slices.Contains(m.Features, FeatureNetwork)
+}
+
+func (m *MetricsConfig) NetworkInterzoneMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureNetworkInterZone)
 }
 
 func (m *MetricsConfig) Enabled() bool {

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -27,7 +27,7 @@ type NetMetricsConfig struct {
 	Metrics            *MetricsConfig
 	AttributeSelectors attributes.Selection
 	// Deprecated: to be removed in Beyla 3.0 with BEYLA_NETWORK_METRICS bool flag
-	GloballyEnabled    bool
+	GloballyEnabled bool
 }
 
 func (mc NetMetricsConfig) Enabled() bool {

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -26,6 +26,7 @@ import (
 type NetMetricsConfig struct {
 	Metrics            *MetricsConfig
 	AttributeSelectors attributes.Selection
+	// Deprecated: to be removed in Beyla 3.0 with BEYLA_NETWORK_METRICS bool flag
 	GloballyEnabled    bool
 }
 
@@ -113,7 +114,7 @@ func newMetricsExporter(ctx context.Context, ctxInfo *global.ContextInfo, cfg *N
 		clock:     clock,
 		expireTTL: cfg.Metrics.TTL,
 	}
-	if cfg.Metrics.NetworkFlowBytesEnabled() {
+	if cfg.GloballyEnabled || cfg.Metrics.NetworkFlowBytesEnabled() {
 		log := log.With("metricFamily", "FlowBytes")
 		bytesMetric, err := ebpfEvents.Int64Counter(attributes.BeylaNetworkFlow.OTEL,
 			metric2.WithDescription("total bytes_sent value of network flows observed by probe since its launch"),

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -47,10 +47,11 @@ func TestMetricAttributes(t *testing.T) {
 			Interval:          10 * time.Millisecond,
 			ReportersCacheLen: 100,
 			TTL:               5 * time.Minute,
+			Features:          []string{FeatureNetwork, FeatureNetworkInterZone},
 		}})
 	require.NoError(t, err)
 
-	_, reportedAttributes := me.metrics.ForRecord(in)
+	_, reportedAttributes := me.flowBytes.ForRecord(in)
 	for _, mustContain := range []attribute.KeyValue{
 		attribute.String("src.address", "12.34.56.78"),
 		attribute.String("dst.address", "33.22.11.1"),
@@ -106,10 +107,11 @@ func TestMetricAttributes_Filter(t *testing.T) {
 			MetricsEndpoint:   "http://foo",
 			Interval:          10 * time.Millisecond,
 			ReportersCacheLen: 100,
+			Features:          []string{FeatureNetwork, FeatureNetworkInterZone},
 		}})
 	require.NoError(t, err)
 
-	_, reportedAttributes := me.metrics.ForRecord(in)
+	_, reportedAttributes := me.flowBytes.ForRecord(in)
 	for _, mustContain := range []attribute.KeyValue{
 		attribute.String("src.address", "12.34.56.78"),
 		attribute.String("k8s.src.name", "srcname"),

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -131,7 +131,15 @@ func (p *PrometheusConfig) ServiceGraphMetricsEnabled() bool {
 }
 
 func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
+	return p.NetworkFlowBytesEnabled() || p.NetworkInterzoneMetricsEnabled()
+}
+
+func (p *PrometheusConfig) NetworkFlowBytesEnabled() bool {
 	return slices.Contains(p.Features, otel.FeatureNetwork)
+}
+
+func (p *PrometheusConfig) NetworkInterzoneMetricsEnabled() bool {
+	return slices.Contains(p.Features, otel.FeatureNetworkInterZone)
 }
 
 func (p *PrometheusConfig) EBPFEnabled() bool {

--- a/pkg/export/prom/prom_net.go
+++ b/pkg/export/prom/prom_net.go
@@ -21,6 +21,7 @@ import (
 type NetPrometheusConfig struct {
 	Config             *PrometheusConfig
 	AttributeSelectors attributes.Selection
+	// Deprecated: to be removed in Beyla 3.0 with BEYLA_NETWORK_METRICS bool flag
 	GloballyEnabled    bool
 }
 
@@ -90,7 +91,7 @@ func newNetReporter(
 
 	var register []prometheus.Collector
 	log := slog.With("component", "prom.NetworkEndpoint")
-	if mr.cfg.NetworkFlowBytesEnabled() {
+	if cfg.GloballyEnabled || mr.cfg.NetworkFlowBytesEnabled() {
 		log.Debug("registering network flow bytes metric")
 		mr.flowAttrs = attributes.PrometheusGetters(
 			ebpf.RecordStringGetters,

--- a/pkg/export/prom/prom_net.go
+++ b/pkg/export/prom/prom_net.go
@@ -32,10 +32,12 @@ type netMetricsReporter struct {
 	cfg *PrometheusConfig
 
 	flowBytes *Expirer[prometheus.Counter]
+	interZone *Expirer[prometheus.Counter]
 
 	promConnect *connector.PrometheusManager
 
-	attrs []attributes.Field[*ebpf.Record, string]
+	flowAttrs      []attributes.Field[*ebpf.Record, string]
+	interZoneAttrs []attributes.Field[*ebpf.Record, string]
 
 	clock *expire.CachedClock
 	bgCtx context.Context
@@ -75,29 +77,47 @@ func newNetReporter(
 		return nil, fmt.Errorf("network Prometheus exporter attributes enable: %w", err)
 	}
 
-	attrs := attributes.PrometheusGetters(
-		ebpf.RecordStringGetters,
-		provider.For(attributes.BeylaNetworkFlow))
-
-	labelNames := make([]string, 0, len(attrs))
-	for _, label := range attrs {
-		labelNames = append(labelNames, label.ExposedName)
-	}
-
 	clock := expire.NewCachedClock(timeNow)
+
 	// If service name is not explicitly set, we take the service name as set by the
 	// executable inspector
 	mr := &netMetricsReporter{
 		bgCtx:       ctx,
 		cfg:         cfg.Config,
 		promConnect: ctxInfo.Prometheus,
-		attrs:       attrs,
 		clock:       clock,
-		flowBytes: NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+	}
+
+	if mr.cfg.NetworkFlowBytesEnabled() {
+		mr.flowAttrs = attributes.PrometheusGetters(
+			ebpf.RecordStringGetters,
+			provider.For(attributes.BeylaNetworkFlow))
+
+		labelNames := make([]string, 0, len(mr.flowAttrs))
+		for _, label := range mr.flowAttrs {
+			labelNames = append(labelNames, label.ExposedName)
+		}
+		mr.flowBytes = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attributes.BeylaNetworkFlow.Prom,
 			Help: "bytes submitted from a source network endpoint to a destination network endpoint",
-		}, labelNames).MetricVec, clock.Time, cfg.Config.TTL),
+		}, labelNames).MetricVec, clock.Time, cfg.Config.TTL)
 	}
+
+	if mr.cfg.NetworkInterzoneMetricsEnabled() {
+		mr.interZoneAttrs = attributes.PrometheusGetters(
+			ebpf.RecordStringGetters,
+			provider.For(attributes.BeylaNetworkInterZone))
+
+		labelNames := make([]string, 0, len(mr.interZoneAttrs))
+		for _, label := range mr.interZoneAttrs {
+			labelNames = append(labelNames, label.ExposedName)
+		}
+		mr.interZone = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: attributes.BeylaNetworkInterZone.Prom,
+			Help: "bytes submitted between different cloud availability zones",
+		}, labelNames).MetricVec, clock.Time, cfg.Config.TTL)
+	}
+
 	if cfg.Config.Registry != nil {
 		cfg.Config.Registry.MustRegister(mr.flowBytes)
 	} else {
@@ -118,15 +138,30 @@ func (r *netMetricsReporter) collectMetrics(input <-chan []*ebpf.Record) {
 		// remove the old metrics
 		r.clock.Update()
 		for _, flow := range flows {
-			r.observe(flow)
+			r.observeFlowBytes(flow)
+			r.observeInterZone(flow)
 		}
 	}
 }
 
-func (r *netMetricsReporter) observe(flow *ebpf.Record) {
-	labelValues := make([]string, 0, len(r.attrs))
-	for _, attr := range r.attrs {
+func (r *netMetricsReporter) observeFlowBytes(flow *ebpf.Record) {
+	if r.flowBytes == nil {
+		return
+	}
+	labelValues := make([]string, 0, len(r.flowAttrs))
+	for _, attr := range r.flowAttrs {
 		labelValues = append(labelValues, attr.Get(flow))
 	}
 	r.flowBytes.WithLabelValues(labelValues...).metric.Add(float64(flow.Metrics.Bytes))
+}
+
+func (r *netMetricsReporter) observeInterZone(flow *ebpf.Record) {
+	if r.interZone == nil {
+		return
+	}
+	labelValues := make([]string, 0, len(r.interZoneAttrs))
+	for _, attr := range r.interZoneAttrs {
+		labelValues = append(labelValues, attr.Get(flow))
+	}
+	r.interZone.WithLabelValues(labelValues...).metric.Add(float64(flow.Metrics.Bytes))
 }

--- a/pkg/export/prom/prom_net.go
+++ b/pkg/export/prom/prom_net.go
@@ -22,7 +22,7 @@ type NetPrometheusConfig struct {
 	Config             *PrometheusConfig
 	AttributeSelectors attributes.Selection
 	// Deprecated: to be removed in Beyla 3.0 with BEYLA_NETWORK_METRICS bool flag
-	GloballyEnabled    bool
+	GloballyEnabled bool
 }
 
 // nolint:gocritic

--- a/pkg/export/prom/prom_net.go
+++ b/pkg/export/prom/prom_net.go
@@ -112,7 +112,7 @@ func newNetReporter(
 		mr.interZone = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attributes.BeylaNetworkInterZone.Prom,
 			Help: "bytes submitted between different cloud availability zones",
-		}, labelNames (mr.interZoneAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
+		}, labelNames(mr.interZoneAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
 		register = append(register, mr.interZone)
 	}
 

--- a/test/integration/configs/otelcol-config-4017.yml
+++ b/test/integration/configs/otelcol-config-4017.yml
@@ -17,6 +17,7 @@ exporters:
     enable_open_metrics: true
 processors:
   batch:
+    timeout: 0
 service:
   pipelines:
     metrics:

--- a/test/integration/configs/otelcol-config.yml
+++ b/test/integration/configs/otelcol-config.yml
@@ -17,6 +17,7 @@ exporters:
     enable_open_metrics: true
 processors:
   batch:
+    timeout: 0
 service:
   pipelines:
     metrics:

--- a/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
+++ b/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
@@ -13,3 +13,32 @@ scrape_configs:
           - 'beyla-netolly:8999'
           - 'beyla-promscrape:8999'
           - 'k8s-cache:8999'
+  # Scrape config for service endpoints.
+  #
+  # The relabeling allows the actual service scrape endpoint to be configured
+  # via the following annotations:
+  #
+  # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
+  # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+  # * `prometheus.io/port`: If the metrics are exposed on a different port to the
+  #   service then set this appropriately.
+  - job_name: 'kubernetes-pods'
+    honor_labels: true
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      # select only those pods that has "prometheus.io/scrape: true" annotation
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+        # set metrics_path (default is /metrics) to the metrics path specified in "prometheus.io/path: <metric path>" annotation.
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+        # set the scrapping port to the port specified in "prometheus.io/port: <port>" annotation and set address accordingly.
+      - source_labels: [ "__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__

--- a/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
+++ b/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
@@ -22,7 +22,7 @@ scrape_configs:
   # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
   # * `prometheus.io/port`: If the metrics are exposed on a different port to the
   #   service then set this appropriately.
-  - job_name: 'kubernetes-pods'
+  - job_name: 'beyla-network-flows-scrape'
     honor_labels: true
     kubernetes_sd_configs:
       - role: pod

--- a/test/integration/configs/prometheus-config.yml
+++ b/test/integration/configs/prometheus-config.yml
@@ -1,5 +1,5 @@
 global:
-  evaluation_interval: 30s
+  evaluation_interval: 5s
   scrape_interval: 5s
 scrape_configs:
   - job_name: otel

--- a/test/integration/k8s/manifests/02-prometheus-promscrape.yml
+++ b/test/integration/k8s/manifests/02-prometheus-promscrape.yml
@@ -1,3 +1,34 @@
+# allows Prometheus to get scrape annotations
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - services
+      - endpoints
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
@@ -7,6 +7,7 @@ data:
     log_level: debug
     otel_metrics_export:
       endpoint: http://otelcol.default:4317
+      features: ["network", "network_inter_zone"]
     network:
       protocols:
         - TCP

--- a/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
@@ -28,18 +28,6 @@ data:
           include: ["*"]
           exclude: ["src_port"]
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: beyla-netolly
-spec:
-  selector:
-    instrumentation: beyla
-  ports:
-    - port: 8999
-      name: prometheus
-      protocol: TCP
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -55,6 +43,10 @@ spec:
         # this label will trigger a deletion of beyla pods before tearing down
         # kind, to force Beyla writing the coverage data
         teardown: delete
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: '/metrics'
+        prometheus.io/port: '8999'
     spec:
       hostPID: true  #important for appo11y!
       hostNetwork: true #important for neto11y!
@@ -88,8 +80,9 @@ spec:
               value: "/testoutput"
             - name: BEYLA_CONFIG_PATH
               value: /config/beyla-config.yml
-            - name: BEYLA_PROMETHEUS_FEATURES # implicitly enabling network metrics for Prometheus scrape
-              value: "network"
+              # network_inter_zone won't have effect on non-multizone kind clusters
+            - name: BEYLA_PROMETHEUS_FEATURES
+              value: "network,network_inter_zone"
             - name: BEYLA_NETWORK_CACHE_ACTIVE_TIMEOUT
               value: "100ms"
             - name: BEYLA_NETWORK_CACHE_MAX_FLOWS

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -58,7 +58,9 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Equal(t, "beyla-network-flows", metric["job"])
+		assert.Regexp(t,
+			regexp.MustCompile("^beyla-network-flows"),
+			metric["job"])
 		assert.Equal(t, "my-kube", metric["k8s_cluster_name"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
@@ -89,7 +91,9 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Equal(t, "beyla-network-flows", metric["job"])
+		assert.Regexp(t,
+			regexp.MustCompile("^beyla-network-flows"),
+			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
 		assert.Equal(t, "Pod", metric["k8s_src_owner_type"])
@@ -124,7 +128,9 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Equal(t, "beyla-network-flows", metric["job"])
+		assert.Regexp(t,
+			regexp.MustCompile("^beyla-network-flows"),
+			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Regexp(t, regexp.MustCompile("^testserver-"), metric["k8s_src_name"])
 		assert.Equal(t, "Deployment", metric["k8s_src_owner_type"])
@@ -159,7 +165,9 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Equal(t, "beyla-network-flows", metric["job"])
+		assert.Regexp(t,
+			regexp.MustCompile("^beyla-network-flows"),
+			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "testserver", metric["k8s_src_name"])
 		assert.Equal(t, "Service", metric["k8s_src_owner_type"])

--- a/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
+++ b/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
@@ -1,0 +1,150 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/grafana/beyla/test/integration/components/prom"
+)
+
+const (
+	testTimeout        = 3 * time.Minute
+	prometheusHostPort = "localhost:39090"
+)
+
+func FeatureMultizoneNetworkFlows() features.Feature {
+	return features.New("Multizone Network flows").
+		Assess("flows are decorated with zone", testFlowsDecoratedWithZone).
+		Assess("interzone bytes are reported as their own metric", testInterZoneMetric).
+		Feature()
+}
+
+func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := prom.Client{HostPort: prometheusHostPort}
+
+	// checking pod-to-pod node communication (request)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`k8s_src_name="httppinger",k8s_dst_name=~"testserver.*",` +
+			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+		for _, res := range results {
+			assert.Equal(t, "client-zone", res.Metric["src_zone"])
+			assert.Equal(t, "server-zone", res.Metric["dst_zone"])
+		}
+	})
+	// checking pod-to-pod node communication (response)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`k8s_dst_name="httppinger",k8s_src_name=~"testserver.*",` +
+			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+		for _, res := range results {
+			assert.Equal(t, "server-zone", res.Metric["src_zone"])
+			assert.Equal(t, "client-zone", res.Metric["dst_zone"])
+		}
+	})
+
+	// checking node-to-node communication (e.g between control plane and workers)
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`src_zone="server-zone",dst_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`dst_zone="server-zone",src_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`src_zone="client-zone",dst_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+			`dst_zone="client-zone",src_zone="control-plane-zone",` +
+			`k8s_src_type="Node",k8s_dst_type="Node"` +
+			`}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// check that the metrics are properly decorated
+		// should have 2 exact metrics, measured from Beyla instances in both nodes
+		require.GreaterOrEqual(t, len(results), 2)
+	})
+	return ctx
+}
+
+func testInterZoneMetric(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := prom.Client{HostPort: prometheusHostPort}
+
+	// inter-zone bytes are reported
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+			`src_zone="client-zone", dst_zone="server-zone"}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+	})
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+			`dst_zone="client-zone", src_zone="server-zone"}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		// AND the reported attributes are different from the flow bytes attributes
+		require.NotContains(t, results, "k8s_src_type")
+		require.NotContains(t, results, "iface_direction")
+	})
+
+	// BUT same-zone bytes are not reported in this metric
+	results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+		`src_zone="client-zone", dst_zone="client-zone"}`)
+	require.NoError(t, err)
+	require.Empty(t, results)
+	results, err = pq.Query(`beyla_network_inter_zone_bytes_total{` +
+		`src_zone="server-zone", dst_zone="server-zone"}`)
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	return ctx
+}

--- a/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
+++ b/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
@@ -45,6 +45,6 @@ func TestMain(m *testing.M) {
 	cluster.Run(m)
 }
 
-func TestMultizoneNetworkFlows(t *testing.T) {
+func TestMultizoneNetworkFlows_Prom(t *testing.T) {
 	cluster.TestEnv().Test(t, otel.FeatureMultizoneNetworkFlows())
 }

--- a/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
+++ b/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/beyla/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/test/integration/k8s/common"
 	"github.com/grafana/beyla/test/integration/k8s/common/testpath"
+	otel "github.com/grafana/beyla/test/integration/k8s/netolly_multizone"
 	"github.com/grafana/beyla/test/tools"
 )
 
@@ -34,18 +35,16 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("beyla:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("quay.io/prometheus/prometheus:v2.53.0"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
-		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),
-		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),
 		kube.Deploy(testpath.Manifests+"/05-uninstrumented-multizone-client-server.yml"),
-		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-multizone.yml"),
+		kube.Deploy(testpath.Manifests+"/06-beyla-netolly-promexport.yml"),
 	)
 
 	cluster.Run(m)
 }
 
 func TestMultizoneNetworkFlows(t *testing.T) {
-	cluster.TestEnv().Test(t, FeatureMultizoneNetworkFlows())
+	cluster.TestEnv().Test(t, otel.FeatureMultizoneNetworkFlows())
 }


### PR DESCRIPTION
In addition to the decoration of beyla flow bytes metric with the `src_zone` and `dst_zone`, Beyla now enables a new counter metric that only reports flow bytes for inter-zone traffic (when `src_zone != dst_zone`).

The reasons for adding a new metric:

* You don't have to add new attributes to the `beyla_network_flow_bytes` metric.
* PromQL queries remain simpler (no need to join `beyla_network_flow_bytes` for different values of src/dst zones)
* Can track inter-AZ traffic with different levels of granularity. You can keep inter-az traffic as simple as possible (only cluster and src/dst zones) or go to finest levels of granularity (e.g. source Pod) that would increase too much cardinality in the general-purpose beyla_network_flow_bytes` metric.

Documentation will go in a different PR.