### PR TITLE
More connection tracking fixes

### DIFF
--- a/bpf/common/ssl_helpers.h
+++ b/bpf/common/ssl_helpers.h
@@ -14,20 +14,6 @@
 #include <maps/ssl_to_conn.h>
 
 static __always_inline void set_active_ssl_connection(pid_connection_info_t *conn, void *ssl) {
-    void **other_ssl = bpf_map_lookup_elem(&active_ssl_connections, conn);
-
-    // Sometimes a single thread can work with multiple SSL connections, if
-    // we are trying to associate the same connection with multiple SSLs, we detect that
-    // to avoid conflicting the requests.
-    if (other_ssl) {
-        if (*other_ssl != ssl) {
-            bpf_dbg_printk(
-                "Found different correlated SSL[%llx] to this connection, not correlating",
-                *other_ssl);
-            return;
-        }
-    }
-
     bpf_dbg_printk("Correlating SSL %llx to connection", ssl);
     dbg_print_http_connection_info(&conn->conn);
 

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -313,7 +313,7 @@ int beyla_uprobe_ServeHTTPReturns(struct pt_regs *ctx) {
         }
         if (!invocation) {
             bpf_dbg_printk("can't read http invocation metadata");
-            return 0;
+            goto done;
         }
     }
 

--- a/bpf/tctracer/tctracer.c
+++ b/bpf/tctracer/tctracer.c
@@ -17,9 +17,11 @@
 
 #include <tctracer/tc_ip.h>
 
-static const u64 BPF_F_CURRENT_NETNS = -1;
+// Do not change this into u64 const, the API doesn't work if
+// we pass in anything other than -1 explicitly.
+#define BPF_F_CURRENT_NETNS (-1)
 
-enum protocol : u8 { protocol_ip4, protocol_ip6, protocol_unknown };
+enum protocol { protocol_ip4, protocol_ip6, protocol_unknown };
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 


### PR DESCRIPTION
This PR introduces two fixes:

1. First one is a regression to our ability to add a socket for sock_msg tracking if the socket was established before Beyla launched. For some reason passing a u64 const -1 doesn't work for searching all namespaces, I restored back the old define.

**At this point I think we have too many cases where we can mess up the connection information tracking for SSL requests and it might be worthwhile looking up the file descriptors on the BIO structs in the SSL struct and pull the correct information from the open file descriptors on a given thread.**

2. ~~Second is another scenario where the same thread is handling multiple SSL connections. In this case, if they are both of the same direction we can end up producing the wrong information~~. Here's a case with annotations:

