### PR TITLE
Helm chart: do not override network flows attributes

### DIFF
--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -207,12 +207,6 @@ config:
     attributes:
       kubernetes:
         enable: true
-      select:
-        beyla_network_flow_bytes:
-          include:
-            - 'k8s.src.owner.type'
-            - 'k8s.dst.owner.type'
-            - 'direction'
     filter:
       network:
         k8s_dst_owner_name:


### PR DESCRIPTION
Addresses https://github.com/grafana/beyla/issues/1468

The Beyla default attributes for network flows were internally discussed and agreed. The provided override in Helm is useless, as knowing that a Pod is communicating with a Service (in generic) is obvious.