### PR TITLE
Fix VM tests go version

### DIFF
--- a/test/vm/Dockerfile
+++ b/test/vm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-rc-alpine
+FROM golang:1.24.1-alpine
 
 # this is the toplevel Makefile target to be invoked
 # see the contents of 'startup.sh' at the end of this file


### PR DESCRIPTION
Bring the go version of the VM tests root filesystem in line with what we are using.