### PR TITLE
Print printable characters in cfg.ProtocolDebug

### DIFF
--- a/pkg/internal/ebpf/common/tcp_detect_transform.go
+++ b/pkg/internal/ebpf/common/tcp_detect_transform.go
@@ -37,8 +37,8 @@ func ReadTCPRequestIntoSpan(cfg *config.EBPFTracer, record *ringbuf.Record, filt
 	b := event.Buf[:l]
 
 	if cfg.ProtocolDebug {
-		fmt.Printf("[>] %v\n", b)
-		fmt.Printf("[<] %v\n", event.Rbuf[:rl])
+		fmt.Printf("[>] %q\n", b)
+		fmt.Printf("[<] %q\n", event.Rbuf[:rl])
 	}
 
 	// Check if we have a SQL statement


### PR DESCRIPTION
ProtoDebug=true shows messages in binary format, which are useful for binary buffers but not really for printable text.

Replacing `%v` by `%q` so it will show printable characters as text, and non-printable characters as escaped char codes.

Example: https://go.dev/play/p/GVXC3OIu5q9?v=