### PR TITLE
Add an option to debug protocol issues

### DIFF
--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -55,4 +55,7 @@ type EBPFTracer struct {
 
 	// Enables GPU instrumentation for CUDA kernel launches and allocations
 	InstrumentGPU bool `yaml:"instrument_gpu" env:"BEYLA_INSTRUMENT_GPU"`
+
+	// Enables GPU instrumentation for CUDA kernel launches and allocations
+	ProtocolDebug bool `yaml:"protocol_debug_print" env:"BEYLA_PROTOCOL_DEBUG_PRINT"`
 }

--- a/pkg/internal/ebpf/common/tcp_detect_transform.go
+++ b/pkg/internal/ebpf/common/tcp_detect_transform.go
@@ -3,6 +3,7 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	"github.com/cilium/ebpf/ringbuf"
 
@@ -34,6 +35,11 @@ func ReadTCPRequestIntoSpan(cfg *config.EBPFTracer, record *ringbuf.Record, filt
 	}
 
 	b := event.Buf[:l]
+
+	if cfg.ProtocolDebug {
+		fmt.Printf("[>] %v\n", b)
+		fmt.Printf("[<] %v\n", event.Rbuf[:rl])
+	}
 
 	// Check if we have a SQL statement
 	op, table, sql, kind := detectSQLPayload(cfg.HeuristicSQLDetect, b)


### PR DESCRIPTION
When we have a customer issue and a protocol detection doesn't work as expected, it would be useful to see what's coming out from the TCP request tracing. This PR adds an option (not documented) that we can use to print useful debugging information for fixing protocol detection issues.