### PR TITLE
Fix batcher configuration for internal OTEL metrics exporter

### DIFF
--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -34,7 +34,7 @@ func imlog() *slog.Logger {
 func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo, metrics *MetricsConfig) (*InternalMetricsReporter, error) {
 	log := imlog()
 	log.Debug("instantiating internal metrics exporter provider")
-	exporter, err := InstantiateMetricsExporter(context.Background(), metrics, log)
+	exporter, err := InstantiateMetricsExporter(ctx, metrics, log)
 	if err != nil {
 		log.Error("can't instantiate metrics exporter", "error", err)
 		return nil, err


### PR DESCRIPTION
I observed that `TestTraces_InternalInstrumentation` was taking 15 seconds despite it was configured to export metrics every 10ms.

The reason was that the internal metrics OTEL exporter did not took the batching configuration from the main OTEL metrics exporter.

Now `TestTraces_InternalInstrumentation` takes around `800ms`