### PR TITLE
exclude OTEL-imported code from code coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ CLANG_TIDY ?= clang-tidy
 CILIUM_EBPF_VER ?= $(call gomod-version,cilium/ebpf)
 
 # regular expressions for excluded file patterns
-EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/beyla/v2/test/)|\
-(/beyla/v2/configs/)|(/v2/examples/)|(.pb.go)|\
-(/beyla/v2/pkg/export/otel/metric/)"
+EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/beyla/v2/test/)|(/beyla/v2/configs/)|(/v2/examples/)|(.pb.go)|(/beyla/v2/pkg/export/otel/metric/)"
 
 .DEFAULT_GOAL := all
 


### PR DESCRIPTION
Excludes from the coverage reports a package that was directly copied from the OTEL library. That package is untested but it isn't actually something that we are maintaining and will be removed at some point.

Excluding that package until either we actively maintain it and add tests, or until we remove it and bring the official OTEL library again.