### PR TITLE
Edit export modes

### DIFF
--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -1,7 +1,7 @@
 ---
 title: Configure Beyla export modes
 menuTitle: Export modes
-description: Configure Beyla to export data either directly to an OTLP endpoint or through Alloy.
+description: Configure Beyla to export data directly to an OTLP endpoint or through Alloy.
 weight: 1
 keywords:
   - Beyla
@@ -12,54 +12,44 @@ aliases:
 
 # Configure Beyla export modes
 
-Beyla can export data in two modes:
-
-- **Alloy mode** (recommended mode): the auto-instrumentation tool sends metrics and traces to the
-  [Grafana Alloy](/docs/alloy/), which processes and sends them
-  to Mimir and Tempo. In this scenario, Alloy takes care of the authentication required by the Grafana Mimir/Tempo endpoints.
-  This mode also integrates better with some Grafana exclusive features,
-  such as the [span-to-metrics](/docs/tempo/latest/metrics-generator/span_metrics/) and
-  [span-to-service graph](/docs/tempo/latest/metrics-generator/service_graphs/) converters.
-- **Direct mode**: the auto-instrumentation tool can **push** metrics and/or traces directly to a remote endpoint
-  (using the OpenTelemetry/OTEL protocols) or expose a Prometheus HTTP endpoint ready to be scraped (i.e. **pull** mode).
-  In the direct OTEL push mode, the auto-instrumentation tool needs to be configured with the authentication credentials.
+Beyla exports data in Alloy or Direct mode.
 
 ![Beyla architecture alloy vs direct](https://grafana.com/media/docs/grafana-cloud/beyla/alloy-vs-direct.png)
 
-*On the left, Beyla running in Alloy mode versus Direct mode on the right.*
+*Beyla running in Alloy mode on the left and Direct mode on the right.*
 
 ## Direct mode
 
-The OTLP endpoint authentication credentials are provided by using the following environment variables:
+In Direct mode Beyla pushes metrics and traces directly to a remote endpoint using the OpenTelemetry protocol (OTLP).
+
+Beyla can also expose a Prometheus HTTP endpoint ready to scrape, for example in **pull** mode.
+
+To use Direct mode requires configuration with authentication credentials. Set the OTLP endpoint authentication credentials with these environment variables:
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT`
 - `OTEL_EXPORTER_OTLP_HEADERS`
 
-To run in Direct mode by using the Prometheus scrape endpoint, please refer to the
+To run in Direct mode using the Prometheus scrape endpoint, see the
 [configuration documentation](../options/).
 
 ## Alloy mode
 
-> ℹ️ This tutorial assumes that both Alloy and the auto-instrumentation tool are installed
-> as local Linux OS executables. For further examples on downloading and running the
-> auto-instrumentation tool as an OCI container, you can check the documentation sections on
-> [running the Beyla as a Docker container](../../setup/docker/)
-> or [running Beyla in Kubernetes](../../setup/kubernetes/).
+In Alloy mode Beyla sends metrics and traces to [Grafana Alloy](/docs/alloy/). Alloy processes and sends them to Mimir and Tempo. Alloy manages the authentication required by the Mimir and Tempo endpoints.
 
-First, locally install and configure [Grafana Alloy, according to the latest documentation](/docs/alloy/).
-Alloy facilitates the ingestion of OpenTelemetry metrics and traces from the auto-instrumentation tool,
-and process and forward to the different Grafana product endpoints (Mimir and/or Tempo).
+This mode integrates with Grafana exclusive features like [span-to-metrics](/docs/tempo/latest/metrics-generator/span_metrics/) and [span-to-service graph](/docs/tempo/latest/metrics-generator/service_graphs/) converters.
+
+The following sections are examples of how to set up Alloy and Beyla to send to Grafana Cloud.
 
 ### Configure Alloy pipeline
 
-Configure the [Alloy](/docs/alloy/) pipeline and specify the following nodes:
+First, install and configure [Grafana Alloy](/docs/alloy/). Configure the [Alloy](/docs/alloy/) pipeline and specify the following nodes:
 
 ![Beyla nodes](https://grafana.com/media/docs/grafana-cloud/beyla/nodes-2.png)
 
-Download the [example River configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/alloy-config.river) used in this article.
+Download the example [River configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/alloy-config.river).
 
-Alloy needs to expose an **OpenTelemetry receiver** endpoint, such that the auto-instrumentation tool can forward both metrics and traces.
-The Alloy configuration file needs to include the following entry:
+Create an **OpenTelemetry receiver** endpoint for the auto-instrumentation tool to forward metrics and traces.
+Add this entry to the Alloy configuration file:
 
 ```alloy
 otelcol.receiver.otlp "default" {
@@ -73,9 +63,7 @@ otelcol.receiver.otlp "default" {
 }
 ```
 
-This enables reception of OpenTelemetry events via GRPC and HTTP, which will be
-forwarded to the next stage in the pipeline, the **Batch processor**, which
-will then accumulate the messages and forward them to the exporters:
+This enables Alloy to receive OpenTelemetry events via GRPC and HTTP. Alloy forwards the data to the batch processor. The batch processor accumulate the data and forwards it to exporters:
 
 ```alloy
 otelcol.processor.batch "default" {
@@ -86,14 +74,10 @@ otelcol.processor.batch "default" {
 }
 ```
 
-You can export either metrics, traces, or both. If you only want to export a single
-type of data, you can just avoid the `metrics` or `traces` lines in the previous
-node definitions, and ignore some of the following exporters.
+Export either metrics, traces, or both. To export a single data type, omit the `metrics` or `traces` lines in the node definitions and skip the related exporters.
 
-The metrics are **exported in Prometheus** format to [Grafana Mimir](/oss/mimir/).
-The configuration entry will need to specify an endpoint with basic
-authentication. In the provided example, the endpoint and the credentials are
-provided via environment variables:
+Alloy exports metrics in **Prometheus** format to [Grafana Mimir](/oss/mimir/).
+The configuration uses basic authentication. The Alloy config fetches config options set in environment variables:
 
 ```alloy
 otelcol.exporter.prometheus "default" {
@@ -111,7 +95,7 @@ prometheus.remote_write "mimir" {
 }
 ```
 
-Run Alloy with the following environment variables set:
+Set authentication environment variables and run Alloy:
 
 ```sh
 export MIMIR_USER=734432
@@ -119,9 +103,7 @@ export MIMIR_ENDPOINT=prometheus-prod-01-eu-west-0.grafana.net
 export GRAFANA_API_KEY=VHJhbGFyw60gcXVlIHRlIHbD....=
 ```
 
-Finally, to **export the traces**, you will need to set up a
-[Grafana Tempo](/oss/tempo/) exporter
-and an endpoint, also configured via environment variables:
+Finally, set up a [Grafana Tempo](/oss/tempo/) exporter and endpoint. The Alloy config fetches config options set in environment variables:
 
 ```alloy
 otelcol.exporter.otlp "tempo" {
@@ -137,41 +119,27 @@ otelcol.auth.basic "creds" {
 }
 ```
 
-Please note that the `TEMPO_ENDPOINT` and `TEMPO_USER` values are different
-from `MIMIR_ENDPOINT` and `MIMIR_USER`.
+Note that the `TEMPO_ENDPOINT` and `TEMPO_USER` values are different from `MIMIR_ENDPOINT` and `MIMIR_USER`.
 
-To run Alloy with the previous configuration (for example, written in a file named `alloy-config.river`):
+Run Alloy with a named configuration file:
 
-```
+```sh
 grafana-alloy run alloy-config.river
 ```
 
-### Configuring and running the auto-instrumentation tool
+### Configure and run Beyla
 
-Configure the auto-instrumentation tool to forward data to Grafana Alloy.
-This tutorial assumes Beyla and Alloy are running on the same host, so there is no need to secure the traffic nor provide authentication in the Alloy OTLP receiver.
+This tutorial assumes Beyla and Alloy are running natively on the same host, so there is no need to secure the traffic nor provide authentication in the Alloy OTLP receiver.
 
-You can configure the auto-instrumentation tool both via environment variables or via
-a configuration YAML file, which is what we will use in this example.
-Please refer to the complete [Configuration documentation](../options/) for
-more detailed description of each configuration option.
+Install [Grafana Beyla](../../setup/) and download the example [configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/instrumenter-config.yml).
 
-You can download the whole [example configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/instrumenter-config.yml),
-which we will explain in the rest of this section.
-
-First, you will need to specify the executable to instrument. If, for example,
-the service executable is a process that opens the port `443`, you can use the `open_port`
-property of the YAML document:
+First, specify the executable to instrument. For a service executable running on port `443`, add the `open_port` property to the YAML document:
 
 ```yaml
 open_port: 443
 ```
 
-The auto-instrumentation tool will automatically search and instrument the process
-listening on port 443.
-
-Next, specify where the traces and the metrics are submitted.
-If Alloy is running on the local host, it uses port `4318`:
+Next, specify where the traces and the metrics are sent. If Alloy is running on the local host, it uses port `4318`:
 
 ```yaml
 otel_metrics_export:
@@ -180,14 +148,9 @@ otel_traces_export:
   endpoint: http://localhost:4318
 ```
 
-You can specify both `otel_metrics_export` and `otel_traces_export` properties to
-allow exporting both metrics and traces, or only one of them to export either
-metrics or traces.
+You can specify a combination of `otel_metrics_export` and `otel_traces_export` properties to export metrics, traces, or both.
 
-To run the auto-instrumentation tool (previously downloaded from the [Beyla releases page](https://github.com/grafana/beyla/releases)),
-you will need to specify the path to the configuration YAML file, either with the
-`-config` command-line argument or the `BEYLA_CONFIG_PATH` environment variable.
-For example `instrument-config.yml`:
+Run Beyla with a named configuration file:
 
 ```
 beyla -config instrument-config.yml


### PR DESCRIPTION
Lighter edit and format of the content.

In a future change I think we should move the tutorial to another section and update it to use the recommended set up methods K8s or Docker.