### PR TITLE
Explicitly set pointer alignment on clang-format

### DIFF
--- a/bpf/.clang-format
+++ b/bpf/.clang-format
@@ -9,4 +9,5 @@
   BinPackArguments: false,
   BinPackParameters: false,
   TabWidth: 4,
+  PointerAlignment: Right,
 }


### PR DESCRIPTION
Prevents older versions of clang-format from doing `int * foo;` rather than `int *foo;`.