### PR TITLE
Fix fastcgi header parsing

### DIFF
--- a/bpf/http_types.h
+++ b/bpf/http_types.h
@@ -136,6 +136,7 @@ typedef struct tcp_req {
     unsigned char rbuf[K_TCP_RES_LEN]
         __attribute__((aligned(8))); // ringbuffer memcpy complains unless this is 8 byte aligned
     u32 len;
+    u32 req_len;
     u32 resp_len;
     u8 ssl;
     u8 direction;

--- a/bpf/protocol_tcp.h
+++ b/bpf/protocol_tcp.h
@@ -130,6 +130,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
             req->end_monotime_ns = 0;
             req->resp_len = 0;
             req->len = bytes_len;
+            req->req_len = req->len;
             req->extra_id = extra_runtime_id();
             task_pid(&req->pid);
             bpf_probe_read(req->buf, K_TCP_MAX_LEN, u_buf);
@@ -167,8 +168,9 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
         bpf_clamp_umax(off, (K_TCP_MAX_LEN / 2));
         bpf_probe_read(existing->buf + off, (K_TCP_MAX_LEN / 2), u_buf);
         existing->len += bytes_len;
+        existing->req_len = existing->len;
     } else {
-        existing->len += bytes_len;
+        existing->req_len += bytes_len;
     }
 }
 

--- a/pkg/internal/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/internal/ebpf/common/fast_cgi_detect_transform.go
@@ -196,7 +196,7 @@ func TCPToFastCGIToSpan(trace *TCPRequestInfo, op, uri string, status int) reque
 		PeerPort:      int(trace.ConnInfo.S_port),
 		Host:          hostname,
 		HostPort:      hostPort,
-		ContentLength: int64(trace.Len),
+		ContentLength: int64(trace.ReqLen),
 		RequestStart:  int64(trace.StartMonotimeNs),
 		Start:         int64(trace.StartMonotimeNs),
 		End:           int64(trace.EndMonotimeNs),

