### PR TITLE
Add support for generating non-bpf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,26 +181,18 @@ update-offsets: prereqs
 	@echo "### Updating pkg/internal/goexec/offsets.json"
 	$(GO_OFFSETS_TRACKER) -i configs/offsets/tracker_input.json pkg/internal/goexec/offsets.json
 
-# Prefer docker-generate instead, as it's able to perform a parallel build
 .PHONY: generate
-generate: bpf-generate javaagent-generate
-
-.PHONY: bpf-generate
-bpf-generate: export BPF_CLANG := $(CLANG)
-bpf-generate: export BPF_CFLAGS := $(CFLAGS)
-bpf-generate: export BPF2GO := $(BPF2GO)
-bpf-generate: bpf2go
-	@echo "### Generating BPF Go bindings"
-	grep -rlI "BPF2GO" pkg/internal/ | xargs -P 0 -n 1 go generate
-
-.PHONY: javaagent-generate
-javaagent-generate:
-	@go generate pkg/internal/otelsdk/sdk_inject.go
+generate: export BPF_CLANG := $(CLANG)
+generate: export BPF_CFLAGS := $(CFLAGS)
+generate: export BPF2GO := $(BPF2GO)
+generate: bpf2go
+	@echo "### Generating files..."
+	@BEYLA_GENFILES_RUN_LOCALLY=1 go generate cmd/beyla-genfiles/beyla_genfiles.go
 
 .PHONY: docker-generate
 docker-generate:
-	@echo "### Generating BPF Go bindings"
-	@go generate bpf/build_ebpf.go
+	@echo "### Generating files (docker)..."
+	@go generate cmd/beyla-genfiles/beyla_genfiles.go
 
 .PHONY: verify
 verify: prereqs lint-dashboard lint test

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -21,11 +21,9 @@ export BPF_CFLAGS="-O2 -g -Wall -Werror"
 
 export GENFILES=\$1
 
-go generate pkg/internal/otelsdk/sdk_inject.go
-
 if [ -z "\$GENFILES" ]; then
 	echo No genfiles specified - regenerating everything
-	grep -rlI "BPF2GO" pkg/internal/ | xargs -P 0 -n 1 go generate
+	grep -rlI "//go:generate" pkg/ | xargs -P 0 -n 1 go generate
 else
 	cat \$GENFILES | xargs -P 0 -n 1 go generate
 fi

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -18,15 +18,8 @@ RUN cat <<EOF > /generate.sh
 export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
-
-export GENFILES=\$1
-
-if [ -z "\$GENFILES" ]; then
-	echo No genfiles specified - regenerating everything
-	grep -rlI "//go:generate" pkg/ | xargs -P 0 -n 1 go generate
-else
-	cat \$GENFILES | xargs -P 0 -n 1 go generate
-fi
+export BEYLA_GENFILES_RUN_LOCALLY=1
+go run cmd/beyla-genfiles/beyla_genfiles.go
 EOF
 
 RUN chmod +x /generate.sh


### PR DESCRIPTION
This PR generalises the concept brought forth by `build_ebpf.go` into a tool that can be run standalone, and will generate every `//go:generate` tag for Beyla.

Projects that have a dependency on beyla (such as Alloy) can now simply run:
```
go run github.com/grafana/beyla/v2/cmd/beyla-genfiles
```

as part of their build process, simplifying their workflow.

Finally, it simplifies the generator image, which now simply relies on `beyla-genfiles` to do  the work (and build in parallel).

Usage in Alloy: https://github.com/grafana/alloy/pull/2734