### PR TITLE
tctracer: move maps to their own files

### DIFF
--- a/bpf/tctracer/maps/egress_key_mem.h
+++ b/bpf/tctracer/maps/egress_key_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/egress_key.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, egress_key_t);
+    __uint(max_entries, 1);
+} egress_key_mem SEC(".maps");

--- a/bpf/tctracer/maps/extender_jump_table.h
+++ b/bpf/tctracer/maps/extender_jump_table.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1);
+} extender_jump_table SEC(".maps");

--- a/bpf/tctracer/maps/pid_connection_info_mem.h
+++ b/bpf/tctracer/maps/pid_connection_info_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, pid_connection_info_t);
+    __uint(max_entries, 1);
+} pid_connection_info_mem SEC(".maps");

--- a/bpf/tctracer/maps/sock_dir.h
+++ b/bpf/tctracer/maps/sock_dir.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+
+// A map of sockets which we track with sock_ops. The sock_msg
+// program subscribes to this map and runs for each new socket
+// activity
+// The map size must be max u16 to avoid accidentally losing
+// the socket information
+struct {
+    __uint(type, BPF_MAP_TYPE_SOCKHASH);
+    __uint(max_entries, 65535);
+    __uint(key_size, sizeof(connection_info_t));
+    __uint(value_size, sizeof(uint32_t));
+} sock_dir SEC(".maps");


### PR DESCRIPTION
This is a part of what should be a series or PRs that aim to tide up our ebpf code.

This one just moves the private tctracer maps to their own subdir.