### PR TITLE
Correct default value in docs for enforce_sys_caps

### DIFF
--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -167,7 +167,7 @@ formats are:
 
 | YAML               | Environment variable     | Type     | Default    |
 | -----------------  | ------------------------ | -------- | ---------- |
-| `enforce_sys_caps` | `BEYLA_ENFORCE_SYS_CAPS` | boolean  | `false`     |
+| `enforce_sys_caps` | `BEYLA_ENFORCE_SYS_CAPS` | boolean  | `false`    |
 
 <a id="caps"></a>
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -167,7 +167,7 @@ formats are:
 
 | YAML               | Environment variable     | Type     | Default    |
 | -----------------  | ------------------------ | -------- | ---------- |
-| `enforce_sys_caps` | `BEYLA_ENFORCE_SYS_CAPS` | boolean  | `true`     |
+| `enforce_sys_caps` | `BEYLA_ENFORCE_SYS_CAPS` | boolean  | `false`     |
 
 <a id="caps"></a>
 


### PR DESCRIPTION
In the docs, it says the default value for `enforce_sys_caps` or `BEYLA_ENFORCE_SYS_CAPS` is true, but it is actually false. This corrects the docs to reflect that.