### PR TITLE
Use mutable tag to keep workflow up to date

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/vale-action@13205961f20ad13843505a9b84fdf032f911a3f4 # vale-action/v1.1.0
+      - uses: grafana/writers-toolkit/vale-action@vale-action/v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The old version broke due to the need to remove `reviewdog` tooling.