### PR TITLE
Run protocol detector always on sock msg

### DIFF
--- a/bpf/tc_sock.h
+++ b/bpf/tc_sock.h
@@ -260,11 +260,10 @@ int beyla_packet_extender(struct sk_msg_md *msg) {
 
     // TODO: execute the protocol handlers here with tail calls, don't
     // rely on tcp_sendmsg to do it and record these message buffers.
-    if (!tracked) {
-        // If we didn't have metadata (sock_msg runs before the kprobe),
-        // we ensure to mark it for any packet we want to extend.
-        tracked = protocol_detector(msg, id, &conn);
-    }
+
+    // We must run the protocol detector always, the outgoing trace map
+    // might be setup for TCP traffic for L4 propagation.
+    tracked = protocol_detector(msg, id, &conn);
 
     u64 len = (u64)msg->data_end - (u64)msg->data;
     if (tracked && len > MIN_HTTP_SIZE) {

--- a/pkg/internal/ebpf/tctracer/bpf_arm64_bpfel.o
+++ b/pkg/internal/ebpf/tctracer/bpf_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:336f3eb4a47dbecaad894d7bf4851e5521b29fb6da7fb12398a88b75923e647f
-size 231512
+oid sha256:755d6326eda0aa43fe6c02037a6e46dfed2a8490a18a367f2d51c2111cde540a
+size 231304

--- a/pkg/internal/ebpf/tctracer/bpf_debug_arm64_bpfel.o
+++ b/pkg/internal/ebpf/tctracer/bpf_debug_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66f91197bb9730c5f7196d2042d105598829ef396f221c6b3ef76b5d320fcd77
-size 421280
+oid sha256:50583ce5bb1b985bfd0bf59a09b5b8f704d9157eb70076c9d292ce3dbec4f95e
+size 421232

--- a/pkg/internal/ebpf/tctracer/bpf_debug_x86_bpfel.o
+++ b/pkg/internal/ebpf/tctracer/bpf_debug_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47b478d0a6e2bf815a850140470c22742911db9c99cda1e18a2ae1d0ea486e89
-size 422592
+oid sha256:1dc32925e7c65e55dcc4fd65b9384a15537845c80f1d30d4c7858f4806a3cbf8
+size 422544

--- a/pkg/internal/ebpf/tctracer/bpf_x86_bpfel.o
+++ b/pkg/internal/ebpf/tctracer/bpf_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:220e4362b1203f5ab131bb7a40d9128ef930f49c57ab9489c48459b2927ad51e
-size 232824
+oid sha256:6d8fe404989b35bbda71b68ce2a3a42219d60a89483baf32dfa0c88342a0a5dc
+size 232616


### PR DESCRIPTION
There are many edge cases when a connection might be added in outgoing trace map and the sock message might extend the packet, when connections are reused. With this PR we do the safe thing, regardless if we are tracking the outgoing trace map, we confirm that the protocol is indeed HTTP always.