### PR TITLE
Avoid log sensitive data

### DIFF
--- a/pkg/internal/ebpf/common/tcp_detect_transform.go
+++ b/pkg/internal/ebpf/common/tcp_detect_transform.go
@@ -2,13 +2,41 @@ package ebpfcommon
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/grafana/beyla/v2/pkg/config"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf/ringbuf"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 )
 
-// nolint:cyclop
+var (
+	// Match tokens, passwords, auth data, and similar sensitive patterns
+	tokenPattern = regexp.MustCompile(`(?i)(token|password|auth|secret|key|credential|jwt)["']?\s*[:=]\s*["']?([^"'\s,\}]+)`)
+	// Match for JSON, XML and plain values that might contain sensitive info
+	sessionDataPattern = regexp.MustCompile(`(?i)(s:[0-9]+:["'])([^"']+)(["'])`)
+	// Redis AUTH command
+	redisAuthPattern = regexp.MustCompile(`(?i)(AUTH\s+)(\S+)`)
+	// Redis SETEX command (which often contains sensitive session data)
+	redisSetexPattern = regexp.MustCompile(`(?i)(SETEX\s+\S+\s+\d+\s+)(.+)`)
+)
+
+// sanitizeBuffer masks sensitive data in protocol buffers before logging
+func sanitizeBuffer(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	content := string(data)
+
+	// Replace sensitive pattern matches with masked data
+	content = tokenPattern.ReplaceAllString(content, "$1: \"***REDACTED***\"")
+	content = sessionDataPattern.ReplaceAllString(content, "$1***REDACTED***$3")
+	content = redisAuthPattern.ReplaceAllString(content, "$1***REDACTED***")
+	content = redisSetexPattern.ReplaceAllString(content, "$1***REDACTED***")
+
+	return []byte(content)
+}
+
 func ReadTCPRequestIntoSpan(cfg *config.EBPFTracer, record *ringbuf.Record, filter ServiceFilter) (request.Span, bool, error) {
 	event, err := ReinterpretCast[TCPRequestInfo](record.RawSample)
 
@@ -33,8 +61,10 @@ func ReadTCPRequestIntoSpan(cfg *config.EBPFTracer, record *ringbuf.Record, filt
 	b := event.Buf[:l]
 
 	if cfg.ProtocolDebug {
-		fmt.Printf("[>] %q\n", b)
-		fmt.Printf("[<] %q\n", event.Rbuf[:rl])
+		sanitizedReq := sanitizeBuffer(b)
+		sanitizedResp := sanitizeBuffer(event.Rbuf[:rl])
+		fmt.Printf("[>] %q\n", sanitizedReq)
+		fmt.Printf("[<] %q\n", sanitizedResp)
 	}
 
 	// Check if we have a SQL statement

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -297,7 +297,10 @@ func (pt *ProcessTracer) UnlinkExecutable(info *exec.FileInfo) {
 		}
 		delete(pt.Instrumentables, info.Ino)
 	} else {
-		pt.log.Warn("Unable to find executable to unlink", "info", info)
+		pt.log.Warn("Unable to find executable to unlink",
+			"path", info.CmdExePath,
+			"pid", info.Pid,
+			"inode", info.Ino)
 	}
 }
 


### PR DESCRIPTION
- Fixes #1838, where env vars were logged.
- Sanitize buff when users activate `BEYLA_PROTOCOL_DEBUG_PRINT`. Sometimes this can log sensitive data.