### PR TITLE
Remove stray debug message

### DIFF
--- a/.github/workflows/beyla_build.yml
+++ b/.github/workflows/beyla_build.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Compile eBPF Programs
         if: ${{ steps.commit-check.outputs.should_build == 'true' }}
         run: |
-          echo COMMITS $${{ github.event.head_commit.message }}
           make docker-generate
 
       # NOTE: The user email is {user.id}+{user.login}@users.noreply.github.com.


### PR DESCRIPTION
The debug message contains a variable not existing in non PR runs, causing the workflow to fail. See https://github.com/grafana/beyla/actions/runs/13293470168/job/37120007098 for an example.