### PR TITLE
Make beyla-genfiles self-contained

### DIFF
--- a/cmd/beyla-genfiles/beyla_genfiles.go
+++ b/cmd/beyla-genfiles/beyla_genfiles.go
@@ -20,6 +20,8 @@ import (
 	"unicode"
 )
 
+const ENV_MODULE_ROOT = "BEYLA_GENFILES_MODULE_ROOT"
+
 type config struct {
 	DebugEnabled    bool   `env:"BEYLA_GENFILES_DEBUG"            envDefault:"false"`
 	RunLocally      bool   `env:"BEYLA_GENFILES_RUN_LOCALLY"      envDefault:"false"`
@@ -369,6 +371,21 @@ func beylaPackageDir() (string, error) {
 }
 
 func moduleRoot() (string, error) {
+	wd := os.Getenv(ENV_MODULE_ROOT)
+
+	if wd != "" {
+		info, err := os.Stat(wd)
+
+		if err != nil {
+			return "", err
+		}
+
+		if !info.IsDir() {
+			return "", fmt.Errorf("specified module root '%s' is not a dir")
+		}
+
+		return wd, nil
+	}
 
 	wd, err := beylaPackageDir()
 
@@ -387,7 +404,13 @@ func moduleRoot() (string, error) {
 		}
 	}
 
-	return wd, nil
+	absPath, err := filepath.Abs(wd)
+
+	if err != nil {
+		return "", fmt.Errorf("error resolving absolute path: %w", err)
+	}
+
+	return absPath, nil
 }
 
 func ensureWritableImpl(path string, info os.FileInfo) error {

--- a/cmd/beyla-genfiles/beyla_genfiles.go
+++ b/cmd/beyla-genfiles/beyla_genfiles.go
@@ -20,7 +20,7 @@ import (
 	"unicode"
 )
 
-const ENV_MODULE_ROOT = "BEYLA_GENFILES_MODULE_ROOT"
+const envModuleRoot = "BEYLA_GENFILES_MODULE_ROOT"
 
 type config struct {
 	DebugEnabled    bool   `env:"BEYLA_GENFILES_DEBUG"            envDefault:"false"`
@@ -371,7 +371,7 @@ func beylaPackageDir() (string, error) {
 }
 
 func moduleRoot() (string, error) {
-	wd := os.Getenv(ENV_MODULE_ROOT)
+	wd := os.Getenv(envModuleRoot)
 
 	if wd != "" {
 		info, err := os.Stat(wd)
@@ -381,7 +381,7 @@ func moduleRoot() (string, error) {
 		}
 
 		if !info.IsDir() {
-			return "", fmt.Errorf("specified module root '%s' is not a dir")
+			return "", fmt.Errorf("specified module root '%s' is not a dir", wd)
 		}
 
 		return wd, nil

--- a/cmd/beyla-genfiles/beyla_genfiles.go
+++ b/cmd/beyla-genfiles/beyla_genfiles.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 	"unicode"
+
+	"github.com/caarlos0/env/v9"
 )
 
 const envModuleRoot = "BEYLA_GENFILES_MODULE_ROOT"
@@ -33,40 +33,7 @@ type config struct {
 	GenImage        string `env:"BEYLA_GENFILES_GEN_IMG"          envDefault:"ghcr.io/grafana/beyla-ebpf-generator:main"`
 }
 
-func loadConfig() (*config, error) {
-	var cfg config
-	t := reflect.TypeOf(cfg)
-	v := reflect.ValueOf(&cfg).Elem()
-
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		envVar := field.Tag.Get("env")
-		defaultValue := field.Tag.Get("envDefault")
-
-		value := os.Getenv(envVar)
-
-		if value == "" {
-			value = defaultValue
-		}
-
-		switch field.Type.Kind() {
-		case reflect.Bool:
-			parsedValue, err := strconv.ParseBool(value)
-
-			if err != nil {
-				return nil, fmt.Errorf("error parsing bool value %s: %w", envVar, err)
-			}
-
-			v.Field(i).SetBool(parsedValue)
-		case reflect.String:
-			v.Field(i).SetString(value)
-		}
-	}
-
-	return &cfg, nil
-}
-
-var cfg *config
+var cfg config
 
 var targetsByGoArch = map[string]Target{
 	"386":      {"bpfel", "x86"},
@@ -589,11 +556,7 @@ func runLocally(wd string) {
 }
 
 func main() {
-	var err error
-
-	cfg, err = loadConfig()
-
-	if err != nil {
+	if err := env.Parse(&cfg); err != nil {
 		bail(fmt.Errorf("error loading config: %w", err))
 	}
 

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -6,6 +6,10 @@ ARG EBPF_VER
 RUN apk add clang llvm19 curl
 RUN apk cache purge
 RUN go install github.com/cilium/ebpf/cmd/bpf2go@$EBPF_VER
+COPY cmd/beyla-genfiles/beyla_genfiles.go .
+RUN go build -o /go/bin/beyla_genfiles beyla_genfiles.go
+RUN go clean -modcache -cache
+RUN rm beyla_genfiles.go
 
 VOLUME ["/src"]
 
@@ -19,7 +23,7 @@ export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
 export BEYLA_GENFILES_RUN_LOCALLY=1
-go run cmd/beyla-genfiles/beyla_genfiles.go
+beyla_genfiles
 EOF
 
 RUN chmod +x /generate.sh

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -23,6 +23,7 @@ export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
 export BEYLA_GENFILES_RUN_LOCALLY=1
+export BEYLA_GENFILES_MODULE_ROOT="/src"
 beyla_genfiles
 EOF
 


### PR DESCRIPTION
This PR embeds the `beyla-genfile` binary in the generator image, to allow downstream software vendoring Beyla to run this tool without having to explicitly fetch its source code and provide it to the image (that only works when building beyla itself, as tools are not distributed as vendored modules).

This relates to https://github.com/grafana/alloy/pull/2734