### PR TITLE
Restrict SSL to connection mapping by direction

### DIFF
--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -42,12 +42,6 @@
 #define TP_MAX_VAL_LENGTH 55
 #define TP_MAX_KEY_LENGTH 11
 
-#define TCP_SEND 1
-#define TCP_RECV 0
-
-#define NO_SSL 0
-#define WITH_SSL 1
-
 // Preface PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n https://datatracker.ietf.org/doc/html/rfc7540#section-3.5
 #define MIN_HTTP2_SIZE 24
 

--- a/bpf/common/protocol_defs.h
+++ b/bpf/common/protocol_defs.h
@@ -32,3 +32,9 @@
 #define TCPHDR_URG 0x20
 #define TCPHDR_ECE 0x40
 #define TCPHDR_CWR 0x80
+
+#define TCP_SEND 1
+#define TCP_RECV 0
+
+#define NO_SSL 0
+#define WITH_SSL 1

--- a/bpf/common/ssl_helpers.h
+++ b/bpf/common/ssl_helpers.h
@@ -4,6 +4,7 @@
 #include <bpfcore/bpf_helpers.h>
 
 #include <common/connection_info.h>
+#include <common/protocol_defs.h>
 
 #include <logger/bpf_dbg.h>
 
@@ -21,13 +22,28 @@ static __always_inline void set_active_ssl_connection(pid_connection_info_t *con
     bpf_map_update_elem(&ssl_to_conn, &ssl, conn, BPF_ANY);
 }
 
