### PR TITLE
Replace context.WithCancel in unit tests

### DIFF
--- a/pkg/components/beyla_test.go
+++ b/pkg/components/beyla_test.go
@@ -62,14 +62,11 @@ func TestRun_DontPanic(t *testing.T) {
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-
 			cfg := tc.configProvider()
 			require.NoError(t, cfg.Validate())
 
 			require.NotPanics(t, func() {
-				_ = RunBeyla(ctx, &cfg)
+				_ = RunBeyla(t.Context(), &cfg)
 			})
 		})
 	}

--- a/pkg/components/beyla_test.go
+++ b/pkg/components/beyla_test.go
@@ -4,7 +4,6 @@ package components
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"testing"
 

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -1,7 +1,6 @@
 package otel
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -24,8 +23,7 @@ const timeout = 20 * time.Second
 
 func TestNetMetricsExpiration(t *testing.T) {
 	defer restoreEnvAfterExecution()()
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -131,8 +129,7 @@ func TestNetMetricsExpiration(t *testing.T) {
 // this test verifies case 1
 func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 	defer restoreEnvAfterExecution()()
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -248,8 +245,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 // this test verifies case 2
 func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 	defer restoreEnvAfterExecution()()
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/export/otel/metrics_proc_test.go
+++ b/pkg/export/otel/metrics_proc_test.go
@@ -1,7 +1,6 @@
 package otel
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -21,8 +20,7 @@ import (
 func TestProcMetrics_Aggregated(t *testing.T) {
 	os.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "100")
 	defer restoreEnvAfterExecution()()
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -186,8 +184,7 @@ func TestProcMetrics_Aggregated(t *testing.T) {
 func TestProcMetrics_Disaggregated(t *testing.T) {
 	os.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "100")
 	defer restoreEnvAfterExecution()()
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -446,8 +446,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancelCtx := context.WithCancel(context.Background())
-			defer cancelCtx()
+			ctx := t.Context()
 
 			otlp, err := collector.Start(ctx)
 			require.NoError(t, err)
@@ -512,8 +511,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 
 	require.NoError(t, os.Setenv(envResourceAttrs, "deployment.environment=production,source=upstream.beyla"))
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -1,7 +1,6 @@
 package prom
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -22,8 +21,8 @@ func TestMetricsExpiration(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
+
 	openPort, err := test.FreeTCPPort()
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)

--- a/pkg/export/prom/prom_proc_test.go
+++ b/pkg/export/prom/prom_proc_test.go
@@ -1,7 +1,6 @@
 package prom
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -23,8 +22,7 @@ func TestProcPrometheusEndpoint_AggregatedMetrics(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 	openPort, err := test.FreeTCPPort()
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
@@ -111,8 +109,7 @@ func TestProcPrometheusEndpoint_DisaggregatedMetrics(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 	openPort, err := test.FreeTCPPort()
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -35,8 +35,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 	openPort, err := test.FreeTCPPort()
 	require.NoError(t, err)
 	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
@@ -264,8 +263,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			now := syncedClock{now: time.Now()}
 			timeNow = now.Now
 
-			ctx, cancelCtx := context.WithCancel(context.Background())
-			defer cancelCtx()
+			ctx := t.Context()
 			openPort, err := test.FreeTCPPort()
 			require.NoError(t, err)
 			promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
@@ -364,8 +362,7 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 	openPort, err := test.FreeTCPPort()
 	require.NoError(t, err)
 

--- a/pkg/internal/goexec/offsets_test.go
+++ b/pkg/internal/goexec/offsets_test.go
@@ -1,7 +1,6 @@
 package goexec
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -13,8 +12,6 @@ import (
 // TestProcessNotFound tests that InspectOffsets process exits on context cancellation
 // even if the target process wasn't found
 func TestProcessNotFound(t *testing.T) {
-	_, cancel := context.WithCancel(context.Background())
-	cancel()
 	finish := make(chan struct{})
 	go func() {
 		defer close(finish)

--- a/pkg/internal/netolly/agent/pipeline_test.go
+++ b/pkg/internal/netolly/agent/pipeline_test.go
@@ -28,8 +28,7 @@ import (
 const timeout = 5 * time.Second
 
 func TestFilter(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	promPort, err := test.FreeTCPPort()
 	require.NoError(t, err)

--- a/pkg/internal/netolly/ifaces/poller_test.go
+++ b/pkg/internal/netolly/ifaces/poller_test.go
@@ -19,7 +19,6 @@
 package ifaces
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -30,8 +29,7 @@ import (
 const timeout = 5 * time.Second
 
 func TestPoller(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// fake net.Interfaces implementation that returns two different sets of
 	// interfaces on successive invocations

--- a/pkg/internal/netolly/ifaces/registerer_test.go
+++ b/pkg/internal/netolly/ifaces/registerer_test.go
@@ -21,7 +21,6 @@
 package ifaces
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/internal/netolly/ifaces/registerer_test.go
+++ b/pkg/internal/netolly/ifaces/registerer_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestRegisterer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher := NewWatcher(10)
 	registry := NewRegisterer(watcher, 10)

--- a/pkg/internal/netolly/ifaces/watcher_test.go
+++ b/pkg/internal/netolly/ifaces/watcher_test.go
@@ -21,7 +21,6 @@
 package ifaces
 
 import (
-	"context"
 	"syscall"
 	"testing"
 

--- a/pkg/internal/netolly/ifaces/watcher_test.go
+++ b/pkg/internal/netolly/ifaces/watcher_test.go
@@ -33,8 +33,7 @@ import (
 )
 
 func TestWatcher(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher := NewWatcher(10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered

--- a/pkg/internal/pipe/instrumenter_test.go
+++ b/pkg/internal/pipe/instrumenter_test.go
@@ -1,7 +1,6 @@
 package pipe
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -59,8 +58,7 @@ func allMetricsBut(patterns ...string) attributes.Selection {
 }
 
 func TestBasicPipeline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -121,8 +119,7 @@ func TestBasicPipeline(t *testing.T) {
 }
 
 func TestTracerPipeline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -155,8 +152,7 @@ func TestTracerPipeline(t *testing.T) {
 }
 
 func TestTracerReceiverPipeline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -184,36 +180,8 @@ func TestTracerReceiverPipeline(t *testing.T) {
 	matchTraceEvent(t, "GET", event)
 }
 
-func BenchmarkTestTracerPipeline(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		tc, _ := collector.Start(ctx)
-		tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
-		gb := newGraphBuilder(&beyla.Config{
-			Traces: otel.TracesConfig{
-				BatchTimeout:      10 * time.Millisecond,
-				TracesEndpoint:    tc.ServerEndpoint,
-				ReportersCacheLen: 16,
-				Instrumentations:  []string{instrumentations.InstrumentationALL},
-			},
-		}, gctx(0), tracesInput)
-		// Override eBPF tracer to send some fake data
-		tracesInput.Send(newRequest("bar-svc", "GET", "/foo/bar", "1.1.1.1:3456", 404))
-		pipe, _ := gb.buildGraph(ctx)
-
-		go pipe.Run(ctx)
-		t := &testing.T{}
-		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
-		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
-		testutil.ReadChannel(t, tc.TraceRecords(), testTimeout)
-	}
-}
-
 func TestTracerPipelineBadTimestamps(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -241,8 +209,7 @@ func TestTracerPipelineBadTimestamps(t *testing.T) {
 }
 
 func TestRouteConsolidation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -359,8 +326,7 @@ func TestRouteConsolidation(t *testing.T) {
 }
 
 func TestGRPCPipeline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -418,8 +384,7 @@ func TestGRPCPipeline(t *testing.T) {
 }
 
 func TestTraceGRPCPipeline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -449,8 +414,7 @@ func TestTraceGRPCPipeline(t *testing.T) {
 }
 
 func TestBasicPipelineInfo(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -511,8 +475,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 }
 
 func TestTracerPipelineInfo(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)
@@ -534,8 +497,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 }
 
 func TestSpanAttributeFilterNode(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tc, err := collector.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/internal/traces/read_decorator_test.go
+++ b/pkg/internal/traces/read_decorator_test.go
@@ -1,7 +1,6 @@
 package traces
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -51,8 +50,7 @@ func TestReadDecorator(t *testing.T) {
 			cfg.TracesInput = msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 			cfg.DecoratedTraces = msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 			decoratedOutput := cfg.DecoratedTraces.Subscribe()
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 			readLoop, err := ReadFromChannel(&cfg)(ctx)
 			require.NoError(t, err)
 			go readLoop(ctx)


### PR DESCRIPTION
Go 1.24 adds the `Context()` method to the `testing.T` struct, which is automatically cancelled when the unit tests end.

This PR replaces the previously used `context.WithCancel` by the new function in most of the unit test.