### PR TITLE
Add Support for Additional Volume Mounts and Volumes in Helm DaemonSet Template

### DIFF
--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -107,6 +107,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/beyla/config
               name: beyla-config
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.global.image.pullSecrets }}
@@ -131,3 +134,6 @@ spec:
         - name: beyla-config
           configMap:
             name: {{ default (include "beyla.fullname" .) .Values.config.name }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -146,7 +146,7 @@ volumes: []
 #     secretName: mysecret
 #     optional: false
 
-# -- Additional volumeMounts on the output Deployment definition.
+# -- Additional volumeMounts on the output daemonset definition.
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"


### PR DESCRIPTION
This pull request introduces enhancements to the Helm DaemonSet template by adding support for additional volume mounts and volumes.

These changes allow users to specify custom volume mounts and volumes through the `values.yaml` file.

This pull request addresses issue #1657

### Testing

- Verified that the DaemonSet template correctly renders additional volume mounts and volumes when specified in the `values.yaml` file.
- Ensured that the default behavior remains unchanged when no additional volume mounts or volumes are specified.

I've not automated said tests.