### PR TITLE
Add service name template

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"text/template"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
@@ -141,6 +142,18 @@ func buildCommonContextInfo(
 		showDeprecation()
 	}
 
+	var templ *template.Template
+
+	if config.Attributes.Kubernetes.ServiceNameTemplate != "" {
+		var err error
+
+		templ, err = template.New("serviceNameTemplate").Parse(config.Attributes.Kubernetes.ServiceNameTemplate)
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse service name template: %w", err)
+		}
+	}
+
 	promMgr := &connector.PrometheusManager{}
 	ctxInfo := &global.ContextInfo{
 		Prometheus: promMgr,
@@ -153,6 +166,7 @@ func buildCommonContextInfo(
 			MetaCacheAddr:     config.Attributes.Kubernetes.MetaCacheAddress,
 			ResourceLabels:    resourceLabels,
 			RestrictLocalNode: config.Attributes.Kubernetes.MetaRestrictLocalNode,
+			ServiceNameTemplate: templ,
 		}),
 	}
 	if config.Attributes.HostID.Override == "" {

--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"text/template"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +37,7 @@ type MetadataConfig struct {
 	MetaCacheAddr     string
 	ResourceLabels    ResourceLabels
 	RestrictLocalNode bool
+	ServiceNameTemplate *template.Template
 }
 
 type MetadataProvider struct {
@@ -107,7 +109,7 @@ func (mp *MetadataProvider) Get(ctx context.Context) (*Store, error) {
 		return nil, err
 	}
 
-	mp.metadata = NewStore(informer, mp.cfg.ResourceLabels)
+	mp.metadata = NewStore(informer, mp.cfg.ResourceLabels, mp.cfg.ServiceNameTemplate)
 
 	return mp.metadata, nil
 }

--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -186,7 +186,7 @@ func (s *Store) cacheResourceMetadata(meta *informer.ObjectMeta) *CachedObjMeta 
 			com.OTELResourceMeta[serviceNamespaceKey] = val
 		}
 	}
-	com.ServiceName, com.ServiceNamespace = s.serviceNameNamespaceForMetadata(meta)
+	com.ServiceName, com.ServiceNamespace = s.serviceNameNamespaceForMetadata(meta, "")
 	return &com
 }
 
@@ -362,21 +362,21 @@ func (s *Store) ObjectMetaByIP(ip string) *CachedObjMeta {
 	return s.objectMetaByIP[ip]
 }
 
