### PR TITLE
Set Resource to internal trace instrumentation

### DIFF
--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -96,7 +96,7 @@ func getResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
 
 func newResourceInternal(hostID string) *resource.Resource {
 	attrs := []attribute.KeyValue{
-		semconv.ServiceName("beyla-internal"),
+		semconv.ServiceName("beyla"),
 		semconv.ServiceInstanceID(uuid.New().String()),
 		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
 		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs

--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"google.golang.org/grpc/credentials"
 
@@ -90,6 +92,19 @@ func getResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
 		attrs = append(attrs, k.OTEL().String(v))
 	}
 	return attrs
+}
+
+func newResourceInternal(hostID string) *resource.Resource {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName("beyla-internal"),
+		semconv.ServiceInstanceID(uuid.New().String()),
+		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
+		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
+		semconv.TelemetrySDKNameKey.String("beyla"),
+		semconv.HostID(hostID),
+	}
+
+	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 }
 
 // ReporterPool keeps an LRU cache of different OTEL reporters given a service name.

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -6,12 +6,10 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	instrument "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"github.com/grafana/beyla/v2/pkg/buildinfo"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
@@ -117,19 +115,6 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		instrumentedProcesses: instrumentedProcesses,
 		beylaInfo:             beylaInfo,
 	}, nil
-}
-
-func newResourceInternal(hostID string) *resource.Resource {
-	attrs := []attribute.KeyValue{
-		semconv.ServiceName("beyla-internal"),
-		semconv.ServiceInstanceID(uuid.New().String()),
-		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
-		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
-		semconv.TelemetrySDKNameKey.String("beyla"),
-		semconv.HostID(hostID),
-	}
-
-	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 }
 
 func newInternalMeterProvider(res *resource.Resource, exporter *metric.Exporter, interval time.Duration) (*metric.MeterProvider, error) {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -389,7 +389,6 @@ func getTraceSettings(ctxInfo *global.ContextInfo, in trace.SpanExporter) export
 	if internalMetricsEnabled(ctxInfo) {
 		telemetryLevel = configtelemetry.LevelBasic
 		spanExporter := instrumentTraceExporter(in, ctxInfo.Metrics)
-		// Reuse newResourceInternal to create the resource with consistent attributes
 		res := newResourceInternal(ctxInfo.HostID)
 		traceProvider = trace.NewTracerProvider(
 			trace.WithBatcher(spanExporter),

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -389,7 +389,12 @@ func getTraceSettings(ctxInfo *global.ContextInfo, in trace.SpanExporter) export
 	if internalMetricsEnabled(ctxInfo) {
 		telemetryLevel = configtelemetry.LevelBasic
 		spanExporter := instrumentTraceExporter(in, ctxInfo.Metrics)
-		traceProvider = trace.NewTracerProvider(trace.WithBatcher(spanExporter))
+		// Reuse newResourceInternal to create the resource with consistent attributes
+		res := newResourceInternal(ctxInfo.HostID)
+		traceProvider = trace.NewTracerProvider(
+			trace.WithBatcher(spanExporter),
+			trace.WithResource(res),
+		)
 	}
 	meterProvider := metric.NewMeterProvider()
 	telemetrySettings := component.TelemetrySettings{


### PR DESCRIPTION
Use `newResourceInternal` when new trace provider is set when setting internal
instrumentation for Tracing. Previously nothing was set to we would see "unknown_service:beya"
in some traces.

Fixes #1467 

This is how looks now:

![image](https://github.com/user-attachments/assets/95e75023-6c63-45a1-abd9-1f7f82d5394b)

cc @gouthamve 