### PR TITLE
Switch the order of env configurations in helm charts

### DIFF
--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -95,14 +95,14 @@ spec:
             - name: BEYLA_KUBE_META_CACHE_ADDRESS
               value: {{ .Values.k8sCache.service.name }}:{{ .Values.k8sCache.service.port }}
           {{- end }}
-          {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-          {{- end }}
           {{- range $key, $value := .Values.envValueFrom }}
             - name: {{ $key | quote }}
               valueFrom:
           {{- tpl (toYaml $value) $ | nindent 16 }}
+          {{- end }}
+          {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
           {{- end }}
           volumeMounts:
             - mountPath: /etc/beyla/config


### PR DESCRIPTION
Switch the order of env configurations so that the scenario where HOST_IP is passed through the downward API can work.
```yaml 
            - name: "HOST_IP"
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
            - name: OTEL_EXPORTER_OTLP_ENDPOINT
              value: "http://$(HOST_IP):4318"
```