### PR TITLE
Remove the mariomac/pipes library from the instrumenter pipeline

### DIFF
--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -1,7 +1,6 @@
 package alloy
 
 import (
-	"context"
 	"encoding/binary"
 	"math/rand/v2"
 	"strconv"
@@ -130,18 +129,14 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 
 func makeTracesTestReceiver() *tracesReceiver {
 	return &tracesReceiver{
-		ctx:        context.Background(),
-		cfg:        &beyla.TracesReceiverConfig{},
-		attributes: attributes.Selection{},
-		hostID:     "Alloy",
+		cfg:    &beyla.TracesReceiverConfig{},
+		hostID: "Alloy",
 	}
 }
 
 func makeTracesTestReceiverWithSpanMetrics() *tracesReceiver {
 	return &tracesReceiver{
-		ctx:                context.Background(),
 		cfg:                &beyla.TracesReceiverConfig{},
-		attributes:         attributes.Selection{},
 		hostID:             "Alloy",
 		spanMetricsEnabled: true,
 	}
@@ -149,14 +144,14 @@ func makeTracesTestReceiverWithSpanMetrics() *tracesReceiver {
 
 func generateTracesForSpans(t *testing.T, tr *tracesReceiver, spans []request.Span) []ptrace.Traces {
 	res := []ptrace.Traces{}
-	traceAttrs, err := tr.getConstantAttributes()
+	err := tr.fetchConstantAttributes(attributes.Selection{})
 	assert.NoError(t, err)
 	for i := range spans {
 		span := &spans[i]
 		if tr.spanDiscarded(span) {
 			continue
 		}
-		res = append(res, otel.GenerateTraces(span, tr.hostID, traceAttrs, []attribute.KeyValue{}))
+		res = append(res, otel.GenerateTraces(span, tr.hostID, tr.traceAttrs, []attribute.KeyValue{}))
 	}
 
 	return res

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -2,14 +2,14 @@
 package debug
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 
-	"github.com/mariomac/pipes/pipe"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 )
 
 type TracePrinter string
@@ -39,7 +39,7 @@ func (t TracePrinter) Enabled() bool {
 	return t.Valid() && t != TracePrinterDisabled
 }
 
-func resolvePrinterFunc(p TracePrinter) pipe.FinalFunc[[]request.Span] {
+func resolvePrinterFunc(p TracePrinter, input *msg.Queue[[]request.Span]) swarm.RunFunc {
 	const (
 		jsonIndent   = true
 		jsonNoIndent = false
@@ -47,67 +47,67 @@ func resolvePrinterFunc(p TracePrinter) pipe.FinalFunc[[]request.Span] {
 
 	switch p {
 	case TracePrinterText:
-		return textPrinter
+		return textPrinter(input)
 	case TracePrinterJSON:
-		return func(input <-chan []request.Span) { jsonPrinter(input, jsonNoIndent) }
+		return jsonPrinter(input, jsonNoIndent)
 	case TracePrinterJSONIndent:
-		return func(input <-chan []request.Span) { jsonPrinter(input, jsonIndent) }
+		return jsonPrinter(input, jsonIndent)
 	case TracePrinterCounter:
-		return makeCounterPrinter()
+		return counterPrinter(input)
 	}
 
-	return pipe.IgnoreFinal[[]request.Span]()
+	// do nothing
+	return func(_ context.Context) {}
 }
 
-func PrinterNode(p TracePrinter) pipe.FinalProvider[[]request.Span] {
-	printerFunc := resolvePrinterFunc(p)
-
-	return func() (pipe.FinalFunc[[]request.Span], error) {
-		return printerFunc, nil
-	}
+func PrinterNode(p TracePrinter, input *msg.Queue[[]request.Span]) swarm.InstanceFunc {
+	return swarm.DirectInstance(resolvePrinterFunc(p, input))
 }
 
-func textPrinter(input <-chan []request.Span) {
-	for spans := range input {
-		for i := range spans {
-			t := spans[i].Timings()
+func textPrinter(in *msg.Queue[[]request.Span]) swarm.RunFunc {
+	input := in.Subscribe()
+	return func(_ context.Context) {
+		for spans := range input {
+			for i := range spans {
+				t := spans[i].Timings()
 
-			pn := ""
-			hn := ""
+				pn := ""
+				hn := ""
 
-			if spans[i].IsClientSpan() {
-				if spans[i].Service.UID.Namespace != "" {
-					pn = "." + spans[i].Service.UID.Namespace
+				if spans[i].IsClientSpan() {
+					if spans[i].Service.UID.Namespace != "" {
+						pn = "." + spans[i].Service.UID.Namespace
+					}
+					if spans[i].OtherNamespace != "" {
+						hn = "." + spans[i].OtherNamespace
+					}
+				} else {
+					if spans[i].OtherNamespace != "" {
+						pn = "." + spans[i].OtherNamespace
+					}
+					if spans[i].Service.UID.Namespace != "" {
+						hn = "." + spans[i].Service.UID.Namespace
+					}
 				}
-				if spans[i].OtherNamespace != "" {
-					hn = "." + spans[i].OtherNamespace
-				}
-			} else {
-				if spans[i].OtherNamespace != "" {
-					pn = "." + spans[i].OtherNamespace
-				}
-				if spans[i].Service.UID.Namespace != "" {
-					hn = "." + spans[i].Service.UID.Namespace
-				}
+
+				fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] size:%dB svc=[%s %s] traceparent=[%s]\n",
+					t.Start.Format("2006-01-02 15:04:05.12345"),
+					t.End.Sub(t.RequestStart),
+					t.End.Sub(t.Start),
+					spans[i].Type,
+					spans[i].Status,
+					spans[i].Method,
+					spans[i].Path,
+					spans[i].Peer+" as "+request.SpanPeer(&spans[i])+pn,
+					spans[i].PeerPort,
+					spans[i].Host+" as "+request.SpanHost(&spans[i])+hn,
+					spans[i].HostPort,
+					spans[i].ContentLength,
+					&spans[i].Service,
+					spans[i].Service.SDKLanguage.String(),
+					traceparent(&spans[i]),
+				)
 			}
-
-			fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] size:%dB svc=[%s %s] traceparent=[%s]\n",
-				t.Start.Format("2006-01-02 15:04:05.12345"),
-				t.End.Sub(t.RequestStart),
-				t.End.Sub(t.Start),
-				spans[i].Type,
-				spans[i].Status,
-				spans[i].Method,
-				spans[i].Path,
-				spans[i].Peer+" as "+request.SpanPeer(&spans[i])+pn,
-				spans[i].PeerPort,
-				spans[i].Host+" as "+request.SpanHost(&spans[i])+hn,
-				spans[i].HostPort,
-				spans[i].ContentLength,
-				&spans[i].Service,
-				spans[i].Service.SDKLanguage.String(),
-				traceparent(&spans[i]),
-			)
 		}
 	}
 }
@@ -120,30 +120,33 @@ func serializeSpansJSON(spans []request.Span, indent bool) ([]byte, error) {
 	return json.Marshal(spans)
 }
 
-func jsonPrinter(input <-chan []request.Span, indent bool) {
-	for spans := range input {
-		data, err := serializeSpansJSON(spans, indent)
+func jsonPrinter(in *msg.Queue[[]request.Span], indent bool) swarm.RunFunc {
+	input := in.Subscribe()
+	return func(_ context.Context) {
+		for spans := range input {
+			data, err := serializeSpansJSON(spans, indent)
 
-		if err != nil {
-			mlog().Error("Error serializing span to json", "error", err)
-			continue
+			if err != nil {
+				mlog().Error("Error serializing span to json", "error", err)
+				continue
+			}
+
+			fmt.Printf("%s\n", data)
 		}
-
-		fmt.Printf("%s\n", data)
 	}
 }
 
 func traceparent(span *request.Span) string {
-	if !trace.TraceID(span.TraceID).IsValid() {
+	if !span.TraceID.IsValid() {
 		return ""
 	}
-	return fmt.Sprintf("00-%s-%s[%s]-%02x", trace.TraceID(span.TraceID).String(), trace.SpanID(span.SpanID).String(), trace.SpanID(span.ParentSpanID).String(), span.Flags)
+	return fmt.Sprintf("00-%s-%s[%s]-%02x", span.TraceID.String(), span.SpanID.String(), span.ParentSpanID.String(), span.Flags)
 }
 
-func makeCounterPrinter() pipe.FinalFunc[[]request.Span] {
+func counterPrinter(in *msg.Queue[[]request.Span]) swarm.RunFunc {
+	input := in.Subscribe()
 	counter := 0
-
-	return func(input <-chan []request.Span) {
+	return func(_ context.Context) {
 		for spans := range input {
 			counter += len(spans)
 		}

--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 func TestTracePrinterValidEnabled(t *testing.T) {
@@ -74,16 +75,16 @@ func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
 	stdout := os.Stdout
 	os.Stdout = w
 
-	spanCh := make(chan []request.Span)
+	spanCh := msg.NewQueue[[]request.Span]()
 
+	f := resolvePrinterFunc(tracePrinter, spanCh)
 	go func() {
-		f := resolvePrinterFunc(tracePrinter)
-		f(spanCh)
+		f(t.Context())
 		w.Close()
 	}()
 
-	spanCh <- []request.Span{fakeSpan}
-	close(spanCh)
+	spanCh.Send([]request.Span{fakeSpan})
+	spanCh.Close()
 
 	funcOutput, err := io.ReadAll(r)
 	r.Close()
@@ -168,10 +169,4 @@ func TestTracePrinterResolve_PrinterJSONIndent(t *testing.T) {
 	actual := traceFuncHelper(t, TracePrinterJSONIndent)
 	assert.True(t, strings.HasPrefix(actual, prefix))
 	assert.True(t, strings.HasSuffix(actual, suffix))
-}
-
-func TestTracePrinterResolve_PrinterDisabledInvalid(t *testing.T) {
-	assert.Nil(t, resolvePrinterFunc(TracePrinterDisabled))
-	assert.Nil(t, resolvePrinterFunc(TracePrinter("")))
-	assert.Nil(t, resolvePrinterFunc(TracePrinter("INVALID")))
 }

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mariomac/pipes/pipe"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -30,6 +29,8 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 )
 
 func mlog() *slog.Logger {
@@ -215,6 +216,7 @@ type MetricsReporter struct {
 	attrGPUKernelGridSize     []attributes.Field[*request.Span, attribute.KeyValue]
 	attrGPUKernelBlockSize    []attributes.Field[*request.Span, attribute.KeyValue]
 	attrGPUMemoryAllocations  []attributes.Field[*request.Span, attribute.KeyValue]
+	input                     <-chan []request.Span
 }
 
 // Metrics is a set of metrics associated to a given OTEL MeterProvider.
@@ -250,18 +252,18 @@ type Metrics struct {
 }
 
 func ReportMetrics(
-	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
 	userAttribSelection attributes.Selection,
-) pipe.FinalProvider[[]request.Span] {
-	return func() (pipe.FinalFunc[[]request.Span], error) {
+	input *msg.Queue[[]request.Span],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
 		if !cfg.Enabled() {
-			return pipe.IgnoreFinal[[]request.Span](), nil
+			return swarm.EmptyRunFunc()
 		}
 		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
-		mr, err := newMetricsReporter(ctx, ctxInfo, cfg, userAttribSelection)
+		mr, err := newMetricsReporter(ctx, ctxInfo, cfg, userAttribSelection, input)
 		if err != nil {
 			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
 		}
@@ -284,6 +286,7 @@ func newMetricsReporter(
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
 	userAttribSelection attributes.Selection,
+	input *msg.Queue[[]request.Span],
 ) (*MetricsReporter, error) {
 	log := mlog()
 
@@ -294,12 +297,18 @@ func newMetricsReporter(
 
 	is := instrumentations.NewInstrumentationSelection(cfg.Instrumentations)
 
+	// swarm.Instancer will cancel the passed InstanceFunc context once all the nodes
+	// are instanced, so we remove the cancellation from the context to avoid
+	// cancelling the metrics reporter
+	ctx = context.WithoutCancel(ctx)
+
 	mr := MetricsReporter{
 		ctx:        ctx,
 		cfg:        cfg,
 		is:         is,
 		attributes: attribProvider,
 		hostID:     ctxInfo.HostID,
+		input:      input.Subscribe(),
 	}
 	// initialize attribute getters
 	if is.HTTPEnabled() {
@@ -346,7 +355,7 @@ func newMetricsReporter(
 		func(id svc.UID, v *expirable[*Metrics]) {
 			if mr.cfg.SpanMetricsEnabled() {
 				attrOpt := instrument.WithAttributeSet(mr.metricResourceAttributes(v.value.service))
-				v.value.tracesTargetInfo.Add(mr.ctx, 1, attrOpt)
+				v.value.tracesTargetInfo.Add(ctx, 1, attrOpt)
 			}
 
 			llog := log.With("service", id)
@@ -975,8 +984,8 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 	}
 }
 
-func (mr *MetricsReporter) reportMetrics(input <-chan []request.Span) {
-	for spans := range input {
+func (mr *MetricsReporter) reportMetrics(_ context.Context) {
+	for spans := range mr.input {
 		for i := range spans {
 			s := &spans[i]
 			if s.InternalSignal() {

--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -12,24 +13,26 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/netolly/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/testutil"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 const timeout = 5 * time.Second
 
 func TestAttributeFilter(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
 	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
 		"beyla.ip":          MatchDefinition{Match: "148.*"},
 		"k8s.src.namespace": MatchDefinition{NotMatch: "debug"},
-	}, ebpf.RecordStringGetters)()
+	}, ebpf.RecordStringGetters, input, output)(context.Background())
 	require.NoError(t, err)
 
-	in := make(chan []*ebpf.Record, 10)
-	defer close(in)
-	out := make(chan []*ebpf.Record, 10)
-	go filterFunc(in, out)
+	out := output.Subscribe()
+	go filterFunc(context.Background())
 
 	// records not matching both the ip and src namespace will be dropped
-	in <- []*ebpf.Record{
+	input.Send([]*ebpf.Record{
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "148.132.1.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "debug"}}},
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "128.132.1.1",
@@ -40,23 +43,23 @@ func TestAttributeFilter(t *testing.T) {
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "tralar"}}},
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "141.132.1.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "tralari"}}},
-	}
+	})
 
 	// the whole batch will be dropped (won't go to the out channel)
-	in <- []*ebpf.Record{
+	input.Send([]*ebpf.Record{
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "128.132.1.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "foo"}}},
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "141.132.1.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "tralari"}}},
-	}
+	})
 
 	// no record will be dropped
-	in <- []*ebpf.Record{
+	input.Send([]*ebpf.Record{
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "148.132.1.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "foo"}}},
 		{Attrs: ebpf.RecordAttrs{BeylaIP: "148.133.2.1",
 			Metadata: map[attr.Name]string{"k8s.src.namespace": "tralar"}}},
-	}
+	})
 
 	filtered := testutil.ReadChannel(t, out, timeout)
 	assert.Equal(t, []*ebpf.Record{
@@ -94,7 +97,9 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
-			_, err := ByAttribute[*ebpf.Record](tc, ebpf.RecordStringGetters)()
+			input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+			output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+			_, err := ByAttribute[*ebpf.Record](tc, ebpf.RecordStringGetters, input, output)(context.Background())
 			assert.Error(t, err)
 		})
 	}
@@ -102,29 +107,29 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 
 func TestAttributeFilter_SpanMetrics(t *testing.T) {
 	// if the attributes are not existing, we should just ignore them
+	input := msg.NewQueue[[]*request.Span](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*request.Span](msg.ChannelBufferLen(10))
 	filterFunc, err := ByAttribute[*request.Span](AttributeFamilyConfig{
 		"client": MatchDefinition{NotMatch: "filtered"},
 		"server": MatchDefinition{NotMatch: "filtered"},
-	}, request.SpanPromGetters)()
+	}, request.SpanPromGetters, input, output)(context.Background())
 	require.NoError(t, err)
 
-	in := make(chan []*request.Span, 10)
-	defer close(in)
-	out := make(chan []*request.Span, 10)
-	go filterFunc(in, out)
+	out := output.Subscribe()
+	go filterFunc(context.Background())
 
 	// will drop filtered events
-	in <- []*request.Span{
+	input.Send([]*request.Span{
 		{Type: request.EventTypeHTTP, PeerName: "someclient", Host: "filtered"},
 		{Type: request.EventTypeHTTPClient, PeerName: "filtered", Host: "someserver"},
 		{Type: request.EventTypeHTTPClient, PeerName: "aserver", Host: "aclient"},
-	}
+	})
 
 	// no record will be dropped
-	in <- []*request.Span{
+	input.Send([]*request.Span{
 		{Type: request.EventTypeHTTP, PeerName: "client", Host: "server"},
 		{Type: request.EventTypeHTTPClient, PeerName: "server", Host: "client"},
-	}
+	})
 
 	filtered := testutil.ReadChannel(t, out, timeout)
 	assert.Equal(t, []*request.Span{

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/pipe"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 func log() *slog.Logger {
@@ -28,7 +29,7 @@ type Instrumenter struct {
 
 	// tracesInput is used to communicate the found traces between the ProcessFinder and
 	// the ProcessTracer.
-	tracesInput chan []request.Span
+	tracesInput *msg.Queue[[]request.Span]
 }
 
 // New Instrumenter, given a Config
@@ -38,7 +39,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 		ctx:         ctx,
 		config:      config,
 		ctxInfo:     ctxInfo,
-		tracesInput: make(chan []request.Span, config.ChannelBufferLen),
+		tracesInput: msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen)),
 	}
 }
 

--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -18,13 +18,14 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type ProcessFinder struct {
 	ctx         context.Context
 	cfg         *beyla.Config
 	ctxInfo     *global.ContextInfo
-	tracesInput chan<- []request.Span
+	tracesInput *msg.Queue[[]request.Span]
 }
 
 // nodesMap stores ProcessFinder pipeline architecture
@@ -60,7 +61,7 @@ func containerDBUpdater(pf *nodesMap) *pipe.Middle[[]Event[ebpf.Instrumentable],
 }
 func traceAttacher(pf *nodesMap) *pipe.Final[[]Event[ebpf.Instrumentable]] { return &pf.TraceAttacher }
 
-func NewProcessFinder(ctx context.Context, cfg *beyla.Config, ctxInfo *global.ContextInfo, tracesInput chan<- []request.Span) *ProcessFinder {
+func NewProcessFinder(ctx context.Context, cfg *beyla.Config, ctxInfo *global.ContextInfo, tracesInput *msg.Queue[[]request.Span]) *ProcessFinder {
 	return &ProcessFinder{ctx: ctx, cfg: cfg, ctxInfo: ctxInfo, tracesInput: tracesInput}
 }
 

--- a/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type Tracer struct{}
@@ -38,7 +39,7 @@ func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}
 func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool                   { return false }
-func (p *Tracer) Run(_ context.Context, _ chan<- []request.Span)         {}
+func (p *Tracer) Run(_ context.Context, _ *msg.Queue[[]request.Span])    {}
 func (p *Tracer) Constants() map[string]any                              { return nil }
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/gotracer/gotracer.c -- -I../../../../bpf -DNO_HEADER_PROPAGATION
@@ -412,7 +413,7 @@ func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool {
 	return false
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan chan<- []request.Span) {
+func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span]) {
 	ebpfcommon.SharedRingbuf(
 		p.cfg,
 		p.pidsFilter,

--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type gpu_kernel_launch_t -type gpu_malloc_t -target amd64,arm64 bpf ../../../../bpf/gpuevent/gpuevent.c -- -I../../../../bpf
@@ -213,7 +214,7 @@ func (p *Tracer) AlreadyInstrumentedLib(id uint64) bool {
 	return module != nil
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan chan<- []request.Span) {
+func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span]) {
 	ebpfcommon.ForwardRingbuf(
 		&p.cfg.EBPF,
 		p.bpfObjects.Rb,

--- a/pkg/internal/ebpf/httptracer/httptracer.go
+++ b/pkg/internal/ebpf/httptracer/httptracer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/httptracer/httptracer.c -- -I../../../../bpf
@@ -142,7 +143,7 @@ func (p *Tracer) startTC(ctx context.Context) {
 	p.ifaceManager.Start(ctx)
 }
 
-func (p *Tracer) Run(ctx context.Context, _ chan<- []request.Span) {
+func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
 	p.startTC(ctx)
 
 	errorCh := p.tcManager.Errors()

--- a/pkg/internal/ebpf/httptracer/httptracer_notlinux.go
+++ b/pkg/internal/ebpf/httptracer/httptracer_notlinux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type Tracer struct{}
@@ -37,7 +38,7 @@ func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}
 func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool                   { return false }
-func (p *Tracer) Run(_ context.Context, _ chan<- []request.Span)         {}
+func (p *Tracer) Run(_ context.Context, _ *msg.Queue[[]request.Span])    {}
 func (p *Tracer) Constants() map[string]any                              { return nil }
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/tctracer/tctracer.c -- -I../../../../bpf -I../../../../bpf
@@ -137,7 +138,7 @@ func (p *Tracer) startTC(ctx context.Context) {
 	p.ifaceManager.Start(ctx)
 }
 
-func (p *Tracer) Run(ctx context.Context, _ chan<- []request.Span) {
+func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
 	p.startTC(ctx)
 
 	errorCh := p.tcManager.Errors()

--- a/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
+++ b/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type Tracer struct{}
@@ -37,7 +38,7 @@ func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}
 func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool                   { return false }
-func (p *Tracer) Run(_ context.Context, _ chan<- []request.Span)         {}
+func (p *Tracer) Run(_ context.Context, _ *msg.Queue[[]request.Span])    {}
 func (p *Tracer) Constants() map[string]any                              { return nil }
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 bpf ../../../../bpf/tpinjector/tpinjector.c -- -I../../../../bpf -I../../../../bpf
@@ -159,7 +160,7 @@ func (p *Tracer) AlreadyInstrumentedLib(uint64) bool {
 	return false
 }
 
-func (p *Tracer) Run(ctx context.Context, _ chan<- []request.Span) {
+func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
 	p.log.Debug("tpinjector started")
 
 	<-ctx.Done()

--- a/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type Tracer struct{}
@@ -37,7 +38,7 @@ func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}
 func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool                   { return false }
-func (p *Tracer) Run(_ context.Context, _ chan<- []request.Span)         {}
+func (p *Tracer) Run(_ context.Context, _ *msg.Queue[[]request.Span])    {}
 func (p *Tracer) Constants() map[string]any                              { return nil }
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type Instrumentable struct {
@@ -96,7 +97,7 @@ type Tracer interface {
 	ProcessBinary(*exec.FileInfo)
 	// Run will do the action of listening for eBPF traces and forward them
 	// periodically to the output channel.
-	Run(context.Context, chan<- []request.Span)
+	Run(context.Context, *msg.Queue[[]request.Span])
 }
 
 // Subset of the above interface, which supports loading eBPF programs which

--- a/pkg/internal/ebpf/tracer_darwin.go
+++ b/pkg/internal/ebpf/tracer_darwin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 type instrumenter struct {
@@ -15,7 +16,7 @@ type instrumenter struct {
 
 // dummy implementations to avoid compilation errors in Darwin.
 // The tracer component is only usable in Linux.
-func (pt *ProcessTracer) Run(_ context.Context, _ chan<- []request.Span) {}
+func (pt *ProcessTracer) Run(_ context.Context, _ *msg.Queue[[]request.Span]) {}
 
 func NewProcessTracer(_ *beyla.Config, _ ProcessTracerType, _ []Tracer) *ProcessTracer {
 	return nil

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/goexec"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 )
 
 const PinInternal = ebpf.PinType(100)
@@ -104,7 +105,7 @@ func NewProcessTracer(cfg *beyla.Config, tracerType ProcessTracerType, programs 
 	}
 }
 
-func (pt *ProcessTracer) Run(ctx context.Context, out chan<- []request.Span) {
+func (pt *ProcessTracer) Run(ctx context.Context, out *msg.Queue[[]request.Span]) {
 	pt.log = ptlog().With("type", pt.Type)
 
 	pt.log.Debug("starting process tracer")

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -3,8 +3,6 @@ package pipe
 import (
 	"context"
 
-	"github.com/mariomac/pipes/pipe"
-
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/alloy"
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
@@ -18,119 +16,83 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/traces"
 	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 	"github.com/grafana/beyla/v2/pkg/transform"
 )
-
-// nodesMap provides the architecture of the whole processing pipeline:
-// each node and which nodes are they connected to
-type nodesMap struct {
-	TracesReader pipe.Start[[]request.Span]
-
-	// Routes is an optional pipe. If not enabled, data will be bypassed to the next stage in the pipeline.
-	Routes pipe.Middle[[]request.Span, []request.Span]
-
-	// Kubernetes is an optional pipe. If not enabled, data will be bypassed to the exporters.
-	Kubernetes pipe.Middle[[]request.Span, []request.Span]
-
-	NameResolver pipe.Middle[[]request.Span, []request.Span]
-
-	AttributeFilter pipe.Middle[[]request.Span, []request.Span]
-
-	AlloyTraces pipe.Final[[]request.Span]
-	Metrics     pipe.Final[[]request.Span]
-	Traces      pipe.Final[[]request.Span]
-	Prometheus  pipe.Final[[]request.Span]
-	BpfMetrics  pipe.Final[[]request.Span]
-	Printer     pipe.Final[[]request.Span]
-
-	ProcessReport pipe.Final[[]request.Span]
-}
-
-// Connect must specify how the above nodes are connected. Nodes that are disabled
-// at build time will be Bypassed (e.g. if the Routes node is disabled, the pipes library
-// will directly connect TracesReader to Kubernetes node).
-func (n *nodesMap) Connect() {
-	n.TracesReader.SendTo(n.Routes)
-	n.Routes.SendTo(n.Kubernetes)
-	n.Kubernetes.SendTo(n.NameResolver)
-	n.NameResolver.SendTo(n.AttributeFilter)
-	n.AttributeFilter.SendTo(n.AlloyTraces, n.Metrics, n.Traces, n.Prometheus, n.Printer, n.ProcessReport)
-}
-
-// accessor functions to each field. Grouped here for code brevity during the pipeline build
-func tracesReader(n *nodesMap) *pipe.Start[[]request.Span]                  { return &n.TracesReader }
-func router(n *nodesMap) *pipe.Middle[[]request.Span, []request.Span]       { return &n.Routes }
-func kubernetes(n *nodesMap) *pipe.Middle[[]request.Span, []request.Span]   { return &n.Kubernetes }
-func nameResolver(n *nodesMap) *pipe.Middle[[]request.Span, []request.Span] { return &n.NameResolver }
-func attrFilter(n *nodesMap) *pipe.Middle[[]request.Span, []request.Span]   { return &n.AttributeFilter }
-func alloyTraces(n *nodesMap) *pipe.Final[[]request.Span]                   { return &n.AlloyTraces }
-func otelMetrics(n *nodesMap) *pipe.Final[[]request.Span]                   { return &n.Metrics }
-func otelTraces(n *nodesMap) *pipe.Final[[]request.Span]                    { return &n.Traces }
-func printer(n *nodesMap) *pipe.Final[[]request.Span]                       { return &n.Printer }
-func prometheus(n *nodesMap) *pipe.Final[[]request.Span]                    { return &n.Prometheus }
-func bpfMetrics(n *nodesMap) *pipe.Final[[]request.Span]                    { return &n.BpfMetrics }
-
-func processReport(n *nodesMap) *pipe.Final[[]request.Span] { return &n.ProcessReport }
 
 // builder with injectable instantiators for unit testing
 type graphFunctions struct {
 	config  *beyla.Config
-	builder *pipe.Builder[*nodesMap]
+	builder *swarm.Instancer
 	ctxInfo *global.ContextInfo
-
-	// tracesCh is shared across all the eBPF tracing programs, which send there
-	// any discovered trace, and the input node of the graph, which reads and
-	// forwards them to the next stages.
-	tracesCh <-chan []request.Span
 }
 
 // Build instantiates the whole instrumentation --> processing --> submit
 // pipeline graph and returns it as a startable item
-func Build(ctx context.Context, config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh <-chan []request.Span) (*Instrumenter, error) {
-	return newGraphBuilder(ctx, config, ctxInfo, tracesCh).buildGraph()
+func Build(ctx context.Context, config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh *msg.Queue[[]request.Span]) (*Instrumenter, error) {
+	return newGraphBuilder(config, ctxInfo, tracesCh).buildGraph(ctx)
 }
 
 // private constructor that can be instantiated from tests to override the node providers
 // and offsets inspector
-func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh <-chan []request.Span) *graphFunctions {
-	// This is how the github.com/mariomac/pipes library, works:
-	// https://github.com/mariomac/pipes/tree/main/docs/tutorial/b-highlevel/01-basic-nodes
-
-	// We are migrating the pipes library to a simpler-but-more-flexible "Swarm" model
-	// We might see some duplications in the code here until we migrate everything
-	appToProcChannel := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen))
-
+func newGraphBuilder(config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh *msg.Queue[[]request.Span]) *graphFunctions {
 	// First, we create a graph builder
-	gnb := pipe.NewBuilder(&nodesMap{}, pipe.ChannelBufferLen(config.ChannelBufferLen))
+	swi := &swarm.Instancer{}
 	gb := &graphFunctions{
-		builder:  gnb,
-		config:   config,
-		ctxInfo:  ctxInfo,
-		tracesCh: tracesCh,
+		builder: swi,
+		config:  config,
+		ctxInfo: ctxInfo,
 	}
-	// Second, we register providers for each pipe node.
-	pipe.AddStart(gnb, tracesReader, traces.ReadFromChannel(ctx, &traces.ReadDecorator{
-		InstanceID:  config.Attributes.InstanceID,
-		TracesInput: gb.tracesCh,
+
+	newQueue := func() *msg.Queue[[]request.Span] {
+		return msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen))
+	}
+
+	// Second, we register instancers for each pipe node, as well as communication queues between them
+	// TODO: consider moving the queues to a publis structure so when Beyla is used as library, other components can
+	// listen to the messages and expanding the Pipeline
+	tracesReaderToRouter := newQueue()
+	swi.Add(traces.ReadFromChannel(&traces.ReadDecorator{
+		InstanceID:      config.Attributes.InstanceID,
+		TracesInput:     tracesCh,
+		DecoratedTraces: tracesReaderToRouter,
 	}))
 
-	pipe.AddMiddleProvider(gnb, router, transform.RoutesProvider(config.Routes))
-	pipe.AddMiddleProvider(gnb, kubernetes, transform.KubeDecoratorProvider(ctx, &config.Attributes.Kubernetes, ctxInfo))
-	pipe.AddMiddleProvider(gnb, nameResolver, transform.NameResolutionProvider(ctx, gb.ctxInfo, config.NameResolver))
-	pipe.AddMiddleProvider(gnb, attrFilter, filter.ByAttribute(config.Filters.Application, spanPtrPromGetters))
+	routerToKubeDecorator := newQueue()
+	swi.Add(transform.RoutesProvider(
+		config.Routes,
+		tracesReaderToRouter,
+		routerToKubeDecorator,
+	))
+
+	kubeDecoratorToNameResolver := newQueue()
+	swi.Add(transform.KubeDecoratorProvider(
+		ctxInfo, &config.Attributes.Kubernetes,
+		routerToKubeDecorator, kubeDecoratorToNameResolver,
+	))
+
+	nameResolverToAttrFilter := newQueue()
+	swi.Add(transform.NameResolutionProvider(ctxInfo, config.NameResolver,
+		kubeDecoratorToNameResolver, nameResolverToAttrFilter))
+
+	exportableSpans := newQueue()
+	swi.Add(filter.ByAttribute(config.Filters.Application, spanPtrPromGetters,
+		nameResolverToAttrFilter, exportableSpans))
+
 	config.Metrics.Grafana = &gb.config.Grafana.OTLP
-	pipe.AddFinalProvider(gnb, otelMetrics, otel.ReportMetrics(ctx, gb.ctxInfo, &config.Metrics, config.Attributes.Select))
+	swi.Add(otel.ReportMetrics(ctxInfo, &config.Metrics, config.Attributes.Select, exportableSpans))
+
 	config.Traces.Grafana = &gb.config.Grafana.OTLP
-	pipe.AddFinalProvider(gnb, otelTraces, otel.TracesReceiver(ctx, config.Traces, config.Metrics.SpanMetricsEnabled(), gb.ctxInfo, config.Attributes.Select))
-	pipe.AddFinalProvider(gnb, prometheus, prom.PrometheusEndpoint(ctx, gb.ctxInfo, &config.Prometheus, config.Attributes.Select))
-	pipe.AddFinalProvider(gnb, bpfMetrics, prom.BPFMetrics(ctx, gb.ctxInfo, &config.Prometheus))
-	pipe.AddFinalProvider(gnb, alloyTraces, alloy.TracesReceiver(ctx, gb.ctxInfo, &config.TracesReceiver, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select))
+	swi.Add(otel.TracesReceiver(ctxInfo, config.Traces, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select, exportableSpans))
+	swi.Add(prom.PrometheusEndpoint(ctxInfo, &config.Prometheus, config.Attributes.Select, exportableSpans))
+	swi.Add(prom.BPFMetrics(ctxInfo, &config.Prometheus))
+	swi.Add(alloy.TracesReceiver(ctxInfo, &config.TracesReceiver, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select, exportableSpans))
 
-	pipe.AddFinalProvider(gnb, printer, debug.PrinterNode(config.TracePrinter))
+	swi.Add(debug.PrinterNode(config.TracePrinter, exportableSpans))
 
-	// process subpipeline will start another pipeline only to collect and export data
+	// process subpipeline optionally starts another pipeline only to collect and export data
 	// about the processes of an instrumented application
-	pipe.AddFinalProvider(gnb, processReport, connectOldPipesLibToSwarmProcessSubpipeline(ctx, config, ctxInfo, appToProcChannel))
+	swi.Add(ProcessMetricsSwarmInstancer(ctxInfo, config, exportableSpans))
 
 	// The returned builder later invokes its "Build" function that, given
 	// the contents of the nodesMap struct, will instantiate
@@ -139,36 +101,11 @@ func newGraphBuilder(ctx context.Context, config *beyla.Config, ctxInfo *global.
 	return gb
 }
 
-func connectOldPipesLibToSwarmProcessSubpipeline(
-	ctx context.Context,
-	config *beyla.Config,
-	ctxInfo *global.ContextInfo,
-	appToProcChannel *msg.Queue[[]request.Span],
-) pipe.FinalProvider[[]request.Span] {
-	return func() (pipe.FinalFunc[[]request.Span], error) {
-		if !isProcessSubPipeEnabled(config) {
-			return pipe.IgnoreFinal[[]request.Span](), nil
-		}
-		processMetrics, err := ProcessMetricsSwarmInstancer(ctxInfo, config, appToProcChannel)(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return func(in <-chan []request.Span) {
-			go processMetrics(ctx)
-			// just connects the old pipe library with the new swarm library
-			// TODO: will be removed when we move the rest of the pipeline to the new swarm
-			for i := range in {
-				appToProcChannel.Send(i)
-			}
-		}, nil
-	}
-}
-
-func (gb *graphFunctions) buildGraph() (*Instrumenter, error) {
+func (gb *graphFunctions) buildGraph(ctx context.Context) (*Instrumenter, error) {
 	// setting explicitly some configuration properties that are needed by their
 	// respective node providers
 
-	grp, err := gb.builder.Build()
+	grp, err := gb.builder.Instance(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -180,12 +117,12 @@ func (gb *graphFunctions) buildGraph() (*Instrumenter, error) {
 
 type Instrumenter struct {
 	internalMetrics imetrics.Reporter
-	graph           *pipe.Runner
+	graph           *swarm.Runner
 }
 
 func (i *Instrumenter) Run(ctx context.Context) {
 	go i.internalMetrics.Start(ctx)
-	i.graph.Start()
+	i.graph.Start(ctx)
 	// run until either the graph is finished or the context is cancelled
 	select {
 	case <-i.graph.Done():

--- a/pkg/pipe/swarm/instancer.go
+++ b/pkg/pipe/swarm/instancer.go
@@ -44,3 +44,11 @@ func (s *Instancer) Instance(ctx context.Context) (*Runner, error) {
 	}
 	return runner, nil
 }
+
+// DirectInstance provides a shortcut to provide the Instancer with a RunFunc that is already instanced, or
+// whose creation does not require any error handling API.
+func DirectInstance(r RunFunc) InstanceFunc {
+	return func(_ context.Context) (RunFunc, error) {
+		return r, nil
+	}
+}

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -7,13 +7,13 @@ import (
 	"maps"
 	"time"
 
-	"github.com/mariomac/pipes/pipe"
-
 	attr "github.com/grafana/beyla/v2/pkg/export/attributes/names"
 	"github.com/grafana/beyla/v2/pkg/internal/kube"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/kubeflags"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
 )
 
 func klog() *slog.Logger {
@@ -72,20 +72,26 @@ const (
 )
 
 func KubeDecoratorProvider(
-	ctx context.Context,
-	cfg *KubernetesDecorator,
 	ctxInfo *global.ContextInfo,
-) pipe.MiddleProvider[[]request.Span, []request.Span] {
-	return func() (pipe.MiddleFunc[[]request.Span, []request.Span], error) {
+	cfg *KubernetesDecorator,
+	input, output *msg.Queue[[]request.Span],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
 		if !ctxInfo.K8sInformer.IsKubeEnabled() {
 			// if kubernetes decoration is disabled, we just bypass the node
-			return pipe.Bypass[[]request.Span](), nil
+			input.Bypass(output)
+			return swarm.EmptyRunFunc()
 		}
 		metaStore, err := ctxInfo.K8sInformer.Get(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("inititalizing KubeDecoratorProvider: %w", err)
 		}
-		decorator := &metadataDecorator{db: metaStore, clusterName: KubeClusterName(ctx, cfg, ctxInfo.K8sInformer)}
+		decorator := &metadataDecorator{
+			db:          metaStore,
+			clusterName: KubeClusterName(ctx, cfg, ctxInfo.K8sInformer),
+			input:       input.Subscribe(),
+			output:      output,
+		}
 		return decorator.nodeLoop, nil
 	}
 }
@@ -93,16 +99,20 @@ func KubeDecoratorProvider(
 type metadataDecorator struct {
 	db          *kube.Store
 	clusterName string
+	input       <-chan []request.Span
+	output      *msg.Queue[[]request.Span]
 }
 
-func (md *metadataDecorator) nodeLoop(in <-chan []request.Span, out chan<- []request.Span) {
+func (md *metadataDecorator) nodeLoop(_ context.Context) {
+	// output channel must be closed so later stages in the pipeline can finish in cascade
+	defer md.output.Close()
 	klog().Debug("starting kubernetes decoration loop")
-	for spans := range in {
+	for spans := range md.input {
 		// in-place decoration and forwarding
 		for i := range spans {
 			md.do(&spans[i])
 		}
-		out <- spans
+		md.output.Send(spans)
 	}
 	klog().Debug("stopping kubernetes decoration loop")
 }


### PR DESCRIPTION
Continuation of https://github.com/grafana/beyla/pull/1810

Pros:
* Now everything is more explicit. No "magic" under the hood.
* The pipeline can be easily extended and connected to other pipelines. This simplifies unit tests, also simplified connections between e.g. instrumentation pipeline with process or tracer pipelines. Will simplify usage of Beyla code as a library.
* Code is shorter.

Cons:
* Now we need to explicitly manage the communication channels.
* We need to take care to explicitly close output channels when a node finishes. Otherwise Beyla couldn't stop in cascade. 

Above "cons" actions were previously done automatically by the pipes library.