### PR TITLE
Fetch cluster name from nodes labels

### DIFF
--- a/pkg/internal/kube/informer_provider.go
+++ b/pkg/internal/kube/informer_provider.go
@@ -23,6 +23,16 @@ const (
 	kubeConfigEnvVariable = "KUBECONFIG"
 )
 
+// Some cloud providers store the cluster name as a Node label.
+// This greatly facilitates the retrieval of the cluster name, as we
+// don't need to rely on provider-specific APIs.
+// TODO: update with labels from other providers, or newer labels as long as specs are updated
+var clusterNameNodeLabels = []string{
+	"alpha.eksctl.io/cluster-name",
+	"cluster.x-k8s.io/cluster-name",
+	"kubernetes.azure.com/cluster",
+}
+
 func klog() *slog.Logger {
 	return slog.With("component", "kube.MetadataProvider")
 }
@@ -45,6 +55,7 @@ type MetadataProvider struct {
 	informer meta.Notifier
 
 	localNodeName string
+	clusterName   string
 
 	cfg *MetadataConfig
 }
@@ -141,6 +152,22 @@ func (mp *MetadataProvider) CurrentNodeName(ctx context.Context) (string, error)
 	return mp.localNodeName, nil
 }
 
+func (mp *MetadataProvider) ClusterName(ctx context.Context) (string, error) {
+	if mp.clusterName != "" {
+		return mp.clusterName, nil
+	}
+	// make sure that node name has been fetched and cached previously
+	if _, err := mp.CurrentNodeName(ctx); err != nil {
+		return "", fmt.Errorf("can't get node name before getting Cluster name: %w", err)
+	}
+	if cn, err := mp.fetchClusterNameFromNodeLabels(ctx); err != nil {
+		return "", err
+	} else {
+		mp.clusterName = cn
+	}
+	return mp.clusterName, nil
+}
+
 func (mp *MetadataProvider) fetchNodeName(ctx context.Context) (string, error) {
 	log := klog().With("func", "fetchNodeName")
 	kubeClient, err := mp.KubeClient()
@@ -164,6 +191,23 @@ func (mp *MetadataProvider) fetchNodeName(ctx context.Context) (string, error) {
 		return checkLocalHostNameWithNodeName(ctx, log, kubeClient, podHostName)
 	}
 	return pods.Items[0].Spec.NodeName, nil
+}
+
+func (mp *MetadataProvider) fetchClusterNameFromNodeLabels(ctx context.Context) (string, error) {
+	kubeClient, err := mp.KubeClient()
+	if err != nil {
+		return "", fmt.Errorf("can't get kubernetes client: %w", err)
+	}
+	node, err := kubeClient.CoreV1().Nodes().Get(ctx, mp.localNodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("fetchClusterNameFromNodeLabels getting node %s: %w", mp.localNodeName, err)
+	}
+	for _, label := range clusterNameNodeLabels {
+		if name, ok := node.Labels[label]; ok {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no cluster name found in node labels")
 }
 
 func currentNamespace(log *slog.Logger) string {

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -85,7 +85,7 @@ func KubeDecoratorProvider(
 		if err != nil {
 			return nil, fmt.Errorf("inititalizing KubeDecoratorProvider: %w", err)
 		}
-		decorator := &metadataDecorator{db: metaStore, clusterName: KubeClusterName(ctx, cfg)}
+		decorator := &metadataDecorator{db: metaStore, clusterName: KubeClusterName(ctx, cfg, ctxInfo.K8sInformer)}
 		return decorator.nodeLoop, nil
 	}
 }
@@ -194,7 +194,7 @@ func OwnerLabelName(kind string) attr.Name {
 	}
 }
 
-func KubeClusterName(ctx context.Context, cfg *KubernetesDecorator) string {
+func KubeClusterName(ctx context.Context, cfg *KubernetesDecorator, k8sInformer *kube.MetadataProvider) string {
 	log := klog().With("func", "KubeClusterName")
 	if cfg.ClusterName != "" {
 		log.Debug("using cluster name from configuration", "cluster_name", cfg.ClusterName)
@@ -202,7 +202,7 @@ func KubeClusterName(ctx context.Context, cfg *KubernetesDecorator) string {
 	}
 	retries := 0
 	for retries < clusterMetadataRetries {
-		if clusterName := fetchClusterName(ctx); clusterName != "" {
+		if clusterName := fetchClusterName(ctx, k8sInformer); clusterName != "" {
 			return clusterName
 		}
 		retries++

--- a/test/integration/configs/instrumenter-config-go-otel-grpc.yml
+++ b/test/integration/configs/instrumenter-config-go-otel-grpc.yml
@@ -9,7 +9,7 @@ otel_traces_export:
   endpoint: http://jaeger:4318
 attributes:
   kubernetes:
-    cluster_name: beyla
+    cluster_name: beyla-k8s-test-cluster
   select:
     "*":
       include: ["*"]

--- a/test/integration/configs/instrumenter-config-go-otel.yml
+++ b/test/integration/configs/instrumenter-config-go-otel.yml
@@ -6,7 +6,7 @@ otel_traces_export:
   endpoint: http://jaeger:4318
 attributes:
   kubernetes:
-    cluster_name: beyla
+    cluster_name: beyla-k8s-test-cluster
   select:
     "*":
       include: ["*"]

--- a/test/integration/configs/instrumenter-config-promscrape.yml
+++ b/test/integration/configs/instrumenter-config-promscrape.yml
@@ -27,4 +27,4 @@ attributes:
     "*":
       include: ["*"]
   kubernetes:
-    cluster_name: beyla
+    cluster_name: beyla-k8s-test-cluster

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -11,7 +11,7 @@ otel_traces_export:
   endpoint: http://jaeger:4318
 attributes:
   kubernetes:
-    cluster_name: beyla
+    cluster_name: beyla-k8s-test-cluster
     resource_labels:
       deployment.environment: ["deployment.environment"]
   select:

--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -112,7 +112,7 @@ func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]stri
 		"k8s_owner_name":           "^testserver$",
 		"k8s_deployment_name":      "^testserver$",
 		"k8s_replicaset_name":      "^testserver-",
-		"k8s_cluster_name":         "^beyla$",
+		"k8s_cluster_name":         "^beyla-k8s-test-cluster$",
 		"server_service_namespace": "integration-test",
 		"server":                   "testserver",
 		"source":                   "beyla",
@@ -203,7 +203,7 @@ func FeatureGRPCMetricsDecoration(manifest string, overrideAttrs map[string]stri
 		"k8s_node_name":          ".+-control-plane$",
 		"k8s_pod_uid":            UUIDRegex,
 		"k8s_pod_start_time":     TimeRegex,
-		"k8s_cluster_name":       "^beyla$",
+		"k8s_cluster_name":       "^beyla-k8s-test-cluster",
 		"k8s_owner_name":         "^testserver$",
 		"k8s_deployment_name":    "^testserver$",
 		"k8s_replicaset_name":    "^testserver-",
@@ -246,7 +246,7 @@ func FeatureProcessMetricsDecoration(overrideProperties map[string]string) featu
 		"k8s_pod_start_time":  TimeRegex,
 		"k8s_deployment_name": "^testserver$",
 		"k8s_replicaset_name": "^testserver-",
-		"k8s_cluster_name":    "^beyla$",
+		"k8s_cluster_name":    "^beyla-k8s-test-cluster",
 	}
 	for k, v := range overrideProperties {
 		properties[k] = v
@@ -278,7 +278,7 @@ func FeatureDisableInformersAppMetricsDecoration() features.Feature {
 					"k8s_pod_start_time":  TimeRegex,
 					"k8s_deployment_name": "^testserver$",
 					"k8s_replicaset_name": "^testserver-.*",
-					"k8s_cluster_name":    "^beyla$",
+					"k8s_cluster_name":    "^beyla-k8s-test-cluster$",
 					"service_instance_id": "^default\\.testserver-.+\\.testserver",
 				})).Feature()
 }

--- a/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_traces_test.go
@@ -76,7 +76,7 @@ func TestBasicTracing(t *testing.T) {
 						{Key: "k8s.owner.name", Type: "string", Value: "^otherinstance$"},
 						{Key: "k8s.deployment.name", Type: "string", Value: "^otherinstance$"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd)
 
@@ -153,7 +153,7 @@ func TestBasicTracing(t *testing.T) {
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.deployment.name", Type: "string", Value: "^otherinstance"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd)
 

--- a/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
+++ b/test/integration/k8s/daemonset_python/k8s_daemonset_traces_test.go
@@ -67,7 +67,7 @@ func TestPythonBasicTracing(t *testing.T) {
 						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 						{Key: "service.instance.id", Type: "string", Value: "^default\\.pytestserver-.+\\.pytestserver"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd, sd.String())
@@ -125,7 +125,7 @@ func TestPythonBasicTracing(t *testing.T) {
 						{Key: "k8s.pod.uid", Type: "string", Value: k8s.UUIDRegex},
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 						{Key: "service.instance.id", Type: "string", Value: "^default\\.pytestserver-.+\\.pytestserver"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd, sd.String())

--- a/test/integration/k8s/manifests/00-kind-multi-node.yml
+++ b/test/integration/k8s/manifests/00-kind-multi-node.yml
@@ -3,6 +3,8 @@ kind: Cluster
 name: beyla
 nodes:
   - role: worker
+    labels:
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -25,6 +27,8 @@ nodes:
       - containerPort: 8080
         hostPort: 38080
   - role: worker
+    labels:
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -65,6 +69,8 @@ nodes:
       - containerPort: 16686
         hostPort: 36686
   - role: control-plane
+    labels:
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
     extraMounts:
       # configuration files that need to be mounted in the host
       - hostPath: ../../configs

--- a/test/integration/k8s/manifests/00-kind-multi-zone.yml
+++ b/test/integration/k8s/manifests/00-kind-multi-zone.yml
@@ -4,6 +4,7 @@ name: beyla
 nodes:
   - role: control-plane
     labels:
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
       # faking a multi-zone cluster
       topology.kubernetes.io/zone: control-plane-zone
     extraMounts:
@@ -17,6 +18,7 @@ nodes:
     labels:
       # faking a multi-zone cluster
       topology.kubernetes.io/zone: server-zone
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
     extraMounts:
       # configuration files that need to be mounted in the host
       - hostPath: ../../configs
@@ -28,6 +30,7 @@ nodes:
     labels:
       # faking a multi-zone cluster
       topology.kubernetes.io/zone: client-zone
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
       # otel collector / prom scraper needs to be placed here, due to port mappings
       deployment/zone: otel
     extraMounts:

--- a/test/integration/k8s/manifests/00-kind.yml
+++ b/test/integration/k8s/manifests/00-kind.yml
@@ -3,6 +3,8 @@ kind: Cluster
 name: beyla
 nodes:
   - role: control-plane
+    labels:
+      cluster.x-k8s.io/cluster-name: beyla-k8s-test-cluster
     extraMounts:
       # configuration files that need to be mounted in the host
       - hostPath: ../../configs

--- a/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -114,7 +114,5 @@ spec:
               value: "autodetect"
             - name: BEYLA_OTEL_METRIC_FEATURES 
               value: "application,application_span,application_service_graph,application_process"
-            - name: BEYLA_KUBE_CLUSTER_NAME
-              value: "beyla"
             - name: BEYLA_NAME_RESOLVER_SOURCES
               value: "dns,k8s"

--- a/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -126,8 +126,6 @@ spec:
               value: "application,application_span,application_service_graph,application_process"
             - name: BEYLA_OTEL_METRICS_TTL
               value: "30m0s"
-            - name: BEYLA_KUBE_CLUSTER_NAME
-              value: "beyla"
             - name: BEYLA_NAME_RESOLVER_SOURCES
               value: "dns,k8s"
           ports:

--- a/test/integration/k8s/manifests/06-beyla-all-processes.yml
+++ b/test/integration/k8s/manifests/06-beyla-all-processes.yml
@@ -27,7 +27,6 @@ data:
           include: ["*"]
       kubernetes:
         enable: true
-        cluster_name: beyla
         resource_labels:
           deployment.environment: ["deployment.environment"]
     trace_printer: text

--- a/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: beyla
         disable_informers:
           - replicaset
           - node

--- a/test/integration/k8s/manifests/06-beyla-daemonset-multi-node-l7.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-multi-node-l7.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: beyla
         resource_labels:
           deployment.environment: ["deployment.environment"]
     trace_printer: text

--- a/test/integration/k8s/manifests/06-beyla-daemonset-multi-node.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-multi-node.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: beyla
         resource_labels:
           deployment.environment: ["deployment.environment"]
     trace_printer: text

--- a/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-python.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: beyla
         resource_labels:
           deployment.environment: ["deployment.environment"]
     trace_printer: text

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: beyla
         resource_labels:
           deployment.environment: ["deployment.environment"]
       select:

--- a/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
@@ -7,7 +7,6 @@ data:
     attributes:
       kubernetes:
         enable: true
-        cluster_name: my-kube
         drop_external: true
         resource_labels:
           deployment.environment: ["deployment.environment"]
@@ -76,3 +75,5 @@ spec:
               value: "10ms"
             - name: BEYLA_BPF_BATCH_TIMEOUT
               value: "10ms"
+            - name: BEYLA_KUBE_CLUSTER_NAME
+              value: "beyla"

--- a/test/integration/k8s/otel/k8s_otel_traces_test.go
+++ b/test/integration/k8s/otel/k8s_otel_traces_test.go
@@ -63,7 +63,7 @@ func TestTracesDecoration(t *testing.T) {
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
 						{Key: "k8s.deployment.name", Type: "string", Value: "^testserver$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 						{Key: "service.instance.id", Type: "string", Value: "^default\\.testserver-.+\\.testserver"},
 					}, trace.Processes[parent.ProcessID].Tags)
 					require.Empty(t, sd, sd.String())

--- a/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_daemonset_metadata_test.go
@@ -68,7 +68,7 @@ func TestDaemonSetMetadata(t *testing.T) {
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.daemonset.name", Type: "string", Value: "^dsservice$"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 						{Key: "service.namespace", Type: "string", Value: "^default$"},
 						{Key: "service.instance.id", Type: "string", Value: "^default\\.dsservice-.+\\.dsservice"},
 					}, trace.Processes[parent.ProcessID].Tags)

--- a/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
+++ b/test/integration/k8s/owners/k8s_statefulset_metadata_test.go
@@ -68,7 +68,7 @@ func TestStatefulSetMetadata(t *testing.T) {
 						{Key: "k8s.pod.start_time", Type: "string", Value: k8s.TimeRegex},
 						{Key: "k8s.statefulset.name", Type: "string", Value: "^statefulservice$"},
 						{Key: "k8s.namespace.name", Type: "string", Value: "^default$"},
-						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla$"},
+						{Key: "k8s.cluster.name", Type: "string", Value: "^beyla-k8s-test-cluster$"},
 						{Key: "service.namespace", Type: "string", Value: "^default$"},
 						{Key: "service.instance.id", Type: "string", Value: "^default\\.statefulservice-.+\\.statefulservice"},
 					}, trace.Processes[parent.ProcessID].Tags)


### PR DESCRIPTION
Fixes https://github.com/grafana/beyla/issues/1322

The OTEL contrib library seems broken/outdated, as it is relying on some non-existing maps to get the cluster metadata (related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31300).

In the meanwhile, I realized that EKS already adds the cluster name as a Node label, so I added another simpler cluster name retrieving mechanism, based on Node labels, which will allow quickly expanding the functionality to any other cloud provider already using other labels for setting the cluster name.