### PR TITLE
Enable ProtocolDebug for ExternalLogger

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -323,11 +323,12 @@ func (c *Config) Enabled(feature Feature) bool {
 // ExternalLogger sets the logging capabilities of Beyla.
 // Used for integrating Beyla with an external logging system (for example Alloy)
 // TODO: maybe this method has too many responsibilities, as it affects the global logger.
-func (c *Config) ExternalLogger(handler slog.Handler, tracing bool) {
+func (c *Config) ExternalLogger(handler slog.Handler, debugMode bool) {
 	slog.SetDefault(slog.New(handler))
-	if tracing {
+	if debugMode {
 		c.TracePrinter = debug.TracePrinterText
 		c.EBPF.BpfDebug = true
+		c.EBPF.ProtocolDebug = true
 		if c.NetworkFlows.Enable {
 			c.NetworkFlows.Print = true
 		}

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -432,7 +432,7 @@ func TestConfig_ExternalLogger(t *testing.T) {
 		handler       func(out io.Writer) slog.Handler
 		expectedText  *regexp.Regexp
 		expectedCfg   Config
-		tracing       bool
+		debugMode     bool
 		networkEnable bool
 	}
 	for _, tc := range []testCase{{
@@ -450,10 +450,10 @@ func TestConfig_ExternalLogger(t *testing.T) {
 		expectedText: regexp.MustCompile(
 			`^time=\S+ level=INFO msg=information arg=info
 time=\S+ level=DEBUG msg=debug arg=debug$`),
-		tracing: true,
+		debugMode: true,
 		expectedCfg: Config{
 			TracePrinter: debug.TracePrinterText,
-			EBPF:         config.EBPFTracer{BpfDebug: true},
+			EBPF:         config.EBPFTracer{BpfDebug: true, ProtocolDebug: true},
 		},
 	}, {
 		name: "debug log with network flows",
@@ -464,17 +464,17 @@ time=\S+ level=DEBUG msg=debug arg=debug$`),
 		expectedText: regexp.MustCompile(
 			`^time=\S+ level=INFO msg=information arg=info
 time=\S+ level=DEBUG msg=debug arg=debug$`),
-		tracing: true,
+		debugMode: true,
 		expectedCfg: Config{
 			TracePrinter: debug.TracePrinterText,
-			EBPF:         config.EBPFTracer{BpfDebug: true},
+			EBPF:         config.EBPFTracer{BpfDebug: true, ProtocolDebug: true},
 			NetworkFlows: NetworkConfig{Enable: true, Print: true},
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := Config{NetworkFlows: NetworkConfig{Enable: tc.networkEnable}}
 			out := &bytes.Buffer{}
-			cfg.ExternalLogger(tc.handler(out), tc.tracing)
+			cfg.ExternalLogger(tc.handler(out), tc.debugMode)
 			slog.Info("information", "arg", "info")
 			slog.Debug("debug", "arg", "debug")
 			assert.Regexp(t, tc.expectedText, strings.TrimSpace(out.String()))

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -8,6 +8,7 @@ import (
 
 // EBPFTracer configuration for eBPF programs
 type EBPFTracer struct {
+	// Enables logging of eBPF program events
 	BpfDebug bool `yaml:"bpf_debug" env:"BEYLA_BPF_DEBUG"`
 
 	// WakeupLen specifies how many messages need to be accumulated in the eBPF ringbuffer
@@ -56,6 +57,6 @@ type EBPFTracer struct {
 	// Enables GPU instrumentation for CUDA kernel launches and allocations
 	InstrumentGPU bool `yaml:"instrument_gpu" env:"BEYLA_INSTRUMENT_GPU"`
 
-	// Enables GPU instrumentation for CUDA kernel launches and allocations
+	// Enables debug printing of the protocol data
 	ProtocolDebug bool `yaml:"protocol_debug_print" env:"BEYLA_PROTOCOL_DEBUG_PRINT"`
 }


### PR DESCRIPTION
- Expose newly added `ProtocolDebug` in `ExternalLogger`. This would expose those logs in Alloy.
- Fixed comments