### PR TITLE
Migrate process pipeline out of pipes library

### DIFF
--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/mariomac/pipes/pipe"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -21,6 +20,8 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 )
 
 var (
@@ -78,6 +79,8 @@ type procMetricsExporter struct {
 	// the *.io.direction attributes being selected or not
 	diskObserver func(context.Context, *procMetrics, *process.Status)
 	netObserver  func(context.Context, *procMetrics, *process.Status)
+
+	procStatusInput <-chan []*process.Status
 }
 
 type procMetrics struct {
@@ -94,16 +97,15 @@ type procMetrics struct {
 }
 
 func ProcMetricsExporterProvider(
-	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *ProcMetricsConfig,
-) pipe.FinalProvider[[]*process.Status] {
-	return func() (pipe.FinalFunc[[]*process.Status], error) {
+	input *msg.Queue[[]*process.Status],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
 		if !cfg.Enabled() {
-			// This node is not going to be instantiated. Let the pipes library just ignore it.
-			return pipe.IgnoreFinal[[]*process.Status](), nil
+			return swarm.EmptyRunFunc()
 		}
-		return newProcMetricsExporter(ctx, ctxInfo, cfg)
+		return newProcMetricsExporter(ctx, ctxInfo, cfg, input)
 	}
 }
 
@@ -111,7 +113,8 @@ func newProcMetricsExporter(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *ProcMetricsConfig,
-) (pipe.FinalFunc[[]*process.Status], error) {
+	input *msg.Queue[[]*process.Status],
+) (swarm.RunFunc, error) {
 	SetupInternalOTELSDKLogger(cfg.Metrics.SDKLogLevel)
 
 	log := pmlog()
@@ -147,8 +150,9 @@ func newProcMetricsExporter(
 			attrProv.For(attributes.ProcessMemoryUsage)),
 		attrMemoryVirtual: attributes.OpenTelemetryGetters(process.OTELGetters,
 			attrProv.For(attributes.ProcessMemoryVirtual)),
-		attrDisk: attrDisk,
-		attrNet:  attrNet,
+		attrDisk:        attrDisk,
+		attrNet:         attrNet,
+		procStatusInput: input.Subscribe(),
 	}
 	if slices.Contains(cpuTimeNames, attr2.ProcCPUMode) {
 		mr.cpuTimeObserver = cpuTimeDisaggregatedObserver
@@ -301,8 +305,8 @@ func (me *procMetricsExporter) newMetricSet(procID *process.ID) (*procMetrics, e
 }
 
 // Do reads all the process status data points and create the metrics accordingly
-func (me *procMetricsExporter) Do(in <-chan []*process.Status) {
-	for i := range in {
+func (me *procMetricsExporter) Do(_ context.Context) {
+	for i := range me.procStatusInput {
 		me.clock.Update()
 		for _, s := range i {
 			reporter, err := me.reporters.For(&s.ID)

--- a/pkg/export/prom/prom_proc.go
+++ b/pkg/export/prom/prom_proc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/mariomac/pipes/pipe"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
@@ -15,6 +14,8 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/connector"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 )
 
 // injectable function reference for testing
@@ -34,14 +35,16 @@ func (p ProcPrometheusConfig) Enabled() bool {
 // ProcPrometheusEndpoint provides a pipeline node that export the process information as
 // prometheus metrics
 func ProcPrometheusEndpoint(
-	ctx context.Context, ctxInfo *global.ContextInfo, cfg *ProcPrometheusConfig,
-) pipe.FinalProvider[[]*process.Status] {
-	return func() (pipe.FinalFunc[[]*process.Status], error) {
+	ctxInfo *global.ContextInfo,
+	cfg *ProcPrometheusConfig,
+	procStatusInput *msg.Queue[[]*process.Status],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
 		if !cfg.Enabled() {
 			// This node is not going to be instantiated. Let the pipes library just ignore it.
-			return pipe.IgnoreFinal[[]*process.Status](), nil
+			return swarm.EmptyRunFunc()
 		}
-		reporter, err := newProcReporter(ctx, ctxInfo, cfg)
+		reporter, err := newProcReporter(ctx, ctxInfo, cfg, procStatusInput)
 		if err != nil {
 			return nil, err
 		}
@@ -88,15 +91,12 @@ type procMetricsReporter struct {
 
 	// the observation code for IO metrics will be different depending on
 	// the "*.io.direction" attributes
-	diskObserver func(*process.Status)
-	netObserver  func(*process.Status)
+	diskObserver    func(*process.Status)
+	netObserver     func(*process.Status)
+	procStatusInput <-chan []*process.Status
 }
 
-func newProcReporter(
-	ctx context.Context,
-	ctxInfo *global.ContextInfo,
-	cfg *ProcPrometheusConfig,
-) (*procMetricsReporter, error) {
+func newProcReporter(ctx context.Context, ctxInfo *global.ContextInfo, cfg *ProcPrometheusConfig, input *msg.Queue[[]*process.Status]) (*procMetricsReporter, error) {
 	group := ctxInfo.MetricAttributeGroups
 	// this property can't be set inside the ConfiguredGroups function, otherwise the
 	// OTEL exporter would report also some prometheus-exclusive attributes
@@ -157,6 +157,7 @@ func newProcReporter(
 			Name: attributes.ProcessNetIO.Prom,
 			Help: "Network bytes transferred",
 		}, netLblNames).MetricVec, clock.Time, cfg.Metrics.TTL),
+		procStatusInput: input.Subscribe(),
 	}
 
 	if cpuTimeHasState {
@@ -197,13 +198,13 @@ func newProcReporter(
 	return mr, nil
 }
 
-func (r *procMetricsReporter) reportMetrics(input <-chan []*process.Status) {
+func (r *procMetricsReporter) reportMetrics(ctx context.Context) {
 	go r.promConnect.StartHTTP(r.bgCtx)
-	r.collectMetrics(input)
+	r.collectMetrics(ctx)
 }
 
-func (r *procMetricsReporter) collectMetrics(input <-chan []*process.Status) {
-	for processes := range input {
+func (r *procMetricsReporter) collectMetrics(_ context.Context) {
+	for processes := range r.procStatusInput {
 		// clock needs to be updated to let the expirer
 		// remove the old metrics
 		r.clock.Update()

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -154,7 +154,7 @@ func connectOldPipesLibToSwarmProcessSubpipeline(
 			return nil, err
 		}
 		return func(in <-chan []request.Span) {
-			processMetrics(ctx)
+			go processMetrics(ctx)
 			// just connects the old pipe library with the new swarm library
 			// TODO: will be removed when we move the rest of the pipeline to the new swarm
 			for i := range in {

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/traces"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 	"github.com/grafana/beyla/v2/pkg/transform"
 )
 
@@ -95,6 +96,10 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 	// This is how the github.com/mariomac/pipes library, works:
 	// https://github.com/mariomac/pipes/tree/main/docs/tutorial/b-highlevel/01-basic-nodes
 
+	// We are migrating the pipes library to a simpler-but-more-flexible "Swarm" model
+	// We might see some duplications in the code here until we migrate everything
+	appToProcChannel := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen))
+
 	// First, we create a graph builder
 	gnb := pipe.NewBuilder(&nodesMap{}, pipe.ChannelBufferLen(config.ChannelBufferLen))
 	gb := &graphFunctions{
@@ -125,13 +130,38 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 
 	// process subpipeline will start another pipeline only to collect and export data
 	// about the processes of an instrumented application
-	pipe.AddFinalProvider(gnb, processReport, SubPipelineProvider(ctx, ctxInfo, config))
+	pipe.AddFinalProvider(gnb, processReport, connectOldPipesLibToSwarmProcessSubpipeline(ctx, config, ctxInfo, appToProcChannel))
 
 	// The returned builder later invokes its "Build" function that, given
 	// the contents of the nodesMap struct, will instantiate
 	// and interconnect each node according to the SendTo invocations in the
 	// Connect() method of the nodesMap.
 	return gb
+}
+
+func connectOldPipesLibToSwarmProcessSubpipeline(
+	ctx context.Context,
+	config *beyla.Config,
+	ctxInfo *global.ContextInfo,
+	appToProcChannel *msg.Queue[[]request.Span],
+) pipe.FinalProvider[[]request.Span] {
+	return func() (pipe.FinalFunc[[]request.Span], error) {
+		if !isSubPipeEnabled(config) {
+			return pipe.IgnoreFinal[[]request.Span](), nil
+		}
+		processMetrics, err := ProcessMetricsSwarmInstancer(ctxInfo, config, appToProcChannel)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return func(in <-chan []request.Span) {
+			processMetrics(ctx)
+			// just connects the old pipe library with the new swarm library
+			// TODO: will be removed when we move the rest of the pipeline to the new swarm
+			for i := range in {
+				appToProcChannel.Send(i)
+			}
+		}, nil
+	}
 }
 
 func (gb *graphFunctions) buildGraph() (*Instrumenter, error) {

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -146,7 +146,7 @@ func connectOldPipesLibToSwarmProcessSubpipeline(
 	appToProcChannel *msg.Queue[[]request.Span],
 ) pipe.FinalProvider[[]request.Span] {
 	return func() (pipe.FinalFunc[[]request.Span], error) {
-		if !isSubPipeEnabled(config) {
+		if !isProcessSubPipeEnabled(config) {
 			return pipe.IgnoreFinal[[]request.Span](), nil
 		}
 		processMetrics, err := ProcessMetricsSwarmInstancer(ctxInfo, config, appToProcChannel)(ctx)

--- a/pkg/internal/pipe/proc_pipeline.go
+++ b/pkg/internal/pipe/proc_pipeline.go
@@ -35,7 +35,7 @@ func ProcessMetricsSwarmInstancer(
 		if !isSubPipeEnabled(cfg) {
 			// returns nothing. Nothing will subscribe to the ProcessSubPipeInput, no extra
 			// load will be held
-			return func(_ context.Context) {}, nil
+			return swarm.EmptyRunFunc()
 		}
 
 		// communication channel between the process collector and the metrics exporters

--- a/pkg/internal/pipe/proc_pipeline.go
+++ b/pkg/internal/pipe/proc_pipeline.go
@@ -17,7 +17,7 @@ import (
 
 // the sub-pipe is enabled only if there is a metrics exporter enabled,
 // and both the "application" and "application_process" features are enabled
-func isSubPipeEnabled(cfg *beyla.Config) bool {
+func isProcessSubPipeEnabled(cfg *beyla.Config) bool {
 	return (cfg.Metrics.EndpointEnabled() && cfg.Metrics.OTelMetricsEnabled() &&
 		slices.Contains(cfg.Metrics.Features, otel.FeatureProcess)) ||
 		(cfg.Prometheus.EndpointEnabled() && cfg.Prometheus.OTelMetricsEnabled() &&
@@ -32,7 +32,7 @@ func ProcessMetricsSwarmInstancer(
 	appInputSpans *msg.Queue[[]request.Span],
 ) swarm.InstanceFunc {
 	return func(ctx context.Context) (swarm.RunFunc, error) {
-		if !isSubPipeEnabled(cfg) {
+		if !isProcessSubPipeEnabled(cfg) {
 			// returns nothing. Nothing will subscribe to the ProcessSubPipeInput, no extra
 			// load will be held
 			return swarm.EmptyRunFunc()

--- a/pkg/internal/testutil/channels.go
+++ b/pkg/internal/testutil/channels.go
@@ -18,3 +18,17 @@ func ReadChannel[T any](t *testing.T, inCh <-chan T, timeout time.Duration) T {
 	}
 	return item
 }
+
+// ChannelEmpty asserts that a channel is empty and does not receive any message,
+// giving a timeout as margin to check that no actual messages are received during that Duration.
+func ChannelEmpty[T any](t *testing.T, inCh <-chan T, timeout time.Duration) {
+	t.Helper()
+	select {
+	case stuff, ok := <-inCh:
+		if ok {
+			t.Fatalf("channel should be empty. Got %#v", stuff)
+		}
+	case <-time.After(timeout):
+		// ok, channel is empty!
+	}
+}

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -1,0 +1,91 @@
+// Package msg provides tools for message passing and queues between the different nodes of the Beyla pipelines.
+package msg
+
+type queueConfig struct {
+	channelBufferLen int
+}
+
+var defaultQueueConfig = queueConfig{
+	channelBufferLen: 1,
+}
+
+// QueueOpts allow configuring some operation of a queue
+type QueueOpts func(*queueConfig)
+
+// ChannelBufferLen sets the length of the channel buffer for the queue.
+func ChannelBufferLen(l int) QueueOpts {
+	return func(c *queueConfig) {
+		c.channelBufferLen = l
+	}
+}
+
+// Queue is a simple message queue that allows sending messages to multiple subscribers.
+// It also allows bypassing messages to other queues, so that a message sent to one queue
+// can be received by subscribers of another queue.
+// If a message is sent to a queue that has no subscribers, it will not block the sender and the
+// message will be lost. This is by design, as the queue is meant to be used for fire-and-forget
+type Queue[T any] struct {
+	cfg  *queueConfig
+	dsts []chan T
+	// double-linked list of bypassing queues
+	// For simplicity, a Queue instance:
+	// - can't bypass to a queue and having other dsts
+	// - can only bypass to a single queue, despite multiple queues can bypass to it
+	bypassTo *Queue[T]
+}
+
+// NewQueue creates a new Queue instance with the given options.
+func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
+	cfg := defaultQueueConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Queue[T]{cfg: &cfg}
+}
+
+func (q *Queue[T]) config() *queueConfig {
+	if q.cfg == nil {
+		return &defaultQueueConfig
+	}
+	return q.cfg
+}
+
+// Send a message to all subscribers of this queue. If there are no subscribers,
+// the message will be lost and the sender will not be blocked.
+func (q *Queue[T]) Send(o T) {
+	if q.bypassTo != nil {
+		q.bypassTo.Send(o)
+		return
+	}
+	for _, d := range q.dsts {
+		d <- o
+	}
+}
+
+// Subscribe to this queue. This will return a channel that will receive messages.
+// It's important to notice that, if Subscribe is invoked after Send, the sent message
+// will be lost, or forwarded to other subscribed but not to the channel resulting from the
+// last invocation.
+// This operation is not thread-safe.
+// You can't subscribe to a queue that is bypassing to another queue.
+func (q *Queue[T]) Subscribe() <-chan T {
+	if q.bypassTo != nil {
+		panic("this queue is already bypassing data to another queue. Can't subscribe to it")
+	}
+	out := make(chan T, q.config().channelBufferLen)
+	q.dsts = append(q.dsts, out)
+	return out
+}
+
+// Bypass allows this queue to bypass messages to another queue. This means that
+// messages sent to this queue will also be sent to the other queue.
+// This operation is not thread-safe and does not control for graph cycles.
+func (q *Queue[T]) Bypass(to *Queue[T]) {
+	if q == to {
+		panic("this queue can't bypass to itself")
+	}
+	if q.bypassTo != nil {
+		panic("this queue is already bypassing to another queue")
+	}
+	q.bypassTo = to
+}

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -1,0 +1,96 @@
+package msg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/beyla/v2/pkg/internal/testutil"
+)
+
+const timeout = 5 * time.Second
+
+func TestNoSubscribers(t *testing.T) {
+	// test that sender is not blocked if there are no subscribers
+	q := Queue[int]{}
+	sent := make(chan int)
+	go func() {
+		q.Send(1)
+		close(sent)
+	}()
+	testutil.ReadChannel(t, sent, timeout)
+	testutil.ChannelEmpty(t, sent, 5*time.Millisecond)
+}
+
+func TestMultipleSubscribers(t *testing.T) {
+	q := Queue[int]{}
+	ch1 := q.Subscribe()
+	ch2 := q.Subscribe()
+	go q.Send(123)
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch1, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
+func TestBypass(t *testing.T) {
+	q1 := Queue[int]{}
+	q2 := Queue[int]{}
+	ch2 := q2.Subscribe()
+	q1.Bypass(&q2)
+	go q1.Send(123)
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
+func TestBypass_SubscribeAfterBypass(t *testing.T) {
+	q1 := Queue[int]{}
+	q2 := Queue[int]{}
+	q1.Bypass(&q2)
+	ch2 := q2.Subscribe()
+	go q1.Send(123)
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
+func TestChainedBypass(t *testing.T) {
+	q1 := Queue[int]{}
+	q2 := Queue[int]{}
+	q3 := Queue[int]{}
+	q1.Bypass(&q2)
+	q2.Bypass(&q3)
+	ch3 := q3.Subscribe()
+	go q1.Send(123)
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch3, timeout))
+	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
+
+}
+
+func TestErrors(t *testing.T) {
+	t.Run("can't bypass to itself", func(t *testing.T) {
+		q := &Queue[int]{}
+		assert.Panics(t, func() {
+			q.Bypass(q)
+		})
+	})
+	t.Run("can't bypass to another queue that is already bypassing", func(t *testing.T) {
+		q1 := Queue[int]{}
+		q2 := Queue[int]{}
+		q3 := Queue[int]{}
+		q1.Bypass(&q2)
+		assert.Panics(t, func() {
+			q1.Bypass(&q3)
+		})
+	})
+	t.Run("can't subscribe to a queue that is bypassing", func(t *testing.T) {
+		q1 := Queue[int]{}
+		q2 := Queue[int]{}
+		q1.Bypass(&q2)
+		assert.Panics(t, func() {
+			q1.Subscribe()
+		})
+	})
+}

--- a/pkg/pipe/swarm/instancer.go
+++ b/pkg/pipe/swarm/instancer.go
@@ -1,0 +1,40 @@
+package swarm
+
+import (
+	"context"
+)
+
+// InstanceFunc is a function that creates a service RunFunc.
+// The passed context will be cancelled by the Instancer's Instance method
+// after all the nodes are created (or if any node has failed), so the context
+// should be not stored for later use in the RunFunc.
+type InstanceFunc func(context.Context) (RunFunc, error)
+
+// Instancer coordinates the instantiation of all the swarm nodes and
+// manages any error during the construction of it.
+type Instancer struct {
+	creators []InstanceFunc
+}
+
+// Add a service instancer to the swarm. The intancer will be called when the swarm Instance starts,
+// and must return a RunFunc instance that will execute the actual operation of the service node.
+func (s *Instancer) Add(c InstanceFunc) {
+	s.creators = append(s.creators, c)
+}
+
+// Instance the Swarm. It calls all registered service creators and, if all succeed,
+// returns a Runner instance that will execute the actual operation of the service nodes.
+func (s *Instancer) Instance(ctx context.Context) (*Runner, error) {
+	runner := &Runner{runners: make([]RunFunc, 0, len(s.creators))}
+	buildCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	for _, creator := range s.creators {
+		runFn, err := creator(buildCtx)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		runner.runners = append(runner.runners, runFn)
+	}
+	return runner, nil
+}

--- a/pkg/pipe/swarm/instancer.go
+++ b/pkg/pipe/swarm/instancer.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"sync"
 )
 
 // InstanceFunc is a function that creates a service RunFunc.
@@ -13,18 +14,23 @@ type InstanceFunc func(context.Context) (RunFunc, error)
 // Instancer coordinates the instantiation of all the swarm nodes and
 // manages any error during the construction of it.
 type Instancer struct {
+	mt       sync.Mutex
 	creators []InstanceFunc
 }
 
 // Add a service instancer to the swarm. The intancer will be called when the swarm Instance starts,
 // and must return a RunFunc instance that will execute the actual operation of the service node.
 func (s *Instancer) Add(c InstanceFunc) {
+	s.mt.Lock()
+	defer s.mt.Unlock()
 	s.creators = append(s.creators, c)
 }
 
 // Instance the Swarm. It calls all registered service creators and, if all succeed,
 // returns a Runner instance that will execute the actual operation of the service nodes.
 func (s *Instancer) Instance(ctx context.Context) (*Runner, error) {
+	s.mt.Lock()
+	defer s.mt.Unlock()
 	runner := &Runner{runners: make([]RunFunc, 0, len(s.creators))}
 	buildCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/pipe/swarm/runner.go
+++ b/pkg/pipe/swarm/runner.go
@@ -1,0 +1,38 @@
+// Package swarm provides tools for the creation and coordination of the nodes that go inside the different
+// Beyla pipelines
+package swarm
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// RunFunc is a function that runs a node. The node should be stoppable via the passed context Done function.
+type RunFunc func(context.Context)
+
+// EmptyRunFunc returns a no-op RunFunc that does nothing. Can be used as a convenience reference
+// for an Instancer that returns a function that can be ignored
+func EmptyRunFunc() (RunFunc, error) {
+	return func(_ context.Context) {}, nil
+}
+
+// Runner runs all the nodes in the swarm returned from an Instancer.
+type Runner struct {
+	started atomic.Bool
+	runners []RunFunc
+}
+
+// Start the Swarm in background. It calls all registered service creators and, if all succeed,
+// it runs the returned RunFunc instances.
+// If any of the creators return an error, the swarm will stop and return the error. The context
+// that is passed to the rest of creators will be cancelled.
+// No service RunFunc internal instance is started until all the Creators are successfully
+// created. This means that if any of the creators fail, no service RunFunc is started.
+func (s *Runner) Start(ctx context.Context) {
+	if s.started.Swap(true) {
+		panic("swarm.Runner already started")
+	}
+	for i := range s.runners {
+		go s.runners[i](ctx)
+	}
+}

--- a/pkg/pipe/swarm/swarm_test.go
+++ b/pkg/pipe/swarm/swarm_test.go
@@ -1,0 +1,115 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwarm_BuildWithError(t *testing.T) {
+	inst := Instancer{}
+	inst.Add(func(_ context.Context) (RunFunc, error) {
+		return nil, errors.New("creation error")
+	})
+	_, err := inst.Instance(context.Background())
+	assert.Error(t, err)
+}
+
+func TestSwarm_StartTwice(t *testing.T) {
+	inst := Instancer{}
+	inst.Add(func(_ context.Context) (RunFunc, error) {
+		return func(_ context.Context) {}, nil
+	})
+	s, err := inst.Instance(context.Background())
+	require.NoError(t, err)
+	s.Start(context.Background())
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic, got none")
+		}
+	}()
+	s.Start(context.Background())
+}
+
+func TestSwarm_RunnerExecution(t *testing.T) {
+	inst := Instancer{}
+	runnerExecuted := atomic.Bool{}
+	inst.Add(func(_ context.Context) (RunFunc, error) {
+		return func(_ context.Context) {
+			runnerExecuted.Store(true)
+		}, nil
+	})
+	s, err := inst.Instance(context.Background())
+	require.NoError(t, err)
+	s.Start(context.Background())
+	test.Eventually(t, 5*time.Second, func(t require.TestingT) {
+		assert.True(t, runnerExecuted.Load(), "runner was not executed")
+	})
+}
+
+func TestSwarm_CreatorFailure(t *testing.T) {
+	inst := Instancer{}
+	runnerStarted := atomic.Bool{}
+	c1cancel := atomic.Bool{}
+	c3exec := atomic.Bool{}
+	inst.Add(func(ctx context.Context) (RunFunc, error) {
+		go func() {
+			<-ctx.Done()
+			c1cancel.Store(true)
+		}()
+		return func(_ context.Context) {
+			runnerStarted.Store(true)
+		}, nil
+	})
+	inst.Add(func(_ context.Context) (RunFunc, error) {
+		return nil, errors.New("creation error")
+	})
+	inst.Add(func(_ context.Context) (RunFunc, error) {
+		c3exec.Store(true)
+		return func(_ context.Context) {}, nil
+	})
+
+	// second creator fails, so the first one should be cancelled and the third one should not be instantiated
+	_, err := inst.Instance(context.Background())
+	require.Error(t, err)
+	test.Eventually(t, 5*time.Second, func(t require.TestingT) {
+		assert.True(t, c1cancel.Load(), "c1 was not cancelled")
+	})
+	assert.False(t, c3exec.Load(), "c3 was executed")
+	assert.False(t, runnerStarted.Load(), "runner was started")
+}
+
+func TestSwarm_ContextPassed(t *testing.T) {
+	startWg := sync.WaitGroup{}
+	startWg.Add(3)
+	doneWg := sync.WaitGroup{}
+	doneWg.Add(3)
+	inst := Instancer{}
+	innerRunner := func(ctx context.Context) {
+		startWg.Done()
+		<-ctx.Done()
+		doneWg.Done()
+	}
+	inst.Add(func(_ context.Context) (RunFunc, error) { return innerRunner, nil })
+	inst.Add(func(_ context.Context) (RunFunc, error) { return innerRunner, nil })
+	inst.Add(func(_ context.Context) (RunFunc, error) { return innerRunner, nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := inst.Instance(context.Background())
+	require.NoError(t, err)
+	s.Start(ctx)
+	test.Eventually(t, 5*time.Second, func(_ require.TestingT) {
+		startWg.Wait()
+	})
+	cancel()
+	test.Eventually(t, 5*time.Second, func(_ require.TestingT) {
+		doneWg.Wait()
+	})
+
+}


### PR DESCRIPTION
As the start of a progressive migration, we are removing the pipes library from the Process Metrics pipeline.

The pipes library has some inconveniences that might be a problem when we move most of the Beyla code to an OTEL repo:

* Despite nodes can be dynamically enabled/disabled, the architecture is static. This difficults expanding the topology with new functionalities outside of the original pipeline definition.
* It's opinionated and "magic". It might be difficult to troubleshoot by people not knowing its internals.

We are going to replace it with two simpler structures: queues and swarm.

A Queue enables a simple publish/subscription mechanism that allows:
- Multiple subscribers to the same channel.
- Connecting/Bypassing queues

A Swarm is just a group of goroutine functions whose instantiation/error handling is coordinated from a single function.

This more flexible approach doesn't really require extra code, or more complex code, and greatly facilitates composition and connection of different pipelines (e.g. connecting two swarms, adding a swarm as a node of another swarm, etc...).

The inconvenience I see in the new approach:
* You must explicitly instantiate all the communication channels and pass them to the different nodes.
* There is no library control on wether nodes are well connected.