### PR TITLE
Traces host info metric

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -253,7 +253,10 @@ func ReportMetrics(
 		if mr.cfg.SpanMetricsEnabled() || mr.cfg.ServiceGraphMetricsEnabled() {
 			hostMetrics := mr.newMetricsInstance(nil)
 			hostMeter := hostMetrics.provider.Meter(reporterName)
-			mr.setupHostInfoMeter(hostMeter)
+			err := mr.setupHostInfoMeter(hostMeter)
+			if err != nil {
+				return nil, fmt.Errorf("setting up host metrics: %w", err)
+			}
 		}
 
 		return mr.reportMetrics, nil

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -548,10 +548,6 @@ func (mr *MetricsReporter) setupSpanMeters(m *Metrics, meter instrument.Meter) e
 }
 
 func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
-	if !mr.cfg.SpanMetricsEnabled() || !mr.cfg.ServiceGraphMetricsEnabled() {
-		return nil
-	}
-
 	tracesHostInfo, err := meter.Int64Gauge(TracesHostInfo)
 	if err != nil {
 		return fmt.Errorf("creating span metric traces host info: %w", err)

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -549,12 +549,12 @@ func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
 		return nil
 	}
 
-	tracesHostInfo, err := meter.Int64UpDownCounter(TracesHostInfo)
+	tracesHostInfo, err := meter.Int64Gauge(TracesHostInfo)
 	if err != nil {
 		return fmt.Errorf("creating span metric traces host info: %w", err)
 	}
 	attrOpt := instrument.WithAttributeSet(mr.metricHostAttributes())