-func (s *Store) ServiceNameNamespaceForMetadata(om *informer.ObjectMeta) (string, string) {
+func (s *Store) ServiceNameNamespaceForMetadata(om *informer.ObjectMeta, containerName string) (string, string) {
 	s.access.RLock()
 	defer s.access.RUnlock()
-	return s.serviceNameNamespaceForMetadata(om)
+	return s.serviceNameNamespaceForMetadata(om, containerName)
 }
 
 // TODO: this function can be probably simplified, as it is used to build a CachedObjectMeta
 // that already contains the metadata
-func (s *Store) serviceNameNamespaceForMetadata(om *informer.ObjectMeta) (string, string) {
+func (s *Store) serviceNameNamespaceForMetadata(om *informer.ObjectMeta, containerName string) (string, string) {
 	var name string
 	var namespace string
 	if owner := TopOwner(om.Pod); owner != nil {
-		name, namespace = s.serviceNameNamespaceOwnerID(om, owner.Name)
+		name, namespace = s.serviceNameNamespaceOwnerID(om, owner.Name, containerName)
 	} else {
-		name, namespace = s.serviceNameNamespaceOwnerID(om, om.Name)
+		name, namespace = s.serviceNameNamespaceOwnerID(om, om.Name, containerName)
 	}
 	return name, namespace
 }
@@ -415,7 +415,7 @@ func (s *Store) ServiceNameNamespaceForIP(ip string) (string, string) {
 
 	name, namespace := "", ""
 	if om, ok := s.objectMetaByIP[ip]; ok {
-		name, namespace = s.serviceNameNamespaceForMetadata(om.Meta)
+		name, namespace = s.serviceNameNamespaceForMetadata(om.Meta, "")
 	}
 
 	s.otelServiceInfoByIP[ip] = OTelServiceNamePair{Name: name, Namespace: namespace}
@@ -429,7 +429,7 @@ func (s *Store) ServiceNameNamespaceForIP(ip string) (string, string) {
 // 2. Resource attributes set via annotations (with the resource.opentelemetry.io/ prefix)
 // 3. Resource attributes set via labels (e.g. app.kubernetes.io/name)
 // 4. Resource attributes calculated from the owner's metadata (e.g. k8s.deployment.name) or pod's metadata (e.g. k8s.pod.name)
-func (s *Store) serviceNameNamespaceOwnerID(om *informer.ObjectMeta, ownerName string) (string, string) {
+func (s *Store) serviceNameNamespaceOwnerID(om *informer.ObjectMeta, ownerName string, containerName string) (string, string) {
 	// ownerName can be the top Owner name, or om.Name in case it's a pod without owner
 	serviceName := ownerName
 	serviceNamespace := om.Namespace
@@ -442,7 +442,14 @@ func (s *Store) serviceNameNamespaceOwnerID(om *informer.ObjectMeta, ownerName s
 	} else if s.serviceNameTemplate != nil {
 		// defining a serviceNameTemplate disables the resolution via annotation + label (this can be implemented in the template)
 		var serviceNameBuffer bytes.Buffer
-		err := s.serviceNameTemplate.Execute(&serviceNameBuffer, om)
+		ctx := struct{
+			Meta *informer.ObjectMeta
+			ContainerName string
+		}{
+			Meta: om,
+			ContainerName: containerName,
+		}
+		err := s.serviceNameTemplate.Execute(&serviceNameBuffer, ctx)
 
 		if err != nil {
 			s.log.Error("error executing service name template", "error", err)

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -133,7 +133,7 @@ func (md *metadataDecorator) appendMetadata(span *request.Span, meta *kube.Cache
 		return
 	}
 	topOwner := kube.TopOwner(meta.Meta.Pod)
-	name, namespace := md.db.ServiceNameNamespaceForMetadata(meta.Meta)
+	name, namespace := md.db.ServiceNameNamespaceForMetadata(meta.Meta, containerName)
 	// If the user has not defined criteria values for the reported
 	// service name and namespace, we will automatically set it from
 	// the kubernetes metadata

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -64,6 +64,9 @@ type KubernetesDecorator struct {
 	// ResourceLabels allows Beyla overriding the OTEL Resource attributes from a map of user-defined labels.
 	// nolint:undoc
 	ResourceLabels kube.ResourceLabels `yaml:"resource_labels"`
+
+	// ServiceNameTemplate allows to override the service.name with a custom value. Uses the go template language.
+	ServiceNameTemplate string `yaml:"service_name_template" env:"BEYLA_SERVICE_NAME_TEMPLATE"`
 }
 
 const (


### PR DESCRIPTION
**This PR is a proof of concept and not ready to be merged.**

feature #1811

Adds a new configuration for a template under attributes.kubernetes.service_name_template

Adds ability to define the service.name based the ObjectMeta and ContainerName.

An example template that's possible:

```
{{- .Meta.Namespace }}/{{ index .Meta.Labels "app.kubernetes.io/name" }}/{{ index .Meta.Labels "app.kubernetes.io/component" -}}{{ if .ContainerName }}/{{ .ContainerName -}}{{ end -}}
```

I'm not sure about the implication in store.go:150 (cacheResourceMetadata) and store.go:405 (ServiceNameNamespaceForIP).

ServiceNameNamespaceForIP: figuring out the container name is probably hard / impossible 
cacheResourceMetadata: I think the ServiceName and ServiceNamespace is wrongly written into the cache anyways, so probably it doesn't matter, and it's overwritten in k8s.go:129 (appendMetadata). Specifically it reads the service name from the env var for each container, but overrides each of them, and in the end anyways loads it from the ServiceNameNamespace function.

