### PR TITLE
Handle disconnects better

### DIFF
--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -496,6 +496,7 @@ int BPF_KPROBE(beyla_kprobe_tcp_close, struct sock *sk, long timeout) {
         sort_connection_info(&info.conn);
         //dbg_print_http_connection_info(&info.conn);
         info.pid = pid_from_pid_tgid(id);
+        terminate_http_request_if_needed(&info);
         bpf_map_delete_elem(&ongoing_tcp_req, &info);
         delete_backup_sk_buff(&info.conn);
     }

--- a/docs/sources/configure/tune-performance.md
+++ b/docs/sources/configure/tune-performance.md
@@ -44,12 +44,14 @@ An empty or unset value defaults to `auto`.
 
 | YAML                    | Environment variable               | Type    | Default |
 | ----------------------- | ---------------------------------- | ------- | ------- |
-| `http_request_timeout`  | `BEYLA_BPF_HTTP_REQUEST_TIMEOUT`   | string  | (30s)   |
+| `http_request_timeout`  | `BEYLA_BPF_HTTP_REQUEST_TIMEOUT`   | string  | (0ms)   |
 
 Configures the time interval after which an HTTP request is considered as a timeout.
 This option allows Beyla to report HTTP transactions which timeout and never return.
-To disable the automatic HTTP request timeout feature, set this option to zero,
-that is "0ms".
+To enable the automatic HTTP request timeout feature, set this option to a non-zero
+value. When a request is automatically timed out, Beyla will report the HTTP status
+code of 408. Disconnects can be misinterpreted as timeouts, therefore, setting this
+value may incorrectly increase your request averages.
 
 | YAML                    | Environment variable               | Type     | Default |
 | ----------------------- | ---------------------------------- | -------- | ------- |

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 	EBPF: config.EBPFTracer{
 		BatchLength:               100,
 		BatchTimeout:              time.Second,
-		HTTPRequestTimeout:        30 * time.Second,
+		HTTPRequestTimeout:        0,
 		TCBackend:                 tcmanager.TCBackendAuto,
 		ContextPropagationEnabled: false,
 		ContextPropagation:        config.ContextPropagationDisabled,

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -123,7 +123,7 @@ network:
 		EBPF: config.EBPFTracer{
 			BatchLength:               100,
 			BatchTimeout:              time.Second,
-			HTTPRequestTimeout:        30 * time.Second,
+			HTTPRequestTimeout:        0,
 			TCBackend:                 tcmanager.TCBackendAuto,
 			ContextPropagationEnabled: false,
 			ContextPropagation:        config.ContextPropagationDisabled,


### PR DESCRIPTION
For a while we've had the logic that completes artificially requests that have been left in limbo as timeouts with code 408. This was initially done to catch Beyla bugs, but in production systems it can cause confusion. With this change I'm doing the following:

1. I'm changing the default behaviour for this 408s to be optional, that is we can enable it specifically for customers if there are suspicions that there are missing requests, or customers can enable automatic timeouts if they want to. Us forcing a value will always have negative side-effects. One example is slow APIs, we'd time them out instead of reporting the actual time. Another example is disconnects, which could be immediate and we'd report 30seconds timeout, which incorrectly increases the latency numbers.
2. I've added code to detect disconnects, e.g. a request has started and then the client dropped the connection. In this case previously we'd report 408 timeout, now we report 400 (bad request) immediately as the tcp connection drops. I'm not sure if there's a better code to report here, I know NGINX uses 499 sometimes, but it's non-standard afaik.