### PR TITLE
FIx http2 memory leak

### DIFF
--- a/pkg/internal/ebpf/common/http2grpc_transform.go
+++ b/pkg/internal/ebpf/common/http2grpc_transform.go
@@ -106,6 +106,7 @@ func knownFrameKeys(fr *http2.Framer, hf *http2.HeadersFrame) bool {
 		}
 	}
 
+	commonHDec.Close()
 	return known
 }
 
@@ -154,6 +155,8 @@ func readMetaFrame(conn *BPFConnInfo, newConn bool, fr *http2.Framer, hf *http2.
 			return method, path, contentType, ok
 		}
 	}
+
+	h2c.hdec.Close()
 
 	return method, path, contentType, ok
 }

--- a/pkg/internal/ebpf/common/http2grpc_transform.go
+++ b/pkg/internal/ebpf/common/http2grpc_transform.go
@@ -91,6 +91,7 @@ func knownFrameKeys(fr *http2.Framer, hf *http2.HeadersFrame) bool {
 	})
 	// Lose reference to MetaHeadersFrame:
 	defer commonHDec.SetEmitFunc(func(_ bhpack.HeaderField) {})
+	defer commonHDec.Close()
 
 	for {
 		frag := hf.HeaderBlockFragment()
@@ -106,7 +107,6 @@ func knownFrameKeys(fr *http2.Framer, hf *http2.HeadersFrame) bool {
 		}
 	}
 
-	commonHDec.Close()
 	return known
 }
 
@@ -141,6 +141,7 @@ func readMetaFrame(conn *BPFConnInfo, newConn bool, fr *http2.Framer, hf *http2.
 	})
 	// Lose reference to MetaHeadersFrame:
 	defer h2c.hdec.SetEmitFunc(func(_ bhpack.HeaderField) {})
+	defer h2c.hdec.Close()
 
 	for {
 		frag := hf.HeaderBlockFragment()
@@ -155,8 +156,6 @@ func readMetaFrame(conn *BPFConnInfo, newConn bool, fr *http2.Framer, hf *http2.
 			return method, path, contentType, ok
 		}
 	}
-
-	h2c.hdec.Close()
 
 	return method, path, contentType, ok
 }
@@ -201,6 +200,7 @@ func readRetMetaFrame(conn *BPFConnInfo, newConn bool, fr *http2.Framer, hf *htt
 	})
 	// Lose reference to MetaHeadersFrame:
 	defer h2c.hdecRet.SetEmitFunc(func(_ bhpack.HeaderField) {})
+	defer h2c.hdecRet.Close()
 
 	for {
 		frag := hf.HeaderBlockFragment()


### PR DESCRIPTION
We need to call close on the decoder to reset the internal buffer used for parsing the header fields.