### PR TITLE
Silence wget and prevent file from being redownloaded

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -16,7 +16,7 @@ VOLUME ["/src"]
 
 ARG EBPF_VER
 
-RUN apk add clang llvm19 curl
+RUN apk add clang llvm19 curl wget
 RUN apk cache purge
 RUN go install github.com/cilium/ebpf/cmd/bpf2go@$EBPF_VER
 COPY --from=builder /build/beyla_genfiles /go/bin

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -16,7 +16,7 @@ VOLUME ["/src"]
 
 ARG EBPF_VER
 
-RUN apk add clang llvm19 curl wget
+RUN apk add clang llvm19 wget
 RUN apk cache purge
 RUN go install github.com/cilium/ebpf/cmd/bpf2go@$EBPF_VER
 COPY --from=builder /build/beyla_genfiles /go/bin

--- a/pkg/internal/otelsdk/sdk_inject.go
+++ b/pkg/internal/otelsdk/sdk_inject.go
@@ -2,7 +2,7 @@
 
 package otelsdk
 
-//go:generate wget -O grafana-opentelemetry-java.jar https://github.com/grafana/grafana-opentelemetry-java/releases/download/v2.13.2.1/grafana-opentelemetry-java.jar
+//go:generate wget --quiet -N -O grafana-opentelemetry-java.jar https://github.com/grafana/grafana-opentelemetry-java/releases/download/v2.13.2.1/grafana-opentelemetry-java.jar
 
 import (
 	"bufio"


### PR DESCRIPTION
Make `wget` less verbose during the generation step and preventing the file from being redownloaded if it is up to date.. This requires an explicit install of `wget` in the generator image, as the default wget comes from busybox and does not support `-N`.