### PR TITLE
Fix marshaling bug

### DIFF
--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -516,7 +516,7 @@ func (p *Tracer) watchForMisclassifedEvents() {
 			if p.bpfObjects.OngoingHttp2Connections != nil {
 				err := p.bpfObjects.OngoingHttp2Connections.Put(
 					&bpfPidConnectionInfoT{Conn: bpfConnectionInfoT(e.TCPInfo.ConnInfo), Pid: e.TCPInfo.Pid.HostPid},
-					uint8(e.TCPInfo.Ssl), // no new connection flag (0x3)
+					bpfHttp2ConnInfoDataT{Flags: e.TCPInfo.Ssl, Id: 0}, // no new connection flag (0x3)
 				)
 				if err != nil {
 					p.log.Debug("error writing HTTP2/gRPC connection info", "error", err)


### PR DESCRIPTION
I recently changed the data for the HTTP2 connections, but I accidentally broke the restoring of HTTP2 connections which are not detected initially.