### PR TITLE
Add explicit delay flag for delayed http requests

### DIFF
--- a/bpf/http_types.h
+++ b/bpf/http_types.h
@@ -123,6 +123,7 @@ typedef struct http_info {
     tp_info_t tp;
     u64 extra_id;
     u32 task_tid;
+    u8 delayed;
 } http_info_t;
 
 // Here we track unknown TCP requests that are not HTTP, HTTP2 or gRPC

--- a/bpf/protocol_http.h
+++ b/bpf/protocol_http.h
@@ -268,7 +268,7 @@ static __always_inline void finish_possible_delayed_http_request(pid_connection_
         return;
     }
     http_info_t *info = bpf_map_lookup_elem(&ongoing_http, pid_conn);
-    if (info) {
+    if (info && info->delayed) {
         finish_http(info, pid_conn);
     }
 }
@@ -334,6 +334,7 @@ static __always_inline void handle_http_response(unsigned char *small_buf,
             finish_http(info, pid_conn);
         } else {
             bpf_dbg_printk("Delaying finish http for large request, orig_len %d", orig_len);
+            info->delayed = 1;
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where two SSLs can get associated to the same connection info, this is if different SSLs are used for sending and receiving. In this case, there's a race condition that can happen when we finish the HTTP request, one will finish it, but the other may be checking for a delayed request, finishing it again in unfortunate timing. 

This bug was recently exposed in a new test we added where we explicitly check that spans are not duplicated.