### PR TITLE
Revert "Print printable characters in cfg.ProtocolDebug (#1738)"

### DIFF
--- a/pkg/internal/ebpf/common/tcp_detect_transform.go
+++ b/pkg/internal/ebpf/common/tcp_detect_transform.go
@@ -33,8 +33,8 @@ func ReadTCPRequestIntoSpan(cfg *config.EBPFTracer, record *ringbuf.Record, filt
 	b := event.Buf[:l]
 
 	if cfg.ProtocolDebug {
-		fmt.Printf("[>] %q\n", b)
-		fmt.Printf("[<] %q\n", event.Rbuf[:rl])
+		fmt.Printf("[>] %v\n", b)
+		fmt.Printf("[<] %v\n", event.Rbuf[:rl])
 	}
 
 	// Check if we have a SQL statement


### PR DESCRIPTION
This reverts commit 6e7397a3526e6b4222ee4d7994f9290d5368fce7.