### PR TITLE
Detect if running on host network before enabling context propagation

### DIFF
--- a/pkg/internal/ebpf/common/common_darwin.go
+++ b/pkg/internal/ebpf/common/common_darwin.go
@@ -7,3 +7,11 @@ func KernelVersion() (major, minor int) {
 func hasCapSysAdmin() bool {
 	return false
 }
+
+func HasHostPidAccess() bool {
+	return false
+}
+
+func HasHostNetworkAccess() (bool, error) {
+	return false, nil
+}

--- a/pkg/internal/ebpf/common/common_linux.go
+++ b/pkg/internal/ebpf/common/common_linux.go
@@ -1,6 +1,8 @@
 package ebpfcommon
 
 import (
+	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/cilium/ebpf/link"
@@ -57,4 +59,45 @@ func KernelVersion() (major, minor int) {
 func hasCapSysAdmin() bool {
 	caps, err := helpers.GetCurrentProcCapabilities()
 	return err == nil && caps.Has(unix.CAP_SYS_ADMIN)
+}
+
+func findNetworkNamespace(pid int32) (string, error) {
+	netPath := fmt.Sprintf("/proc/%d/ns/net", pid)
+	f, err := os.Open(netPath)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to open(/proc/%d/ns/net): %w", pid, err)
+	}
+
+	defer f.Close()
+
+	// read the value of the symbolic link
+	buf := make([]byte, syscall.PathMax)
+	n, err := syscall.Readlink(netPath, buf)
+	if err != nil {
+		return "", fmt.Errorf("failed to read symlink(/proc/%d/ns/net): %w", pid, err)
+	}
+
+	return string(buf[:n]), nil
+}
+
+func HasHostPidAccess() bool {
+	return os.Getpid() != 1
+}
+
+func HasHostNetworkAccess() (bool, error) {
+	// Get the network namespace of the current process
+	containerNS, err := findNetworkNamespace(int32(os.Getpid()))
+	if err != nil {
+		return false, err
+	}
+
+	// Get the network namespace of the host process (PID 1)
+	hostNS, err := findNetworkNamespace(1)
+	if err != nil {
+		return false, err
+	}
+
+	// Compare the network namespaces
+	return containerNS == hostNS, nil
 }

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -53,7 +53,7 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 
 	hostNet, err := ebpfcommon.HasHostNetworkAccess()
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for host network access while enabling L4/L7 context-propagation, error:%v", err)
+		return nil, fmt.Errorf("failed to check for host network access while enabling L4/L7 context-propagation, error: %w", err)
 	}
 
 	if !hostNet {


### PR DESCRIPTION
If Beyla is not properly configured on Kubernetes to have host network access, but the user enables context propagation, then the socket filter may attach and space the requests, while there will be no traffic control to write the header information.

With this PR we check if host network is available before we allow the context propagation eBPF programs to load.