### PR TITLE
Fix iface attribute on socket http tracer

### DIFF
--- a/bpf/netolly/flows_sock.c
+++ b/bpf/netolly/flows_sock.c
@@ -52,6 +52,7 @@ static __always_inline bool read_sk_buff(struct __sk_buff *skb, flow_id *id, u16
     bpf_skb_load_bytes(skb, offsetof(struct ethhdr, h_proto), &h_proto, sizeof(h_proto));
     h_proto = __bpf_htons(h_proto);
     id->eth_protocol = h_proto;
+    id->if_index = skb->ifindex;
 
     u8 hdr_len;
     u8 proto = 0;


### PR DESCRIPTION
In network metrics, when the socket tracer was used, the interface number was not correctly populated.

Fixes https://github.com/grafana/beyla/issues/794