### PR TITLE
Remove codecov from VM tests

### DIFF
--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -47,10 +47,3 @@ jobs:
           path: |
             testoutput/*.log
             testoutput/kind
-      - name: Report coverage
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          file: ./testoutput/itest-covdata.txt
-          flags: integration-test-vm-${{ inputs.arch }}-${{ inputs.kernel-version }}


### PR DESCRIPTION
The VM tests never generate any codecov data, so trying to upload it generates a warning. Generating coverage data for these tests is redundant since they are just a subset of the integration tests.