### PR TITLE
Group traces by their resource attributes

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -204,7 +204,7 @@ type Config struct {
 	// and both the "application" and "application_process" features are enabled
 	Processes process.CollectConfig `yaml:"processes"`
 
-	// Grafana Agent specific configuration
+	// Grafana Alloy specific configuration
 	TracesReceiver TracesReceiverConfig `yaml:"-"`
 }
 
@@ -213,7 +213,9 @@ type Consumer interface {
 }
 
 type TracesReceiverConfig struct {
-	Traces []Consumer
+	Traces           []Consumer
+	Sampler          otel.Sampler `yaml:"sampler"`
+	Instrumentations []string     `yaml:"instrumentations" env:"BEYLA_OTEL_TRACES_INSTRUMENTATIONS" envSeparator:","`
 }
 
 func (t TracesReceiverConfig) Enabled() bool {

--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
 	attr "github.com/grafana/beyla/v2/pkg/export/attributes/names"
+	"github.com/grafana/beyla/v2/pkg/export/instrumentations"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
@@ -31,6 +32,9 @@ func TracesReceiver(
 		tr := &tracesReceiver{
 			cfg: cfg, hostID: ctxInfo.HostID, spanMetricsEnabled: spanMetricsEnabled,
 			input: input.Subscribe(),
+			is: instrumentations.NewInstrumentationSelection([]string{
+				instrumentations.InstrumentationALL,
+			}),
 		}
 		// Get user attributes
 		if err := tr.fetchConstantAttributes(userAttribSelection); err != nil {
@@ -44,6 +48,7 @@ type tracesReceiver struct {
 	cfg                *beyla.TracesReceiverConfig
 	hostID             string
 	spanMetricsEnabled bool
+	is                 instrumentations.InstrumentationSelection
 	input              <-chan []request.Span
 	traceAttrs         map[attr.Name]struct{}
 }
@@ -61,24 +66,21 @@ func (tr *tracesReceiver) fetchConstantAttributes(attrs attributes.Selection) er
 	return nil
 }
 
-func (tr *tracesReceiver) spanDiscarded(span *request.Span) bool {
-	return span.IgnoreTraces() || span.Service.ExportsOTelTraces()
-}
-
 func (tr *tracesReceiver) provideLoop(ctx context.Context) {
-	for spans := range tr.input {
-		for i := range spans {
-			span := &spans[i]
-			if tr.spanDiscarded(span) {
-				continue
-			}
-			envResourceAttrs := otel.ResourceAttrsFromEnv(&span.Service)
+	sampler := tr.cfg.Sampler.Implementation()
 
-			for _, tc := range tr.cfg.Traces {
-				traces := otel.GenerateTraces(span, tr.hostID, tr.traceAttrs, envResourceAttrs)
-				err := tc.ConsumeTraces(ctx, traces)
-				if err != nil {
-					slog.Error("error sending trace to consumer", "error", err)
+	for spans := range tr.input {
+		spanGroups := otel.GroupSpans(ctx, spans, tr.traceAttrs, sampler, tr.is)
+		for _, spanGroup := range spanGroups {
+			if len(spanGroup) > 0 {
+				sample := spanGroup[0]
+				envResourceAttrs := otel.ResourceAttrsFromEnv(&sample.Span.Service)
+				for _, tc := range tr.cfg.Traces {
+					traces := otel.GenerateTraces(&sample.Span.Service, envResourceAttrs, tr.hostID, spanGroup)
+					err := tc.ConsumeTraces(ctx, traces)
+					if err != nil {
+						slog.Error("error sending trace to consumer", "error", err)
+					}
 				}
 			}
 		}

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -1,6 +1,7 @@
 package alloy
 
 import (
+	"context"
 	"encoding/binary"
 	"math/rand/v2"
 	"strconv"
@@ -10,15 +11,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/attributes"
 	attr "github.com/grafana/beyla/v2/pkg/export/attributes/names"
+	"github.com/grafana/beyla/v2/pkg/export/instrumentations"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
 	"github.com/grafana/beyla/v2/pkg/internal/request"
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestTracesSkipsInstrumented(t *testing.T) {
@@ -73,7 +75,7 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
-			Service:      svc.Attrs{},
+			Service:      svc.Attrs{UID: svc.UID{Pid: int32(i)}},
 			TraceID:      randomTraceID(),
 		}
 		spans = append(spans, span)
@@ -127,10 +129,38 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 	})
 }
 
+func TestTraceGrouping(t *testing.T) {
+	spans := []request.Span{}
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+		span := request.Span{Type: request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test" + strconv.Itoa(i),
+			Status:       200,
+			Service:      svc.Attrs{UID: svc.UID{Pid: 1}},
+			TraceID:      randomTraceID(),
+		}
+		spans = append(spans, span)
+	}
+
+	t.Run("test span grouping", func(t *testing.T) {
+		receiver := makeTracesTestReceiverWithSpanMetrics()
+
+		traces := generateTracesForSpans(t, receiver, spans)
+		assert.Equal(t, 1, len(traces))
+	})
+}
+
 func makeTracesTestReceiver() *tracesReceiver {
 	return &tracesReceiver{
 		cfg:    &beyla.TracesReceiverConfig{},
 		hostID: "Alloy",
+		is: instrumentations.NewInstrumentationSelection([]string{
+			instrumentations.InstrumentationALL,
+		}),
 	}
 }
 
@@ -139,6 +169,9 @@ func makeTracesTestReceiverWithSpanMetrics() *tracesReceiver {
 		cfg:                &beyla.TracesReceiverConfig{},
 		hostID:             "Alloy",
 		spanMetricsEnabled: true,
+		is: instrumentations.NewInstrumentationSelection([]string{
+			instrumentations.InstrumentationALL,
+		}),
 	}
 }
 
@@ -146,12 +179,15 @@ func generateTracesForSpans(t *testing.T, tr *tracesReceiver, spans []request.Sp
 	res := []ptrace.Traces{}
 	err := tr.fetchConstantAttributes(attributes.Selection{})
 	assert.NoError(t, err)
-	for i := range spans {
-		span := &spans[i]
-		if tr.spanDiscarded(span) {
-			continue
+
+	spanGroups := otel.GroupSpans(context.Background(), spans, tr.traceAttrs, sdktrace.AlwaysSample(), tr.is)
+	for _, spanGroup := range spanGroups {
+		if len(spanGroup) > 0 {
+			sample := spanGroup[0]
+			envResourceAttrs := otel.ResourceAttrsFromEnv(&sample.Span.Service)
+			traces := otel.GenerateTraces(&sample.Span.Service, envResourceAttrs, tr.hostID, spanGroup)
+			res = append(res, traces)
 		}
-		res = append(res, otel.GenerateTraces(span, tr.hostID, tr.traceAttrs, []attribute.KeyValue{}))
 	}
 
 	return res

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -55,6 +55,11 @@ const reporterName = "github.com/grafana/beyla"
 
 var serviceAttrCache = expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute)
 
+type TraceSpanAndAttributes struct {
+	Span       *request.Span
+	Attributes []attribute.KeyValue
+}
+
 type TracesConfig struct {
 	CommonEndpoint string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	TracesEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
@@ -203,27 +208,29 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 	return traceAttrs, nil
 }
 
-func (tr *tracesOTELReceiver) spanDiscarded(span *request.Span) bool {
-	return span.IgnoreTraces() || span.Service.ExportsOTelTraces() || !tr.acceptSpan(span)
+func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
+	return span.IgnoreTraces() || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
 }
 
-func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
+func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
+	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
+
 	for i := range spans {
 		span := &spans[i]
 		if span.InternalSignal() {
 			continue
 		}
-		if tr.spanDiscarded(span) {
+		if spanDiscarded(span, is) {
 			continue
 		}
 
-		finalAttrs := traceAttributes(span, traceAttrs)
+		finalAttrs := TraceAttributes(span, traceAttrs)
 
 		sr := sampler.ShouldSample(trace.SamplingParameters{
 			ParentContext: ctx,
 			Name:          span.TraceName(),
 			TraceID:       span.TraceID,
-			Kind:          spanKind(span),
+			Kind:          SpanKind(span),
 			Attributes:    finalAttrs,
 		})
 
@@ -231,11 +238,29 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			continue
 		}
 
-		envResourceAttrs := ResourceAttrsFromEnv(&span.Service)
-		traces := GenerateTracesWithAttributes(span, tr.ctxInfo.HostID, finalAttrs, envResourceAttrs)
-		err := exp.ConsumeTraces(ctx, traces)
-		if err != nil {
-			slog.Error("error sending trace to consumer", "error", err)
+		group, ok := spanGroups[span.Service.UID]
+		if !ok {
+			group = []TraceSpanAndAttributes{}
+		}
+		group = append(group, TraceSpanAndAttributes{Span: span, Attributes: finalAttrs})
+		spanGroups[span.Service.UID] = group
+	}
+
+	return spanGroups
+}
+
+func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
+	spanGroups := GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
+
+	for _, spanGroup := range spanGroups {
+		if len(spanGroup) > 0 {
+			sample := spanGroup[0]
+			envResourceAttrs := ResourceAttrsFromEnv(&sample.Span.Service)
+			traces := generateTracesWithAttributes(&sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup)
+			err := exp.ConsumeTraces(ctx, traces)
+			if err != nil {
+				slog.Error("error sending trace to consumer", "error", err)
+			}
 		}
 	}
 }
@@ -469,59 +494,66 @@ func traceAppResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyVal
 	return attrs
 }
 
-func GenerateTracesWithAttributes(span *request.Span, hostID string, attrs []attribute.KeyValue, envResourceAttrs []attribute.KeyValue) ptrace.Traces {
-	t := span.Timings()
-	start := spanStartTime(t)
-	hasSubSpans := t.Start.After(start)
+func generateTracesWithAttributes(svc *svc.Attrs, envResourceAttrs []attribute.KeyValue, hostID string, spans []TraceSpanAndAttributes) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
-	ss := rs.ScopeSpans().AppendEmpty()
-	resourceAttrs := traceAppResourceAttrs(hostID, &span.Service)
+	resourceAttrs := traceAppResourceAttrs(hostID, svc)
 	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
 	resourceAttrsMap := attrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
 	resourceAttrsMap.CopyTo(rs.Resource().Attributes())
 
-	traceID := pcommon.TraceID(span.TraceID)
-	spanID := pcommon.SpanID(RandomSpanID())
-	// This should never happen
-	if traceID.IsEmpty() {
-		traceID = pcommon.TraceID(RandomTraceID())
+	for _, spanWithAttributes := range spans {
+		span := spanWithAttributes.Span
+		attrs := spanWithAttributes.Attributes
+
+		ss := rs.ScopeSpans().AppendEmpty()
+
+		t := span.Timings()
+		start := spanStartTime(t)
+		hasSubSpans := t.Start.After(start)
+
+		traceID := pcommon.TraceID(span.TraceID)
+		spanID := pcommon.SpanID(RandomSpanID())
+		// This should never happen
+		if traceID.IsEmpty() {
+			traceID = pcommon.TraceID(RandomTraceID())
+		}
+
+		if hasSubSpans {
+			createSubSpans(span, spanID, traceID, &ss, t)
+		} else if span.SpanID.IsValid() {
+			spanID = pcommon.SpanID(span.SpanID)
+		}
+
+		// Create a parent span for the whole request session
+		s := ss.Spans().AppendEmpty()
+		s.SetName(span.TraceName())
+		s.SetKind(ptrace.SpanKind(SpanKind(span)))
+		s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+
+		// Set trace and span IDs
+		s.SetSpanID(spanID)
+		s.SetTraceID(traceID)
+		if span.ParentSpanID.IsValid() {
+			s.SetParentSpanID(pcommon.SpanID(span.ParentSpanID))
+		}
+
+		// Set span attributes
+		m := attrsToMap(attrs)
+		m.CopyTo(s.Attributes())
+
+		// Set status code
+		statusCode := codeToStatusCode(request.SpanStatusCode(span))
+		s.Status().SetCode(statusCode)
+		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
 	}
-
-	if hasSubSpans {
-		createSubSpans(span, spanID, traceID, &ss, t)
-	} else if span.SpanID.IsValid() {
-		spanID = pcommon.SpanID(span.SpanID)
-	}
-
-	// Create a parent span for the whole request session
-	s := ss.Spans().AppendEmpty()
-	s.SetName(span.TraceName())
-	s.SetKind(ptrace.SpanKind(spanKind(span)))
-	s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
-
-	// Set trace and span IDs
-	s.SetSpanID(spanID)
-	s.SetTraceID(traceID)
-	if span.ParentSpanID.IsValid() {
-		s.SetParentSpanID(pcommon.SpanID(span.ParentSpanID))
-	}
-
-	// Set span attributes
-	m := attrsToMap(attrs)
-	m.CopyTo(s.Attributes())
-
-	// Set status code
-	statusCode := codeToStatusCode(request.SpanStatusCode(span))
-	s.Status().SetCode(statusCode)
-	s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
 	return traces
 }
 
 // GenerateTraces creates a ptrace.Traces from a request.Span
-func GenerateTraces(span *request.Span, hostID string, userAttrs map[attr.Name]struct{}, envResourceAttrs []attribute.KeyValue) ptrace.Traces {
-	return GenerateTracesWithAttributes(span, hostID, traceAttributes(span, userAttrs), envResourceAttrs)
+func GenerateTraces(svc *svc.Attrs, envResourceAttrs []attribute.KeyValue, hostID string, spans []TraceSpanAndAttributes) ptrace.Traces {
+	return generateTracesWithAttributes(svc, envResourceAttrs, hostID, spans)
 }
 
 // createSubSpans creates the internal spans for a request.Span
@@ -606,18 +638,18 @@ func grpcTracer(ctx context.Context, opts otlpOptions) (*otlptrace.Exporter, err
 	return texp, nil
 }
 
-func (tr *tracesOTELReceiver) acceptSpan(span *request.Span) bool {
+func acceptSpan(is instrumentations.InstrumentationSelection, span *request.Span) bool {
 	switch span.Type {
 	case request.EventTypeHTTP, request.EventTypeHTTPClient:
-		return tr.is.HTTPEnabled()
+		return is.HTTPEnabled()
 	case request.EventTypeGRPC, request.EventTypeGRPCClient:
-		return tr.is.GRPCEnabled()
+		return is.GRPCEnabled()
 	case request.EventTypeSQLClient:
-		return tr.is.SQLEnabled()
+		return is.SQLEnabled()
 	case request.EventTypeRedisClient, request.EventTypeRedisServer:
-		return tr.is.RedisEnabled()
+		return is.RedisEnabled()
 	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
-		return tr.is.KafkaEnabled()
+		return is.KafkaEnabled()
 	}
 
 	return false
@@ -628,7 +660,7 @@ var dbSystemRedis = attribute.String(string(attr.DBSystemName), semconv.DBSystem
 var spanMetricsSkip = attribute.Bool(string(attr.SkipSpanMetrics), true)
 
 // nolint:cyclop
-func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
+func TraceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	switch span.Type {
@@ -733,7 +765,7 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 	return attrs
 }
 
-func spanKind(span *request.Span) trace2.SpanKind {
+func SpanKind(span *request.Span) trace2.SpanKind {
 	switch span.Type {
 	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer:
 		return trace2.SpanKindServer

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -362,6 +362,12 @@ func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 	})
 }
 
+func groupFromSpanAndAttributes(span *request.Span, attrs []attribute.KeyValue) []TraceSpanAndAttributes {
+	groups := []TraceSpanAndAttributes{}
+	groups = append(groups, TraceSpanAndAttributes{Span: span, Attributes: attrs})
+	return groups
+}
+
 func TestGenerateTraces(t *testing.T) {
 	t.Run("test with subtraces - with parent spanId", func(t *testing.T) {
 		start := time.Now()
@@ -379,8 +385,10 @@ func TestGenerateTraces(t *testing.T) {
 			ParentSpanID: parentSpanID,
 			TraceID:      traceID,
 			SpanID:       spanID,
+			Service:      svc.Attrs{UID: svc.UID{Pid: 1}},
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -425,7 +433,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -461,7 +469,7 @@ func TestGenerateTraces(t *testing.T) {
 			Route:        "/test",
 			Status:       200,
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -498,7 +506,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -523,7 +531,8 @@ func TestGenerateTraces(t *testing.T) {
 			ParentSpanID: parentSpanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -543,7 +552,7 @@ func TestGenerateTraces(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test",
 		}
-		traces := GenerateTraces(span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -559,7 +568,8 @@ func TestGenerateTraces(t *testing.T) {
 func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, no statement", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		traces := GenerateTraces(&span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -580,7 +590,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		traces := GenerateTraces(&span, "host-id", map[attr.Name]struct{}{"db.operation.name": {}}, []attribute.KeyValue{})
+		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -601,7 +612,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		traces := GenerateTraces(&span, "host-id", map[attr.Name]struct{}{attr.DBQueryText: {}}, []attribute.KeyValue{})
+		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -621,7 +633,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	})
 	t.Run("test Kafka trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeKafkaClient, Method: "process", Path: "important-topic", Statement: "test"}
-		traces := GenerateTraces(&span, "host-id", map[attr.Name]struct{}{}, []attribute.KeyValue{})
+		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
+		traces := GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -641,7 +654,9 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		defer restoreEnvAfterExecution()()
 		require.NoError(t, os.Setenv(envResourceAttrs, "deployment.environment=productions,source.upstream=beyla"))
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
-		traces := GenerateTraces(&span, "host-id", map[attr.Name]struct{}{}, ResourceAttrsFromEnv(&span.Service))
+
+		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
+		traces := GenerateTraces(&span.Service, ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		rs := traces.ResourceSpans().At(0)
@@ -662,8 +677,8 @@ func TestTraceSampling(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
-			Service:      svc.Attrs{},
 			TraceID:      RandomTraceID(),
+			Service:      svc.Attrs{UID: svc.UID{Pid: int32(i)}},
 		}
 		spans = append(spans, span)
 	}
@@ -733,7 +748,7 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
-			Service:      svc.Attrs{},
+			Service:      svc.Attrs{UID: svc.UID{Pid: int32(i)}},
 			TraceID:      RandomTraceID(),
 		}
 		spans = append(spans, span)
@@ -1437,7 +1452,7 @@ func TestHostPeerAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attrs := traceAttributes(&tt.span, nil)
+			attrs := TraceAttributes(&tt.span, nil)
 			if tt.server != "" {
 				var found attribute.KeyValue
 				for _, a := range attrs {
@@ -1460,6 +1475,43 @@ func TestHostPeerAttributes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTraceGrouping(t *testing.T) {
+	spans := []request.Span{}
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+		span := request.Span{Type: request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test" + strconv.Itoa(i),
+			Status:       200,
+			TraceID:      RandomTraceID(),
+			Service:      svc.Attrs{UID: svc.UID{Pid: 1}}, // Same service for all spans
+		}
+		spans = append(spans, span)
+	}
+
+	receiver := makeTracesTestReceiver([]string{"http"})
+
+	t.Run("test sample all, same service", func(t *testing.T) {
+		sampler := sdktrace.AlwaysSample()
+		attrs := make(map[attr.Name]struct{})
+
+		tr := []ptrace.Traces{}
+
+		exporter := TestExporter{
+			collector: func(td ptrace.Traces) {
+				tr = append(tr, td)
+			},
+		}
+
+		receiver.processSpans(context.Background(), exporter, spans, attrs, sampler)
+		// We should make only one trace, all spans under the same resource attributes
+		assert.Equal(t, 1, len(tr))
+	})
 }
 
 func makeSQLRequestSpan(sql string) request.Span {
@@ -1512,12 +1564,15 @@ func generateTracesForSpans(t *testing.T, tr *tracesOTELReceiver, spans []reques
 	res := []ptrace.Traces{}
 	traceAttrs, err := GetUserSelectedAttributes(tr.attributes)
 	assert.NoError(t, err)
+
 	for i := range spans {
 		span := &spans[i]
-		if tr.spanDiscarded(span) {
+		if spanDiscarded(span, tr.is) {
 			continue
 		}
-		res = append(res, GenerateTraces(span, "host-id", traceAttrs, []attribute.KeyValue{}))
+		tAttrs := TraceAttributes(span, traceAttrs)
+
+		res = append(res, GenerateTraces(&span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
 	}
 
 	return res


### PR DESCRIPTION
The current way Beyla was sending traces is quite inefficient, since we were constructing the spans resource array for each individual spans. This causes the resource attributes to be created for each individual span.

Instead the new approach first groups the spans array by their service and then creates one resource array for the group.

Closes https://github.com/grafana/beyla/issues/1854