-	tracesHostInfo.Add(mr.ctx, 1, attrOpt)
+	tracesHostInfo.Record(mr.ctx, 1, attrOpt)
 
 	return nil
 }

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -35,6 +35,7 @@ const (
 	SpanMetricsCalls   = "traces_spanmetrics_calls_total"
 	SpanMetricsSizes   = "traces_spanmetrics_size_total"
 	TracesTargetInfo   = "traces_target_info"
+	TracesHostInfo     = "traces_host_info"
 	TargetInfo         = "target_info"
 
 	ServiceGraphClient = "traces_service_graph_request_client_seconds"
@@ -45,8 +46,9 @@ const (
 	serviceKey          = "service"
 	serviceNamespaceKey = "service_namespace"
 
-	hostIDKey   = "host_id"
-	hostNameKey = "host_name"
+	hostIDKey        = "host_id"
+	hostNameKey      = "host_name"
+	grafanaHostIDKey = "grafana_host_id"
 
 	k8sNamespaceName   = "k8s_namespace_name"
 	k8sPodName         = "k8s_pod_name"
@@ -91,6 +93,7 @@ const (
 
 // not adding version, as it is a fixed value
 var beylaInfoLabelNames = []string{LanguageLabel}
+var hostInfoLabelNames = []string{grafanaHostIDKey}
 
 // TODO: TLS
 type PrometheusConfig struct {
@@ -188,6 +191,7 @@ type metricsReporter struct {
 	spanMetricsCallsTotal *Expirer[prometheus.Counter]
 	spanMetricsSizeTotal  *Expirer[prometheus.Counter]
 	tracesTargetInfo      *Expirer[prometheus.Gauge]
+	tracesHostInfo        *Expirer[prometheus.Gauge]
 
 	// trace service graph
 	serviceGraphClient *Expirer[prometheus.Histogram]
@@ -453,6 +457,12 @@ func newReporter(
 				Help: "target service information in trace span metric format",
 			}, labelNamesTargetInfo(kubeEnabled)).MetricVec, clock.Time, cfg.TTL)
 		}),
+		tracesHostInfo: optionalGaugeProvider(cfg.SpanMetricsEnabled() || cfg.ServiceGraphMetricsEnabled(), func() *Expirer[prometheus.Gauge] {
+			return NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Name: TracesHostInfo,
+				Help: "A metric with a constant '1' value labeled by the host id ",
+			}, hostInfoLabelNames).MetricVec, clock.Time, cfg.TTL)
+		}),
 		serviceGraphClient: optionalHistogramProvider(cfg.ServiceGraphMetricsEnabled(), func() *Expirer[prometheus.Histogram] {
 			return NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name:                            ServiceGraphClient,
@@ -565,6 +575,10 @@ func newReporter(
 		)
 	}
 
+	if cfg.SpanMetricsEnabled() || cfg.ServiceGraphMetricsEnabled() {
+		registeredMetrics = append(registeredMetrics, mr.tracesHostInfo)
+	}
+
 	if is.GPUEnabled() {
 		registeredMetrics = append(registeredMetrics,
 			mr.gpuKernelCallsTotal,
@@ -636,6 +650,7 @@ func (r *metricsReporter) observe(span *request.Span) {
 	}
 	t := span.Timings()
 	r.beylaInfo.WithLabelValues(span.Service.SDKLanguage.String()).metric.Set(1.0)
+	r.tracesHostInfo.WithLabelValues(r.hostID).metric.Set(1.0)
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
 	targetInfoLabelValues := r.labelValuesTargetInfo(span.Service)

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -650,7 +650,9 @@ func (r *metricsReporter) observe(span *request.Span) {
 	}
 	t := span.Timings()
 	r.beylaInfo.WithLabelValues(span.Service.SDKLanguage.String()).metric.Set(1.0)
-	r.tracesHostInfo.WithLabelValues(r.hostID).metric.Set(1.0)
+	if r.cfg.SpanMetricsEnabled() || r.cfg.ServiceGraphMetricsEnabled() {
+		r.tracesHostInfo.WithLabelValues(r.hostID).metric.Set(1.0)
+	}
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
 	targetInfoLabelValues := r.labelValuesTargetInfo(span.Service)

--- a/test/integration/docker-compose-client.yml
+++ b/test/integration/docker-compose-client.yml
@@ -38,6 +38,7 @@ services:
       BEYLA_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
       BEYLA_PROCESSES_INTERVAL: "100ms"
       BEYLA_HOSTNAME: "beyla"
+      BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph"
       BEYLA_OTEL_METRIC_FEATURES: "application,application_process"
     ports:
       - "8999:8999" # Prometheus scrape port, if enabled via config

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -754,6 +754,17 @@ func testPrometheusBeylaBuildInfo(t *testing.T) {
 	})
 }
 
+func testHostInfo(t *testing.T) {
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`traces_host_info{}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+	})
+}
+
 func testPrometheusBPFMetrics(t *testing.T) {
 	t.Skip("BPF metrics are not available in the test environment")
 	pq := prom.Client{HostPort: prometheusHostPort}

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -33,6 +33,7 @@ func TestSuite(t *testing.T) {
 	t.Run("GRPC TLS RED metrics", testREDMetricsGRPCTLS)
 	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
 	t.Run("Exemplars exist", testExemplarsExist)
+	t.Run("Testing Host Info metric", testHostInfo)
 
 	require.NoError(t, compose.Close())
 }
@@ -80,6 +81,7 @@ func TestSuiteClientPromScrape(t *testing.T) {
 	require.NoError(t, compose.Up())
 	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibraryNoTraces)
 	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
+	t.Run("Testing Host Info metric", testHostInfo)
 	t.Run("Testing process-level metrics", testProcesses(map[string]string{
 		"process_executable_name": "pingclient",
 		"process_executable_path": "/pingclient",

--- a/vendor/go.opentelemetry.io/otel/semconv/v1.19.0/resource.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.19.0/resource.go
@@ -919,6 +919,10 @@ const (
 	// Examples: 'fdbf79e8af94cb7f9e8df36789187052'
 	HostIDKey = attribute.Key("host.id")
 
+	// GrafanaHostIDKey is the same attribute Key as HostIDKey, but used for
+	// traces_target_info
+	GrafanaHostIDKey = attribute.Key("grafana.host.id")
+
 	// HostNameKey is the attribute Key conforming to the "host.name" semantic
 	// conventions. It represents the name of the host. On Unix systems, it may
 	// contain what the hostname command returns, or the fully qualified
@@ -1007,6 +1011,11 @@ var (
 // to determine the `machine-id` based on operating system.
 func HostID(val string) attribute.KeyValue {
 	return HostIDKey.String(val)
+}
+
+// GrafanaHostID is the same as the host_id key, just prefixed with grafana_
+func GrafanaHostID(val string) attribute.KeyValue {
+	return GrafanaHostIDKey.String(val)
 }
 
 // HostName returns an attribute KeyValue conforming to the "host.name"


### PR DESCRIPTION
Adds the traces host info metric export in Beyla for OTEL and Prometheus export to support host based pricing, for vendors that charge with that model.