### PR TITLE
Use Sets for traces_target_info metric

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -518,7 +518,7 @@ func newReporter(
 	if cfg.SpanMetricsEnabled() {
 		mr.serviceCache = expirable.NewLRU(cfg.SpanMetricsServiceCacheSize, func(_ svc.UID, v svc.Attrs) {
 			lv := mr.labelValuesTargetInfo(v)
-			mr.tracesTargetInfo.WithLabelValues(lv...).metric.Sub(1)
+			mr.tracesTargetInfo.WithLabelValues(lv...).metric.Set(0)
 		}, cfg.TTL)
 	}
 
@@ -735,7 +735,7 @@ func (r *metricsReporter) observe(span *request.Span) {
 		_, ok := r.serviceCache.Get(span.Service.UID)
 		if !ok {
 			r.serviceCache.Add(span.Service.UID, span.Service)
-			r.tracesTargetInfo.WithLabelValues(targetInfoLabelValues...).metric.Add(1)
+			r.tracesTargetInfo.WithLabelValues(targetInfoLabelValues...).metric.Set(1)
 		}
 	}
 


### PR DESCRIPTION
Previous implementation was using `Add` and `Sub` for `traces_target_info`.
This is risky because in some cases, it can lead to negative values.

Fixes #1707 