### PR TITLE
Fix clang-tidy check workflow

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -21,10 +21,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget lsb-release software-properties-common gnupg
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
-          sudo apt-get install -y clang-tidy-20
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main'
+          sudo apt-get install -y clang-tidy-19
 
       - name: Check Clang Tidy
         run: |
-          CLANG_TIDY=clang-tidy-20 make clang-tidy
+          CLANG_TIDY=clang-tidy-19 make clang-tidy
 


### PR DESCRIPTION
- Upgade to Ubuntu Noble
- Downgrade to clang-tidy 19 -> clang-tidy-20 packages are broken, and 19 is modern enough for our use case. We will look at updating to clang-tidy-21 later, as it is more pedantic and will require other changes.