### PR TITLE
Allow defining extra resource labels in prometheus

### DIFF
--- a/docs/sources/configure/export-data.md
+++ b/docs/sources/configure/export-data.md
@@ -180,6 +180,23 @@ no Prometheus endpoint is open.
 
 Specifies the HTTP query path to fetch the list of Prometheus metrics.
 
+| YAML                        | Environment variable                         | Type            | Default |
+|-----------------------------|----------------------------------------------|-----------------|---------|
+| `extra_resource_attributes` | `BEYLA_PROMETHEUS_EXTRA_RESOURCE_ATTRIBUTES` | list of strings | (empty) |
+
+A list of additional resource attributes to be added to the reported `target_info` metric.
+
+Due to internal limitations of the Prometheus API client, Beyla needs to know beforehand which attributes are exposed
+for each metric. This would cause that some attributes that are discovered at runtime, during instrumentation, won't
+be visible by default. For example, attributes defined on each application via Kubernetes annotations, or in the
+target application's `OTEL_RESOURCE_ATTRIBUTES` environment variable.
+
+For example, an application defining the `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production` as environment
+variable, the `target_info{deployment.environment="production"}` attribute would be visible by default if the metrics
+are exported via OpenTelemetry but not if they are exported via Prometheus.
+
+To make `deployment_environment` visible in Prometheus, you need to add it to the `extra_resource_attributes` list.
+
 | YAML  | Environment variable   | Type     | Default |
 | ----- | ---------------------- | -------- | ------- |
 | `ttl` | `BEYLA_PROMETHEUS_TTL` | Duration | `5m`    |

--- a/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
+++ b/pkg/internal/ebpf/tcmanager/dummymanager_notlinux.go
@@ -21,6 +21,6 @@ func (d *dummyManager) AddProgram(_ string, _ *ebpf.Program, _ AttachmentType) {
 func (d *dummyManager) RemoveProgram(_ string)                                 {}
 func (d *dummyManager) InterfaceName(_ int) (string, bool)                     { return "", false }
 func (d *dummyManager) SetInterfaceManager(_ *InterfaceManager)                {}
-func (d *dummyManager) Errors() chan error                                     {}
+func (d *dummyManager) Errors() chan error                                     { return nil }
 
 func EnsureCiliumCompatibility(_ TCBackend) error { return nil }

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -7,6 +7,7 @@ prometheus_export:
   features:
     - application
     - application_process
+  extra_resource_attributes: ["deployment_environment"]
 attributes:
   select:
     process_cpu_utilization:

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -229,9 +229,9 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 				attributeMap(allAttributes, overrideAttrs))).
 		Assess("target_info metrics exist",
 			testMetricsDecoration([]string{"target_info"}, `{job=~".*testserver"}`, map[string]string{
-				"host_name": "testserver",
-				"host_id":   HostIDRegex,
-				"instance":  targetInfoInstance,
+				"host_name":              "testserver",
+				"host_id":                HostIDRegex,
+				"instance":               targetInfoInstance,
 				"deployment_environment": "integration-test",
 			}),
 		).Feature()

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -232,6 +232,7 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 				"host_name": "testserver",
 				"host_id":   HostIDRegex,
 				"instance":  targetInfoInstance,
+				"deployment_environment": "integration-test",
 			}),
 		).Feature()
 }


### PR DESCRIPTION
Enables BEYLA_PROMETHEUS_EXTRA_RESOURCE_ATTRIBUTES to provide a list of additional resource attributes to be added to the reported `target_info` metric, in Prometheus.

Due to internal limitations of the Prometheus API client, Beyla needs to know beforehand which attributes are exposed
for each metric. This would cause that some attributes that are discovered at runtime, during instrumentation, won't
be visible by default. For example, attributes defined on each application via Kubernetes annotations, or in the
target application's `OTEL_RESOURCE_ATTRIBUTES` environment variable.

For example, an application defining the `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production` as environment
variable, the `target_info{deployment.environment="production"}` attribute would be visible by default if the metrics
are exported via OpenTelemetry but not if they are exported via Prometheus.

To make `deployment_environment` visible in Prometheus, you need to add it to the `extra_resource_attributes` list.