### PR TITLE
Fix example deployment

### DIFF
--- a/deployments/03-instrumented-app.yml
+++ b/deployments/03-instrumented-app.yml
@@ -46,9 +46,6 @@ spec:
           image: mariomac/goblog:dev
           imagePullPolicy: IfNotPresent
           command: [ "/goblog" ]
-          env:
-            - name: "GOBLOG_CONFIG"
-              value: "/sample/config.yml"
           ports:
             - containerPort: 8443
               name: https

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -167,9 +167,6 @@ spec:
           image: mariomac/goblog:dev
           imagePullPolicy: IfNotPresent
           command: ["/goblog"]
-          env:
-            - name: "GOBLOG_CONFIG"
-              value: "/sample/config.yml"
           ports:
             - containerPort: 8443
               name: https


### PR DESCRIPTION
The goblog image was updated with some fixes, but it added a breaking change that caused the K8s deployment example to crash.