### PR TITLE
Only download java agent when out of date

### DIFF
--- a/pkg/internal/otelsdk/sdk_inject.go
+++ b/pkg/internal/otelsdk/sdk_inject.go
@@ -1,6 +1,6 @@
 package otelsdk
 
-//go:generate curl -L https://github.com/grafana/grafana-opentelemetry-java/releases/download/v2.13.2.1/grafana-opentelemetry-java.jar -o grafana-opentelemetry-java.jar
+//go:generate curl -sSLOz grafana-opentelemetry-java.jar https://github.com/grafana/grafana-opentelemetry-java/releases/download/v2.13.2.1/grafana-opentelemetry-java.jar
 
 import (
 	"bufio"


### PR DESCRIPTION
Only download the agent jar file if it does not exist or is out of date. Also, mute the curl progress bar (but not errors)