### PR TITLE
Add option for process discovery to filter on containers

### DIFF
--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -192,6 +192,19 @@ executables in the host.
 If other selectors are specified in the same `services` entry, the processes to be
 selected need to match all the selector properties.
 
+| YAML              | Environment variable | Type    | Default |
+| ----------------- | -------------------- | --------| ------- |
+| `containers_only` | --                   | boolean |  false  |
+
+Selects processes to instrument which are running in an OCI container.
+To perform this check, Beyla inspects the process network namespace and 
+matches it against its own network namespace. This option is ignored, if 
+there are insufficient permissions given to the Beyla process to perform 
+the network namespace inspection.
+
+If other selectors are specified in the same `services` entry, the processes to be
+selected need to match all the selector properties.
+
 | YAML            | Environment variable | Type                        | Default |
 | --------------- | ------- | --------------------------- | ------- |
 | `k8s_namespace` | --      | string (regular expression) | (unset) |

--- a/pkg/internal/discover/matcher_test.go
+++ b/pkg/internal/discover/matcher_test.go
@@ -281,3 +281,69 @@ func TestCriteriaMatcherMissingPort(t *testing.T) {
 	assert.Equal(t, "foo", m.Obj.Criteria.Namespace)
 	assert.Equal(t, services.ProcessInfo{Pid: 3, ExePath: "/bin/weird33", OpenPorts: []uint32{}, PPid: 1}, *m.Obj.Process)
 }
+
+func TestCriteriaMatcherContainersOnly(t *testing.T) {
+	pipeConfig := beyla.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  services:
+  - name: port-only-containers
+    namespace: foo
+    open_ports: 80
+    containers_only: true
+`), &pipeConfig))
+
+	// override the namespace fetcher
+	namespaceFetcherFunc = func(pid int32) (string, error) {
+		switch pid {
+		case 1:
+			return "1", nil
+		case 2:
+			return "2", nil
+		case 3:
+			return "3", nil
+		}
+		panic("pid not exposed by test")
+	}
+
+	// override the os.Getpid func to that Beyla is always reported
+	// with pid 1
+	osPIDFunc = func() int {
+		return 1
+	}
+
+	discoveredProcesses := msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	matcherFunc, err := CriteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer filteredProcessesQu.Close()
+
+	// it will filter unmatching processes and return a ProcessMatch for these that match
+	processInfo = func(pp processAttrs) (*services.ProcessInfo, error) {
+		proc := map[PID]struct {
+			Exe  string
+			PPid int32
+		}{
+			1: {Exe: "/bin/weird33", PPid: 0}, 2: {Exe: "/bin/weird33", PPid: 0}, 3: {Exe: "/bin/weird33", PPid: 1}}[pp.pid]
+		return &services.ProcessInfo{Pid: int32(pp.pid), ExePath: proc.Exe, PPid: proc.PPid, OpenPorts: pp.openPorts}, nil
+	}
+	discoveredProcesses.Send([]Event[processAttrs]{
+		{Type: EventCreated, Obj: processAttrs{pid: 1, openPorts: []uint32{80}}}, // this one is the parent, matches on port, not in container
+		{Type: EventCreated, Obj: processAttrs{pid: 2, openPorts: []uint32{80}}}, // another pid, but in a container
+		{Type: EventCreated, Obj: processAttrs{pid: 3, openPorts: []uint32{80}}}, // this one is the child, without port, but matches the parent by port, in a container
+	})
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 2)
+	m := matches[0]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, "port-only-containers", m.Obj.Criteria.Name)
+	assert.Equal(t, "foo", m.Obj.Criteria.Namespace)
+	assert.Equal(t, services.ProcessInfo{Pid: 2, ExePath: "/bin/weird33", OpenPorts: []uint32{80}, PPid: 0}, *m.Obj.Process)
+	m = matches[1]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, "port-only-containers", m.Obj.Criteria.Name)
+	assert.Equal(t, "foo", m.Obj.Criteria.Namespace)
+	assert.Equal(t, services.ProcessInfo{Pid: 3, ExePath: "/bin/weird33", OpenPorts: []uint32{80}, PPid: 1}, *m.Obj.Process)
+}

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -137,6 +137,9 @@ type Attributes struct {
 
 	// PodAnnotations allows matching against the annotations of a pod
 	PodAnnotations map[string]*RegexpAttr `yaml:"k8s_pod_annotations"`
+
+	// Restrict the discovery to processes which are running inside a container
+	ContainersOnly bool `yaml:"containers_only"`
 }
 
 // PortEnum defines an enumeration of ports. It allows defining a set of single ports as well a set of

--- a/test/integration/configs/instrumenter-config-elixir.yml
+++ b/test/integration/configs/instrumenter-config-elixir.yml
@@ -8,3 +8,7 @@ attributes:
   select:
     "*":
       include: ["*"]
+discovery:
+  services:
+    - open_ports: 4000
+      containers_only: true      

--- a/test/integration/configs/instrumenter-config-http2.yml
+++ b/test/integration/configs/instrumenter-config-http2.yml
@@ -12,9 +12,11 @@ discovery:
     - namespace: http2-go
       name: client
       exe_path: http2client
+      containers_only: true
     - namespace: http2-go
       name: server
       exe_path: http2srv
+      containers_only: true
 attributes:
   select:
     "*":

--- a/test/integration/docker-compose-elixir.yml
+++ b/test/integration/docker-compose-elixir.yml
@@ -30,7 +30,6 @@ services:
     environment:
       GOCOVERDIR: "/coverage"
       BEYLA_TRACE_PRINTER: "text"
-      BEYLA_OPEN_PORT: "4000"
       BEYLA_DISCOVERY_POLL_INTERVAL: 500ms
       BEYLA_SERVICE_NAMESPACE: "integration-test"
       BEYLA_METRICS_INTERVAL: "10ms"


### PR DESCRIPTION
When Beyla runs as a daemonset it can find a lot of processes to instrument, sometimes system processes. To limit the impact of the processing pipeline, I'm introducing an option to further filter processes that are running as OCI containers. This way the default configuration supplied for Kubernetes environments can be focused on pods only.

Closes https://github.com/grafana/beyla/issues/1883