```
           nginx-6195    [003] d... 285251.759323: bpf_trace_printk: tcp_sendmsg for identified SSL connection, ignoring...
           nginx-6195    [003] d... 285251.759324: bpf_trace_printk: === kprobe SSL tcp_sendmsg=6195 ssl=561882481e20 ===
           nginx-6195    [003] d... 285251.759327: bpf_trace_printk: === kprobe tcp_rate_check_app_limited=6195 sock=ffff8eaf47c63780 ===
           nginx-6195    [003] d... 285251.759328: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=3012
           nginx-6195    [003] d... 285251.759328: bpf_trace_printk: [conn] d_h = 0, d_l = 64011aacffff0000, d_port=34418

>>> good correlation of the SSL 0x561882481e20 to the correct connection info
           nginx-6195    [003] d... 285251.759330: bpf_trace_printk: Correlating SSL 561882481e20 to connection
           nginx-6195    [003] d... 285251.759331: bpf_trace_printk: [conn] s_h = 0, s_l = 64011aacffff0000, s_port=34418
           nginx-6195    [003] d... 285251.759332: bpf_trace_printk: [conn] d_h = 0, d_l = c2141aacffff0000, d_port=3012
           nginx-6195    [003] d... 285251.759334: bpf_trace_printk: marked buffer as inactive
           nginx-6195    [003] d... 285251.759335: bpf_trace_printk: [conn] s_h = 0, s_l = 64011aacffff0000, s_port=34418
           nginx-6195    [003] d... 285251.759336: bpf_trace_printk: [conn] d_h = 0, d_l = c2141aacffff0000, d_port=3012

Another send message by the same thread, but different connection information. The last SSL for the thread ID is associated to  0x561882481e20 so we end up associating this new connection information
           nginx-6195    [003] d... 285251.759338: bpf_trace_printk: === kprobe SSL tcp_sendmsg=6195 ssl=561882481e20 ===
           nginx-6195    [003] d.s1 285251.759389: bpf_trace_printk: === tcp_rcv_established id=6195 ===
           nginx-6195    [003] d.s1 285251.759400: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d.s1 285251.759400: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
           nginx-6195    [003] d.s1 285251.759410: bpf_trace_printk: === tcp_rcv_established id=6195 ===
           nginx-6195    [003] d.s1 285251.759412: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d.s1 285251.759413: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
           nginx-6195    [003] d.s1 285251.759415: bpf_trace_printk: === kprobe tcp_rate_check_app_limited=6195 sock=ffff8eaded168000 ===
           nginx-6195    [003] d.s1 285251.759417: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d.s1 285251.759418: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443

>>> correlating to the wrong information
           nginx-6195    [003] d.s1 285251.759420: bpf_trace_printk: Correlating SSL 561882481e20 to connection
           nginx-6195    [003] d.s1 285251.759421: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d.s1 285251.759422: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
           nginx-6195    [003] d.s1 285251.759424: bpf_trace_printk: marked buffer as inactive
           nginx-6195    [003] d.s1 285251.759425: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d.s1 285251.759426: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
           nginx-6195    [003] d.s1 285251.759427: bpf_trace_printk: === kprobe SSL tcp_sendmsg=6195 ssl=561882481e20 ===
           nginx-6195    [003] d... 285251.759433: bpf_trace_printk: === kretprobe tcp_sendmsg=6195 sent 836===
 puma srv tp 008-7631    [002] d... 285251.759437: bpf_trace_printk: === uprobe SSL_read id=7631 ssl=7f0ee2cefcd0 ===
           nginx-6195    [003] d... 285251.759439: bpf_trace_printk: === uretprobe SSL_write id=6195 args ffffb0024ccd9f38 ===
           nginx-6195    [003] d... 285251.759441: bpf_trace_printk: SSL_buf id=6195 ssl=561882481e20
           nginx-6195    [003] d... 285251.759442: bpf_trace_printk: SSL conn
           nginx-6195    [003] d... 285251.759442: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d... 285251.759443: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
           nginx-6195    [003] d... 285251.759445: bpf_trace_printk: buf=[HTTP/1.1 200 OK
Server:�RG�V], pid=6195, len=807

>>> we can't find the original request for the request start and we fail to close the request.
           nginx-6195    [003] d... 285251.759446: bpf_trace_printk: No info, pid =6195?
           nginx-6195    [003] d... 285251.759448: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
           nginx-6195    [003] d... 285251.759449: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
```

A bit later we see that this "wrong" connection information already has another SSL associated to it 0x7f0ee2cefcd0
```
 puma srv tp 008-7631    [002] d... 285251.759489: bpf_trace_printk: deleting sk_buff on
 puma srv tp 008-7631    [002] d... 285251.759489: bpf_trace_printk: [conn] s_h = 0, s_l = c2141aacffff0000, s_port=40994
 puma srv tp 008-7631    [002] d... 285251.759490: bpf_trace_printk: [conn] d_h = 0, d_l = a8e84903ffff0000, d_port=443
 puma srv tp 008-7631    [002] d... 285251.759491: bpf_trace_printk: tcp_recvmsg for an identified SSL connection, ignoring [7f0ee2cefcd0]...

```

~~So my new fix checks to see if the new connection pair we see is already associated to another SSL, then we avoid the correlation.~~
