### PR TITLE
Fix OTEL HTTP exclusion detection

### DIFF
--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -488,9 +488,9 @@ func (s *Span) isHTTPOrGRPCClient() bool {
 func (s *Span) isMetricsExportURL() bool {
 	switch s.Type {
 	case EventTypeGRPCClient:
-		return strings.HasPrefix(s.Path, grpcMetricsDetectPattern)
+		return strings.HasSuffix(s.Path, grpcMetricsDetectPattern)
 	case EventTypeHTTPClient:
-		return strings.HasPrefix(s.Path, metricsDetectPattern)
+		return strings.HasSuffix(s.Path, metricsDetectPattern)
 	default:
 		return false
 	}

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -488,7 +488,7 @@ func (s *Span) isHTTPOrGRPCClient() bool {
 func (s *Span) isMetricsExportURL() bool {
 	switch s.Type {
 	case EventTypeGRPCClient:
-		return strings.HasSuffix(s.Path, grpcMetricsDetectPattern)
+		return strings.HasPrefix(s.Path, grpcMetricsDetectPattern)
 	case EventTypeHTTPClient:
 		return strings.HasSuffix(s.Path, metricsDetectPattern)
 	default:
@@ -501,7 +501,7 @@ func (s *Span) isTracesExportURL() bool {
 	case EventTypeGRPCClient:
 		return strings.HasPrefix(s.Path, grpcTracesDetectPattern)
 	case EventTypeHTTPClient:
-		return strings.HasPrefix(s.Path, tracesDetectPattern)
+		return strings.HasSuffix(s.Path, tracesDetectPattern)
 	default:
 		return false
 	}

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -264,8 +264,13 @@ func TestDetectsOTelExport(t *testing.T) {
 			exports: false,
 		},
 		{
-			name:    "Successfull HTTP /v1/metrics spans export",
+			name:    "Successful HTTP /v1/metrics spans export",
 			span:    Span{Type: EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200},
+			exports: true,
+		},
+		{
+			name:    "Successful HTTP /prefix/v1/metrics spans export",
+			span:    Span{Type: EventTypeHTTPClient, Method: "GET", Path: "/prefix/v1/metrics", RequestStart: 100, End: 200, Status: 200},
 			exports: true,
 		},
 		{


### PR DESCRIPTION
If the OTEL endpoint has a path prefix (e.g. `/otlp` as in Grafana Cloud), the OTEL Exclusion detection mechanism won't work.