### PR TITLE
Tag the generator image for this release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the autoinstrumenter binary
-FROM ghcr.io/grafana/beyla-ebpf-generator:main AS builder
+FROM ghcr.io/grafana/beyla-ebpf-generator:2.1 AS builder
 
 # TODO: embed software version in executable
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ IMG = $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/grafana/beyla-ebpf-generator:main
+GEN_IMG ?= ghcr.io/grafana/beyla-ebpf-generator:2.1
 
 COMPOSE_ARGS ?= -f test/integration/docker-compose.yml
 
@@ -192,7 +192,7 @@ generate: bpf2go
 .PHONY: docker-generate
 docker-generate:
 	@echo "### Generating files (docker)..."
-	@go generate cmd/beyla-genfiles/beyla_genfiles.go
+	@BEYLA_GENFILES_GEN_IMG=$(GEN_IMG) go generate cmd/beyla-genfiles/beyla_genfiles.go
 
 .PHONY: verify
 verify: prereqs lint-dashboard lint test


### PR DESCRIPTION
I missed the 2.1.0 release, but it's not too late: this PR just has this release branch use their corresponding generator image. At the moment, `beyla-ebpf-generator:2.1` and `beyla-ebpf-generator:main` are exactly the same, but `main` can diverge at anypoint in time, so we keep a specific generator tag for this branch to keep it reproducible.

In the future we need to automate this, but this will do for now.