### PR TITLE
More logs for process discovery

### DIFF
--- a/pkg/internal/discover/watcher_kube.go
+++ b/pkg/internal/discover/watcher_kube.go
@@ -187,6 +187,7 @@ func (wk *watcherKubeEnricher) onNewPod(pod *informer.ObjectMeta) []Event[proces
 	var events []Event[processAttrs]
 	for _, cnt := range pod.Pod.Containers {
 		if procInfo, ok := wk.processByContainer[cnt.Id]; ok {
+			wk.log.Debug("matched pod with running process", "container", cnt.Id, "pid", procInfo.pid)
 			events = append(events, Event[processAttrs]{
 				Type: EventCreated,
 				Obj:  withMetadata(procInfo, pod),

--- a/pkg/internal/discover/watcher_proc.go
+++ b/pkg/internal/discover/watcher_proc.go
@@ -267,18 +267,15 @@ func (pa *pollAccounter) checkNewProcessConnectionNotification(
 	if !existingConnection || !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
 		if _, ok := reportedProcs[pp.Pid]; !ok {
+			// avoid notifying multiple times the same process if it has multiple connections
+			reportedProcs[proc.pid] = struct{}{}
 			exec, ok := pa.executableReady(pp.Pid)
 			if ok {
-				// avoid notifying multiple times the same process if it has multiple connections
-				reportedProcs[proc.pid] = struct{}{}
 				wplog().Debug("Executable ready", "path", exec, "pid", pp.Pid, "port", port)
 				return true
 			}
-			if _, ok := notReadyProcs[pp.Pid]; !ok {
-				// avoid notifying multiple times the same process if it has multiple connections
-				notReadyProcs[pp.Pid] = struct{}{}
-				wplog().Debug("Executable not ready", "path", exec, "pid", pp.Pid, "port", port)
-			}
+			notReadyProcs[pp.Pid] = struct{}{}
+			wplog().Debug("Executable not ready", "path", exec, "pid", pp.Pid, "port", port)
 		}
 	}
 	return false
@@ -291,17 +288,15 @@ func (pa *pollAccounter) checkNewProcessNotification(pid PID, reportedProcs, not
 	if _, existingProcess := pa.pids[pid]; !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
 		if _, ok := reportedProcs[pid]; !ok {
+			// avoid notifying multiple times the same process if it has multiple connections
+			reportedProcs[pid] = struct{}{}
 			exec, ok := pa.executableReady(pid)
 			if ok {
-				// avoid notifying multiple times the same process if it has multiple connections
-				reportedProcs[pid] = struct{}{}
 				wplog().Debug("Executable ready", "path", exec, "pid", pid)
 				return true
 			}
-			if _, ok := notReadyProcs[pid]; !ok {
-				notReadyProcs[pid] = struct{}{}
-				wplog().Debug("Executable not ready", "path", exec, "pid", pid)
-			}
+			notReadyProcs[pid] = struct{}{}
+			wplog().Debug("Executable not ready", "path", exec, "pid", pid)
 		}
 	}
 	return false

--- a/pkg/internal/discover/watcher_proc.go
+++ b/pkg/internal/discover/watcher_proc.go
@@ -267,15 +267,18 @@ func (pa *pollAccounter) checkNewProcessConnectionNotification(
 	if !existingConnection || !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
 		if _, ok := reportedProcs[pp.Pid]; !ok {
-			// avoid notifying multiple times the same process if it has multiple connections
-			reportedProcs[proc.pid] = struct{}{}
 			exec, ok := pa.executableReady(pp.Pid)
 			if ok {
+				// avoid notifying multiple times the same process if it has multiple connections
+				reportedProcs[proc.pid] = struct{}{}
 				wplog().Debug("Executable ready", "path", exec, "pid", pp.Pid, "port", port)
 				return true
 			}
-			notReadyProcs[pp.Pid] = struct{}{}
-			wplog().Debug("Executable not ready", "path", exec, "pid", pp.Pid, "port", port)
+			if _, ok := notReadyProcs[pp.Pid]; !ok {
+				// avoid notifying multiple times the same process if it has multiple connections
+				notReadyProcs[pp.Pid] = struct{}{}
+				wplog().Debug("Executable not ready", "path", exec, "pid", pp.Pid, "port", port)
+			}
 		}
 	}
 	return false
@@ -288,15 +291,17 @@ func (pa *pollAccounter) checkNewProcessNotification(pid PID, reportedProcs, not
 	if _, existingProcess := pa.pids[pid]; !existingProcess {
 		// ...also if we haven't already reported the process in the last "snapshot" invocation
 		if _, ok := reportedProcs[pid]; !ok {
-			// avoid notifying multiple times the same process if it has multiple connections
-			reportedProcs[pid] = struct{}{}
 			exec, ok := pa.executableReady(pid)
 			if ok {
+				// avoid notifying multiple times the same process if it has multiple connections
+				reportedProcs[pid] = struct{}{}
 				wplog().Debug("Executable ready", "path", exec, "pid", pid)
 				return true
 			}
-			notReadyProcs[pid] = struct{}{}
-			wplog().Debug("Executable not ready", "path", exec, "pid", pid)
+			if _, ok := notReadyProcs[pid]; !ok {
+				notReadyProcs[pid] = struct{}{}
+				wplog().Debug("Executable not ready", "path", exec, "pid", pid)
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Tries to provide more insights in the flaky K8s test.

The httpinger process is discovered by the process watcher, decorated by the kube watcher enricher, and then passed to the criteria matcher:

```
2025-02-13T01:10:08.275122516Z stdout F time=2025-02-13T01:10:08.274Z level=DEBUG msg="Executable ready" component=discover.ProcessWatcher path=/httppinger pid=2586
2025-02-13T01:10:08.275142573Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="new process watching events" component=discover.ProcessWatcher interval=500ms events="[{Type:0 Obj:{pid:2586 openPorts:[] metadata:map[] podLabels:map[]}} {Type:1 Obj:{pid:2576 openPorts:[] metadata:map[] podLabels:map[]}} {Type:1 Obj:{pid:2592 openPorts:[] metadata:map[] podLabels:map[]}} {Type:1 Obj:{pid:2593 openPorts:[] metadata:map[] podLabels:map[]}}]"
2025-02-13T01:10:08.275150308Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="new process" component=discover.watcherKubeEnricher pid=2586
```
The criteria matcher receives it, it theoretically has all the K8s metadata of the pod (seen in other logs), but the criteria don't match:
```
2025-02-13T01:10:08.275292092Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="filtering processes" component=discover.CriteriaMatcher len=4
2025-02-13T01:10:08.275542091Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="deleted untracked process. Ignoring" component=discover.CriteriaMatcher pid=2576
2025-02-13T01:10:08.275547481Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="deleted untracked process. Ignoring" component=discover.CriteriaMatcher pid=2592
2025-02-13T01:10:08.275549795Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="deleted untracked process. Ignoring" component=discover.CriteriaMatcher pid=2593
2025-02-13T01:10:08.275551719Z stdout F time=2025-02-13T01:10:08.275Z level=DEBUG msg="processes matching selection criteria" component=discover.CriteriaMatcher len=0
```

Adding more logs to see why.