--- a/pkg/internal/ebpf/common/fast_cgi_detect_transform_test.go
+++ b/pkg/internal/ebpf/common/fast_cgi_detect_transform_test.go
@@ -60,6 +60,12 @@ func TestParseCGITable(t *testing.T) {
 		expected map[string]string
 	}{
 		{
+			name:     "Empty URI",
+			input:    []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x01\xdb\x05\x00\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\x01DOCUMENT_URI/\r\rDOCUMENT_ROOT/var/www/html\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e\x04REQUEST_SCHEMEhttp\x11\aGATEWAY_INTERFACECGI/1.1\x0f\fSERVER_SOFTWAREn")[24:],
+			inputLen: 100,
+			expected: map[string]string{"CONTENT_LENGTH": "", "CONTENT_TYPE": "", "QUERY_STRING": "", "REQUEST_METHOD": "GET", "REQUEST_URI": "/", "SCRIPT_NAME": "/index.php"},
+		},
+		{
 			name:     "Correct values",
 			input:    []byte{12, 0, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 12, 0, 67, 79, 78, 84, 69, 78, 84, 95, 84, 89, 80, 69, 14, 0, 67, 79, 78, 84, 69, 78, 84, 95, 76, 69, 78, 71, 84, 72, 11, 5, 83, 67, 82, 73, 80, 84, 95, 78, 65, 77, 69, 47, 112, 105, 110, 103, 11, 5, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 12, 5, 68, 79, 67, 85, 77, 69, 78, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 13, 13, 68, 79, 67, 85, 77, 69, 78, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			inputLen: 100,
@@ -121,6 +127,16 @@ func TestDetectFastCGI(t *testing.T) {
 		expectedPath   string
 		expectedResult int
 	}{
+		{
+			name:           "Correct values empty URI",
+			input:          []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x01\xdb\x05\x00\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\x01DOCUMENT_URI/\r\rDOCUMENT_ROOT/var/www/html\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e\x04REQUEST_SCHEMEhttp\x11\aGATEWAY_INTERFACECGI/1.1\x0f\fSERVER_SOFTWAREn"),
+			output:         []byte{1, 0, 1, 0, 0},
+			inputLen:       200,
+			outputLen:      20,
+			expectedMethod: "GET",
+			expectedPath:   "/",
+			expectedResult: 200,
+		},
 		{
 			name:           "Correct values",
 			input:          []byte{1, 1, 0, 1, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 4, 0, 1, 1, 217, 7, 0, 12, 0, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 12, 0, 67, 79, 78, 84, 69, 78, 84, 95, 84, 89, 80, 69, 14, 0, 67, 79, 78, 84, 69, 78, 84, 95, 76, 69, 78, 71, 84, 72, 11, 5, 83, 67, 82, 73, 80, 84, 95, 78, 65, 77, 69, 47, 112, 105, 110, 103, 11, 5, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 12, 5, 68, 79, 67, 85, 77, 69, 78, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 13, 13, 68, 79, 67, 85, 77, 69, 78, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/pkg/internal/ebpf/common/fast_cgi_detect_transform_test.go
+++ b/pkg/internal/ebpf/common/fast_cgi_detect_transform_test.go
@@ -60,6 +60,12 @@ func TestParseCGITable(t *testing.T) {
 		expected map[string]string
 	}{
 		{
+			name:     "Older PHP",
+			input:    []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x02\t\a\x00\x0f\x1eSCRIPT_FILENAME/var/www/html/public/index.php\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\nDOCUMENT_URI/index.php\r\x14DOCUMENT_ROOT/var/www/html/public\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e")[24:],
+			inputLen: 200,
+			expected: map[string]string{"CONTENT_LENGTH": "", "CONTENT_TYPE": "", "QUERY_STRING": "", "REQUEST_METHOD": "GET", "SCRIPT_FILENAME": "/var/www/html/public/index.php", "DOCUMENT_ROOT": "", "DOCUMENT_URI": "/index.php", "REQUEST_URI": "/", "SCRIPT_NAME": "/index.php"},
+		},
+		{
 			name:     "Empty URI",
 			input:    []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x01\xdb\x05\x00\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\x01DOCUMENT_URI/\r\rDOCUMENT_ROOT/var/www/html\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e\x04REQUEST_SCHEMEhttp\x11\aGATEWAY_INTERFACECGI/1.1\x0f\fSERVER_SOFTWAREn")[24:],
 			inputLen: 100,
@@ -127,6 +133,26 @@ func TestDetectFastCGI(t *testing.T) {
 		expectedPath   string
 		expectedResult int
 	}{
+		{
+			name:           "Older PHP, small frame",
+			input:          []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x02\t\a\x00\x0f\x1eSCRIPT_FILENAME/var/www/html/public/index.php\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/inde\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+			output:         []byte{1, 0, 1, 0, 0},
+			inputLen:       152,
+			outputLen:      20,
+			expectedMethod: "GET",
+			expectedPath:   "",
+			expectedResult: 200,
+		},
+		{
+			name:           "Older PHP",
+			input:          []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x02\t\a\x00\x0f\x1eSCRIPT_FILENAME/var/www/html/public/index.php\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\nDOCUMENT_URI/index.php\r\x14DOCUMENT_ROOT/var/www/html/public\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e"),
+			output:         []byte{1, 0, 1, 0, 0},
+			inputLen:       200,
+			outputLen:      20,
+			expectedMethod: "GET",
+			expectedPath:   "/",
+			expectedResult: 200,
+		},
 		{
 			name:           "Correct values empty URI",
 			input:          []byte("\x01\x01\x00\x01\x00\b\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x01\xdb\x05\x00\f\x00QUERY_STRING\x0e\x03REQUEST_METHODGET\f\x00CONTENT_TYPE\x0e\x00CONTENT_LENGTH\v\nSCRIPT_NAME/index.php\v\x01REQUEST_URI/\f\x01DOCUMENT_URI/\r\rDOCUMENT_ROOT/var/www/html\x0f\bSERVER_PROTOCOLHTTP/1.1\x0e\x04REQUEST_SCHEMEhttp\x11\aGATEWAY_INTERFACECGI/1.1\x0f\fSERVER_SOFTWAREn"),

--- a/pkg/internal/ebpf/common/sql_detect_transform.go
+++ b/pkg/internal/ebpf/common/sql_detect_transform.go
@@ -111,7 +111,7 @@ func TCPToSQLToSpan(trace *TCPRequestInfo, op, table, sql string, kind request.S
 		PeerPort:      peerPort,
 		Host:          hostname,
 		HostPort:      hostPort,
-		ContentLength: int64(trace.Len),
+		ContentLength: int64(trace.ReqLen),
 		RequestStart:  int64(trace.StartMonotimeNs),
 		Start:         int64(trace.StartMonotimeNs),
 		End:           int64(trace.EndMonotimeNs),


### PR DESCRIPTION
This PR changes the way we handle the FastCGI header parsing to anticipate different structure of the request headers.

Closes https://github.com/grafana/beyla/issues/1681