### PR TITLE
Allow periods in route heuristics

### DIFF
--- a/pkg/internal/transform/route/cluster.go
+++ b/pkg/internal/transform/route/cluster.go
@@ -123,5 +123,5 @@ func okWord(w string) bool {
 }
 
 func isAlpha(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_'
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_' || c == '.'
 }

--- a/pkg/internal/transform/route/cluster_test.go
+++ b/pkg/internal/transform/route/cluster_test.go
@@ -37,6 +37,9 @@ func TestURLClustering(t *testing.T) {
 			assert.Equal(t, "/products/", ClusterPath("/products/", tc))
 			assert.Equal(t, "/user-space/", ClusterPath("/user-space/", tc))
 			assert.Equal(t, "/user_space/", ClusterPath("/user_space/", tc))
+			assert.Equal(t, "/api/hello.world", ClusterPath("/api/hello.world", tc))
+			assert.Equal(t, "/api/hello.world.again", ClusterPath("/api/hello.world.again", tc))
+			assert.Equal(t, "/api.backup/hello.world", ClusterPath("/api.backup/hello.world", tc))
 		})
 	}
 }


### PR DESCRIPTION
Closes #1849 

Allows periods in the route path heuristics so that RPC style path components are no longer replaced by the wildcard character.