### PR TITLE
Bump Go version to 1.24.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_check_license.yml
+++ b/.github/workflows/pull_request_check_license.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: github-hosted-ubuntu-arm64-large
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         arch: ['amd64','arm64']
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -12,7 +12,7 @@ jobs:
     - name: "Update Go"
       uses: actions/setup-go@v4
       with:
-        go-version: '>=1.23'
+        go-version: '>=1.24'
         check-latest: true
     - name: "Update offsets"
       run: make update-offsets

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ issues:
         - revive
       text: indent-error-flow
 run:
-  go: "1.23"
+  go: "1.24"
   build-tags:
     - integration
 linters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/beyla/v2
 
-go 1.23.2
+go 1.24.1
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396

--- a/k8scache.Dockerfile
+++ b/k8scache.Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary for the k8s-cache service
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 ENV GOARCH=$TARGETARCH

--- a/protoc.Dockerfile
+++ b/protoc.Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile generates the container image that is required to run "make protoc-gen"
 
 # Use an official Golang runtime as a parent image
-FROM golang:1.23
+FROM golang:1.24
 
 ARG TARGETARCH
 

--- a/test/integration/components/beyla-k8s-cache/Dockerfile
+++ b/test/integration/components/beyla-k8s-cache/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/beyla/Dockerfile
+++ b/test/integration/components/beyla/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/beyla/Dockerfile_dbg
+++ b/test/integration/components/beyla/Dockerfile_dbg
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/go_grpc_server_mux/Dockerfile
+++ b/test/integration/components/go_grpc_server_mux/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/go_grpc_server_mux/Dockerfile_tls
+++ b/test/integration/components/go_grpc_server_mux/Dockerfile_tls
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gohttp2/client/Dockerfile
+++ b/test/integration/components/gohttp2/client/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gohttp2/server/Dockerfile
+++ b/test/integration/components/gohttp2/server/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gokafka-seg/Dockerfile
+++ b/test/integration/components/gokafka-seg/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gokafka/Dockerfile
+++ b/test/integration/components/gokafka/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/goredis/Dockerfile
+++ b/test/integration/components/goredis/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/gosql/Dockerfile
+++ b/test/integration/components/gosql/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/grpcpinger/Dockerfile
+++ b/test/integration/components/grpcpinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/httppinger/Dockerfile
+++ b/test/integration/components/httppinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/old_grpc/backend/Dockerfile
+++ b/test/integration/components/old_grpc/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /src
 

--- a/test/integration/components/old_grpc/worker/Dockerfile
+++ b/test/integration/components/old_grpc/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /src
 

--- a/test/integration/components/pingclient/Dockerfile
+++ b/test/integration/components/pingclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/sqlclient/Dockerfile
+++ b/test/integration/components/sqlclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile
+++ b/test/integration/components/testserver/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_duplicate
+++ b/test/integration/components/testserver/Dockerfile_duplicate
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_nodebug
+++ b/test/integration/components/testserver/Dockerfile_nodebug
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_rename1
+++ b/test/integration/components/testserver/Dockerfile_rename1
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/integration/components/testserver/Dockerfile_static
+++ b/test/integration/components/testserver/Dockerfile_static
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG TARGETARCH
 

--- a/test/vm/Dockerfile
+++ b/test/vm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-rc-alpine
+FROM golang:1.24-rc-alpine
 
 # this is the toplevel Makefile target to be invoked
 # see the contents of 'startup.sh' at the end of this file


### PR DESCRIPTION
Alloy uses already this version, so we need to match go versions to properly build Beyla
in Alloy.