### PR TITLE
Add span skip attribute for span metrics generation

### DIFF
--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/export/attributes"
+	attr "github.com/grafana/beyla/pkg/export/attributes/names"
 	"github.com/grafana/beyla/pkg/export/otel"
 	"github.com/grafana/beyla/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/pkg/internal/request"
@@ -18,16 +19,30 @@ func TracesReceiver(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *beyla.TracesReceiverConfig,
+	spanMetricsEnabled bool,
 	userAttribSelection attributes.Selection,
 ) pipe.FinalProvider[[]request.Span] {
-	return (&tracesReceiver{ctx: ctx, cfg: cfg, attributes: userAttribSelection, hostID: ctxInfo.HostID}).provideLoop
+	return (&tracesReceiver{ctx: ctx, cfg: cfg, attributes: userAttribSelection, hostID: ctxInfo.HostID, spanMetricsEnabled: spanMetricsEnabled}).provideLoop
 }
 
 type tracesReceiver struct {
-	ctx        context.Context
-	cfg        *beyla.TracesReceiverConfig
-	attributes attributes.Selection
-	hostID     string
+	ctx                context.Context
+	cfg                *beyla.TracesReceiverConfig
+	attributes         attributes.Selection
+	hostID             string
+	spanMetricsEnabled bool
+}
+
+func (tr *tracesReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
+	traceAttrs, err := otel.GetUserSelectedAttributes(tr.attributes)
+	if err != nil {
+		return nil, err
+	}
+
+	if tr.spanMetricsEnabled {
+		traceAttrs[attr.SkipSpanMetrics] = struct{}{}
+	}
+	return traceAttrs, nil
 }
 
 func (tr *tracesReceiver) spanDiscarded(span *request.Span) bool {
@@ -40,9 +55,13 @@ func (tr *tracesReceiver) provideLoop() (pipe.FinalFunc[[]request.Span], error) 
 	}
 	return func(in <-chan []request.Span) {
 		// Get user attributes
-		traceAttrs, err := otel.GetUserSelectedAttributes(tr.attributes)
+		traceAttrs, err := tr.getConstantAttributes()
 		if err != nil {
 			slog.Error("error fetching user defined attributes", "error", err)
+		}
+
+		if tr.spanMetricsEnabled {
+			traceAttrs[attr.SkipSpanMetrics] = struct{}{}
 		}
 
 		for spans := range in {

--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -60,10 +60,6 @@ func (tr *tracesReceiver) provideLoop() (pipe.FinalFunc[[]request.Span], error) 
 			slog.Error("error fetching user defined attributes", "error", err)
 		}
 
-		if tr.spanMetricsEnabled {
-			traceAttrs[attr.SkipSpanMetrics] = struct{}{}
-		}
-
 		for spans := range in {
 			for i := range spans {
 				span := &spans[i]

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/export/attributes"
@@ -19,7 +20,6 @@ import (
 	"github.com/grafana/beyla/pkg/export/otel"
 	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/pkg/internal/svc"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTracesSkipsInstrumented(t *testing.T) {

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -2,7 +2,12 @@ package alloy
 
 import (
 	"context"
+	"encoding/binary"
+	"math/rand/v2"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -10,9 +15,11 @@ import (
 
 	"github.com/grafana/beyla/pkg/beyla"
 	"github.com/grafana/beyla/pkg/export/attributes"
+	attr "github.com/grafana/beyla/pkg/export/attributes/names"
 	"github.com/grafana/beyla/pkg/export/otel"
 	"github.com/grafana/beyla/pkg/internal/request"
 	"github.com/grafana/beyla/pkg/internal/svc"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTracesSkipsInstrumented(t *testing.T) {
@@ -56,6 +63,71 @@ func TestTracesSkipsInstrumented(t *testing.T) {
 	}
 }
 
+func TestTraceSkipSpanMetrics(t *testing.T) {
+	spans := []request.Span{}
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+		span := request.Span{Type: request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test" + strconv.Itoa(i),
+			Status:       200,
+			Service:      svc.Attrs{},
+			TraceID:      randomTraceID(),
+		}
+		spans = append(spans, span)
+	}
+
+	t.Run("test with span metrics on", func(t *testing.T) {
+		receiver := makeTracesTestReceiverWithSpanMetrics()
+
+		traces := generateTracesForSpans(t, receiver, spans)
+		assert.Equal(t, 10, len(traces))
+
+		for _, ts := range traces {
+			for i := 0; i < ts.ResourceSpans().Len(); i++ {
+				rs := ts.ResourceSpans().At(i)
+				for j := 0; j < rs.ScopeSpans().Len(); j++ {
+					ss := rs.ScopeSpans().At(j)
+					for k := 0; k < ss.Spans().Len(); k++ {
+						span := ss.Spans().At(k)
+						if strings.HasPrefix(span.Name(), "GET /test") {
+							v, ok := span.Attributes().Get(string(attr.SkipSpanMetrics.OTEL()))
+							assert.True(t, ok)
+							assert.Equal(t, true, v.Bool())
+						}
+					}
+				}
+			}
+		}
+	})
+
+	t.Run("test with span metrics off", func(t *testing.T) {
+		receiver := makeTracesTestReceiver()
+
+		traces := generateTracesForSpans(t, receiver, spans)
+		assert.Equal(t, 10, len(traces))
+
+		for _, ts := range traces {
+			for i := 0; i < ts.ResourceSpans().Len(); i++ {
+				rs := ts.ResourceSpans().At(i)
+				for j := 0; j < rs.ScopeSpans().Len(); j++ {
+					ss := rs.ScopeSpans().At(j)
+					for k := 0; k < ss.Spans().Len(); k++ {
+						span := ss.Spans().At(k)
+						if strings.HasPrefix(span.Name(), "GET /test") {
+							_, ok := span.Attributes().Get(string(attr.SkipSpanMetrics.OTEL()))
+							assert.False(t, ok)
+						}
+					}
+				}
+			}
+		}
+	})
+}
+
 func makeTracesTestReceiver() *tracesReceiver {
 	return &tracesReceiver{
 		ctx:        context.Background(),
@@ -65,9 +137,19 @@ func makeTracesTestReceiver() *tracesReceiver {
 	}
 }
 
+func makeTracesTestReceiverWithSpanMetrics() *tracesReceiver {
+	return &tracesReceiver{
+		ctx:                context.Background(),
+		cfg:                &beyla.TracesReceiverConfig{},
+		attributes:         attributes.Selection{},
+		hostID:             "Alloy",
+		spanMetricsEnabled: true,
+	}
+}
+
 func generateTracesForSpans(t *testing.T, tr *tracesReceiver, spans []request.Span) []ptrace.Traces {
 	res := []ptrace.Traces{}
-	traceAttrs, err := otel.GetUserSelectedAttributes(tr.attributes)
+	traceAttrs, err := tr.getConstantAttributes()
 	assert.NoError(t, err)
 	for i := range spans {
 		span := &spans[i]
@@ -78,4 +160,14 @@ func generateTracesForSpans(t *testing.T, tr *tracesReceiver, spans []request.Sp
 	}
 
 	return res
+}
+
+func randomTraceID() trace.TraceID {
+	t := trace.TraceID{}
+
+	for i := 0; i < len(t); i += 4 {
+		binary.LittleEndian.PutUint32(t[i:], rand.Uint32())
+	}
+
+	return t
 }

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -145,6 +145,7 @@ const (
 	HostID   = Name(semconv.HostIDKey)
 
 	ServiceInstanceID = Name(semconv.ServiceInstanceIDKey)
+	SkipSpanMetrics   = Name("span.metrics.skip")
 )
 
 // traces related attributes

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -116,10 +116,10 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 	config.Metrics.Grafana = &gb.config.Grafana.OTLP
 	pipe.AddFinalProvider(gnb, otelMetrics, otel.ReportMetrics(ctx, gb.ctxInfo, &config.Metrics, config.Attributes.Select))
 	config.Traces.Grafana = &gb.config.Grafana.OTLP
-	pipe.AddFinalProvider(gnb, otelTraces, otel.TracesReceiver(ctx, config.Traces, gb.ctxInfo, config.Attributes.Select))
+	pipe.AddFinalProvider(gnb, otelTraces, otel.TracesReceiver(ctx, config.Traces, config.Metrics.SpanMetricsEnabled(), gb.ctxInfo, config.Attributes.Select))
 	pipe.AddFinalProvider(gnb, prometheus, prom.PrometheusEndpoint(ctx, gb.ctxInfo, &config.Prometheus, config.Attributes.Select))
 	pipe.AddFinalProvider(gnb, bpfMetrics, prom.BPFMetrics(ctx, gb.ctxInfo, &config.Prometheus))
-	pipe.AddFinalProvider(gnb, alloyTraces, alloy.TracesReceiver(ctx, gb.ctxInfo, &config.TracesReceiver, config.Attributes.Select))
+	pipe.AddFinalProvider(gnb, alloyTraces, alloy.TracesReceiver(ctx, gb.ctxInfo, &config.TracesReceiver, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select))
 
 	pipe.AddFinalProvider(gnb, printer, debug.PrinterNode(config.TracePrinter))
 

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -416,6 +416,7 @@ func testHTTPTracesNestedCalls(t *testing.T) {
 		jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(8082)},
 		jaeger.Tag{Key: "http.route", Type: "string", Value: "/echo"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
+		jaeger.Tag{Key: "span.metrics.skip", Type: "bool", Value: bool(true)},
 	)
 	assert.Empty(t, sd, sd.String())
 


### PR DESCRIPTION
Beyla can directly generate span metrics for quick access to unified metrics and service graphs without the need for trace generation. This mainly done to ensure we can generate accurate metrics even in case of trace sampling with head sampling. Tail sampling doesn't need this option, however it does usually require higher compute cost.

In case we generate span metrics directly from Beyla and we also generate traces, some data will be duplicated if the collector has also enabled the span metrics processor. To help with filtering double counted metrics, this PR introduces a new attribute which will get attached to the spans, signalling that the span metrics are already generated and they can be ignored by the span metrics processor. The span metrics processor can check for this flag and drop the trace sample from metrics.

The new attribute is `span.metrics.skip = true`.