### PR TITLE
Fix flaky OATS tests

### DIFF
--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         go: [ '1.23' ]

--- a/Makefile
+++ b/Makefile
@@ -341,22 +341,22 @@ oats-prereq: bin/ginkgo docker-generate
 .PHONY: oats-test-sql
 oats-test-sql: oats-prereq
 	mkdir -p test/oats/sql/$(TEST_OUTPUT)/run
-	cd test/oats/sql && TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd test/oats/sql && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
 
 .PHONY: oats-test-redis
 oats-test-redis: oats-prereq
 	mkdir -p test/oats/redis/$(TEST_OUTPUT)/run
-	cd test/oats/redis && TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd test/oats/redis && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
 
 .PHONY: oats-test-kafka
 oats-test-kafka: oats-prereq
 	mkdir -p test/oats/kafka/$(TEST_OUTPUT)/run
-	cd test/oats/kafka && TESTCASE_TIMEOUT=120s TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd test/oats/kafka && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
 
 .PHONY: oats-test-http
 oats-test-http: oats-prereq
 	mkdir -p test/oats/http/$(TEST_OUTPUT)/run
-	cd test/oats/http && TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd test/oats/http && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
 
 .PHONY: oats-test
 oats-test: oats-test-sql oats-test-redis oats-test-kafka oats-test-http


### PR DESCRIPTION
OATS tests are flaky and it seems that the reason is that GitHub machines are slow and the default 30s timeout causes test to fail (that would explain why I can't reproduce the test failures when running locally).

Increasing the size of the runner as well as the timeouts.