### PR TITLE
Fix memory leak with pids filter

### DIFF
--- a/pkg/internal/ebpf/common/pids.go
+++ b/pkg/internal/ebpf/common/pids.go
@@ -28,8 +28,9 @@ var activePids, _ = lru.New[uint32, *svc.Attrs](1024)
 var readNamespacePIDs = exec.FindNamespacedPids
 
 type PIDInfo struct {
-	service *svc.Attrs
-	pidType PIDType
+	service        *svc.Attrs
+	pidType        PIDType
+	otherKnownPids []uint32
 }
 
 type ServiceFilter interface {
@@ -185,7 +186,7 @@ func (pf *PIDsFilter) addPID(pid, nsid uint32, s *svc.Attrs, t PIDType) {
 	}
 
 	for _, p := range allPids {
-		ns[p] = PIDInfo{service: s, pidType: t}
+		ns[p] = PIDInfo{service: s, pidType: t, otherKnownPids: allPids}
 	}
 }
 
@@ -193,6 +194,12 @@ func (pf *PIDsFilter) removePID(pid, nsid uint32) {
 	ns, nsExists := pf.current[nsid]
 	if !nsExists {
 		return
+	}
+
+	if pidInfo, pidExists := ns[pid]; pidExists {
+		for _, otherPid := range pidInfo.otherKnownPids {
+			delete(ns, otherPid)
+		}
 	}
 
 	delete(ns, pid)

--- a/pkg/internal/ebpf/common/pids_test.go
+++ b/pkg/internal/ebpf/common/pids_test.go
@@ -137,6 +137,62 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	assert.True(t, s.ExportsOTelTraces())
 }
 
+func TestFilter_Cleanup(t *testing.T) {
+	readNamespacePIDs = func(pid int32) ([]uint32, error) {
+		switch pid {
+		case 123:
+			return []uint32{uint32(pid), uint32(1)}, nil
+		case 456:
+			return []uint32{uint32(pid), uint32(2)}, nil
+		case 789:
+			return []uint32{uint32(pid), uint32(3)}, nil
+		}
+		assert.Fail(t, "fix your test, unknown pid")
+		return nil, nil
+	}
+	pf := newPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"))
+	pf.AllowPID(123, 33, &svc.Attrs{}, PIDTypeGo)
+	pf.AllowPID(456, 33, &svc.Attrs{}, PIDTypeGo)
+	pf.AllowPID(789, 33, &svc.Attrs{}, PIDTypeGo)
+
+	// with the same namespace, it filters by user PID, as it is the PID
+	// that is seen by Beyla's process discovery
+	assert.Equal(t, []request.Span{
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
+	}, resetTraceContext(pf.Filter(spanSet)))
+
+	// We should be able to filter on the other namespaced pids: 1, 2 and 3
+	var anotherSpanSet = []request.Span{
+		{Pid: request.PidInfo{UserPID: 33, HostPID: 123, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 1, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 66, HostPID: 456, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 2, HostPID: 666, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 3, HostPID: 234, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
+	}
+
+	assert.Equal(t, []request.Span{
+		{Pid: request.PidInfo{UserPID: 1, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 2, HostPID: 666, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 3, HostPID: 234, Namespace: 33}},
+	}, resetTraceContext(pf.Filter(anotherSpanSet)))
+
+	// We clean-up the first namespaced pids: 123, 456, 789. This should
+	// also clean up: 1, 2, 3.
+	pf.BlockPID(123, 33)
+	pf.BlockPID(456, 33)
+	pf.BlockPID(789, 33)
+
+	assert.False(t, pf.ValidPID(1, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(2, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(3, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(333, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(666, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(234, 33, PIDTypeGo))
+}
+
 func resetTraceContext(spans []request.Span) []request.Span {
 	for i := range spans {
 		spans[i].TraceID = trace.TraceID{0}

--- a/pkg/internal/exec/procenv.go
+++ b/pkg/internal/exec/procenv.go
@@ -38,5 +38,7 @@ func EnvVars(pid int32) (map[string]string, error) {
 		return nil, err
 	}
 
-	return envStrsToMap(varsStr), nil
+	m := envStrsToMap(varsStr)
+
+	return m, nil
 }


### PR DESCRIPTION
When we add processes in our PID filter we discover all possible PIDs for a given process, which will be more than one in containerized environments. However, when clean up the pid map, we only remove the PID mentioned in the removal, not the other versions. This can cause serious leaks when we track processes that are constantly dying.