-static __always_inline void *is_ssl_connection(u64 id, pid_connection_info_t *conn) {
+static __always_inline void *is_ssl_connection(u64 id, pid_connection_info_t *conn, u8 direction) {
     void *ssl = 0;
-    // Checks if it's sandwitched between active SSL handshake, read or write uprobe/uretprobe
-    ssl_args_t *ssl_args = bpf_map_lookup_elem(&active_ssl_read_args, &id);
+    ssl_args_t *ssl_args = 0;
+    u8 update_info = 0;
 
-    if (!ssl_args) {
+    // Checks if it's sandwitched between read or write uprobe/uretprobe
+    if (direction == TCP_RECV) {
+        ssl_args = bpf_map_lookup_elem(&active_ssl_read_args, &id);
+        if (ssl_args) {
+            update_info = 1;
+        } else {
+            ssl_args = bpf_map_lookup_elem(&active_ssl_write_args, &id);
+        }
+    } else if (direction == TCP_SEND) {
         ssl_args = bpf_map_lookup_elem(&active_ssl_write_args, &id);
+        if (ssl_args) {
+            update_info = 1;
+        } else {
+            ssl_args = bpf_map_lookup_elem(&active_ssl_read_args, &id);
+        }
+    } else {
+        bpf_dbg_printk("unknown ssl connection direction, this is a bug");
     }
 
     if (ssl_args) {
@@ -38,7 +54,12 @@ static __always_inline void *is_ssl_connection(u64 id, pid_connection_info_t *co
         return bpf_map_lookup_elem(&active_ssl_connections, conn);
     }
 
-    set_active_ssl_connection(conn, ssl);
+    // We want to update the SSL to connection info, only if the
+    // direction of the SSL traffic matches the SSL operation.
+    // That is TCP_RECV = SSL_read, TCP_SEND = SSL_write.
+    if (update_info) {
+        set_active_ssl_connection(conn, ssl);
+    }
 
     return ssl;
 }

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -292,7 +292,7 @@ int BPF_KPROBE(beyla_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *msg, si
         s_args.p_conn.pid = pid_from_pid_tgid(id);
         s_args.orig_dport = orig_dport;
 
-        void *ssl = is_ssl_connection(id, &s_args.p_conn);
+        void *ssl = is_ssl_connection(id, &s_args.p_conn, TCP_SEND);
         if (size > 0) {
             if (!ssl) {
                 u8 *buf = iovec_memory();
@@ -416,7 +416,7 @@ int BPF_KPROBE(beyla_kprobe_tcp_rate_check_app_limited, struct sock *sk) {
             }
         }
 
-        void *ssl = is_ssl_connection(id, &s_args.p_conn);
+        void *ssl = is_ssl_connection(id, &s_args.p_conn, TCP_SEND);
         if (ssl) {
             make_inactive_sk_buffer(&s_args.p_conn.conn);
             tcp_send_ssl_check(id, ssl, &s_args.p_conn, orig_dport);
@@ -663,7 +663,7 @@ static __always_inline int return_recvmsg(void *ctx, struct sock *in_sock, u64 i
         sort_connection_info(&info.conn);
         info.pid = pid_from_pid_tgid(id);
 
-        void *ssl = is_ssl_connection(id, &info);
+        void *ssl = is_ssl_connection(id, &info, TCP_RECV);
 
         if (!ssl) {
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -182,7 +182,7 @@ static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
     sort_connection_info(&s_args.p_conn.conn);
     s_args.p_conn.pid = pid_from_pid_tgid(id);
 
-    if (s_args.size == 0 || is_ssl_connection(id, &s_args.p_conn)) {
+    if (s_args.size == 0 || is_ssl_connection(id, &s_args.p_conn, TCP_SEND)) {
         return 0;
     }
 


### PR DESCRIPTION
When we look at SSL requests, e.g. using the uprobes on SSL_read and SSL_write, we try to look for traffic inside a uprobe/uretprobe handling, since there's no connection information associated on the SSL pointer. Once we see TCP traffic we establish the relationship between the SSL pointer used by SSL_read and SSL_write and the connection information used for the TCP traffic.

This generally works well, however we recently hit a case of a healthcheck that somehow has traffic to a downstream service while handling the SSL read. Here's an annotated snippet of our traces with what's going on:

The nginx port listens on 3012, there's a downstream Redis listening on 6379.

```
>>> start of SSL_read

           nginx-6313    [003] d... 95132.237869: bpf_trace_printk: === uprobe SSL_read id=6313 ssl=557c4920a740 ===
           nginx-6313    [003] d... 95132.237892: bpf_trace_printk: +++ sock_recvmsg sock=ffff8e6372c2ef00
           nginx-6313    [003] d... 95132.237896: bpf_trace_printk: === tcp_recvmsg id=6313 sock=ffff8e6372c2ef00 ===
           nginx-6313    [003] d... 95132.237900: bpf_trace_printk: === tcp_cleanup_rbuf id=6313 copied_len 1287 ===

>>> correct connection information, associated with the read itself (recvmsg)
           nginx-6313    [003] d... 95132.237901: bpf_trace_printk: [conn] s_h = 0, s_l = 1d041aacffff0000, s_port=45772
           nginx-6313    [003] d... 95132.237902: bpf_trace_printk: [conn] d_h = 0, d_l = ad151aacffff0000, d_port=3012
           nginx-6313    [003] d... 95132.237903: bpf_trace_printk: === return recvmsg id=6313 args=ffff9cf10cb86b20 copied_len 1287 ===
           nginx-6313    [003] d... 95132.237903: bpf_trace_printk: iter_type=4
           nginx-6313    [003] d... 95132.237905: bpf_trace_printk: nr_segs=1, iov=0000000009074867, ubuf=0000000000000000
           nginx-6313    [003] d... 95132.237906: bpf_trace_printk: Correlating SSL 557c4920a740 to connection
           nginx-6313    [003] d... 95132.237907: bpf_trace_printk: [conn] s_h = 0, s_l = 1d041aacffff0000, s_port=45772
           nginx-6313    [003] d... 95132.237908: bpf_trace_printk: [conn] d_h = 0, d_l = ad151aacffff0000, d_port=3012
           nginx-6313    [003] d... 95132.237910: bpf_trace_printk: deleting sk_buff on
           nginx-6313    [003] d... 95132.237911: bpf_trace_printk: [conn] s_h = 0, s_l = 1d041aacffff0000, s_port=45772
           nginx-6313    [003] d... 95132.237911: bpf_trace_printk: [conn] d_h = 0, d_l = ad151aacffff0000, d_port=3012
           nginx-6313    [003] d... 95132.237912: bpf_trace_printk: tcp_recvmsg for an identified SSL connection, ignoring [557c4920a740]...
           nginx-6313    [003] d... 95132.237915: bpf_trace_printk: === kretprobe_tcp_recvmsg id=6313 copied_len 1287 ===
           nginx-6313    [003] d... 95132.237916: bpf_trace_printk: === return recvmsg id=6313 args=0 copied_len 1287 ===
           nginx-6313    [003] d... 95132.237918: bpf_trace_printk: === return sock_recvmsg id=6313 args=0 copied_len 1287 ===

>>> SSL_read hasn't returned yet, the retprobe is below, but we are starting outgoing traffic on this thread 6313
           nginx-6313    [003] d.s. 95132.237957: bpf_trace_printk: === tcp_rcv_established id=6313 ===
           nginx-6313    [003] d.s. 95132.237964: bpf_trace_printk: [conn] s_h = 0, s_l = ad151aacffff0000, s_port=49804
           nginx-6313    [003] d.s. 95132.237964: bpf_trace_printk: [conn] d_h = 0, d_l = b90a140affff0000, d_port=6379

>>> tcp_rate_check_app_limited is a backup for tcp_sendmsg when the sk_msg program is attached, so this effectively a send
           nginx-6313    [003] d.s. 95132.237968: bpf_trace_printk: === kprobe tcp_rate_check_app_limited=6313 sock=ffff8e63175a1280 ===
           nginx-6313    [003] d.s. 95132.237969: bpf_trace_printk: [conn] s_h = 0, s_l = ad151aacffff0000, s_port=49804
           nginx-6313    [003] d.s. 95132.237969: bpf_trace_printk: [conn] d_h = 0, d_l = b90a140affff0000, d_port=6379

>>> the SSL pointer is now wrongly correlated to the connection information with destination port 6379.
           nginx-6313    [003] d.s. 95132.237970: bpf_trace_printk: Correlating SSL 557c4920a740 to connection
           nginx-6313    [003] d.s. 95132.237971: bpf_trace_printk: [conn] s_h = 0, s_l = ad151aacffff0000, s_port=49804
           nginx-6313    [003] d.s. 95132.237972: bpf_trace_printk: [conn] d_h = 0, d_l = b90a140affff0000, d_port=6379
           nginx-6313    [003] d.s. 95132.237974: bpf_trace_printk: marked buffer as inactive
           nginx-6313    [003] d.s. 95132.237974: bpf_trace_printk: [conn] s_h = 0, s_l = ad151aacffff0000, s_port=49804
           nginx-6313    [003] d.s. 95132.237975: bpf_trace_printk: [conn] d_h = 0, d_l = b90a140affff0000, d_port=6379
           nginx-6313    [003] d.s. 95132.237976: bpf_trace_printk: === kprobe SSL tcp_sendmsg=6313 ssl=557c4920a740 ===

>>> SSL_read finishes with the last connection information being the wrong one
           nginx-6313    [003] d... 95132.237996: bpf_trace_printk: === uretprobe SSL_read id=6313 ===
           nginx-6313    [003] d... 95132.237997: bpf_trace_printk: SSL_buf id=6313 ssl=557c4920a740
           nginx-6313    [003] d... 95132.237998: bpf_trace_printk: SSL conn
           nginx-6313    [003] d... 95132.237999: bpf_trace_printk: [conn] s_h = 0, s_l = ad151aacffff0000, s_port=49804
           nginx-6313    [003] d... 95132.237999: bpf_trace_printk: [conn] d_h = 0, d_l = b90a140affff0000, d_port=6379
           nginx-6313    [003] d... 95132.238001: bpf_trace_printk: buf=[POST /api/fulong/v3/serv��(I|U], pid=6313, len=1024

```

When we associate wrong connection information, the response to the client will be on the correct information and we'll not be able to correlate the start of the HTTP request with the end, hence we get a 408 (thinking it's a timeout).

This fix introduces a direction flag to pass down to is_ssl_connection to ensure that if we are associating the SSL pointer to a connection, they must match the direction. If we are doing SSL_read we should only associate connections with recvmsg, while if we are doing SSL_write, then it must be sendmsg.