### PR TITLE
fix: update BUILDINFO_PKG to v2 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROTOC_IMAGE = docker.io/mariomac/protoc-go:latest
 # RELEASE_VERSION will contain the tag name, or the branch name if current commit is not a tag
 RELEASE_VERSION := $(shell git describe --all | cut -d/ -f2)
 RELEASE_REVISION := $(shell git rev-parse --short HEAD )
-BUILDINFO_PKG ?= github.com/grafana/beyla/pkg/buildinfo
+BUILDINFO_PKG ?= github.com/grafana/beyla/v2/pkg/buildinfo
 TEST_OUTPUT ?= ./testoutput
 
 IMG_REGISTRY ?= docker.io


### PR DESCRIPTION
since the `github.com/grafana/beyla/pkg/buildinfo` was changed to `github.com/grafana/beyla/v2/pkg/buildinfo` in this commit(https://github.com/grafana/beyla/commit/3c4e6784379b901a8a128a2736549393385fa288), but the Makefile still uses old name, this will cause the `Version` and `Revision` to not be properly set. 

Below are the logs from the grafana/beyla:2.0.5:

```
time=*** level=INFO msg="Grafana Beyla" Version=unset Revision=unset "OpenTelemetry SDK Version"=1.32.0
******
```