### PR TITLE
Fix tracking stale requests

### DIFF
--- a/bpf/common/trace_common.h
+++ b/bpf/common/trace_common.h
@@ -258,9 +258,10 @@ static __always_inline u8 find_trace_for_server_request(connection_info_t *conn,
                     // We only do it for HTTP because TCP can be confused with SSL
                     existing_tp->valid = 0;
                     set_trace_info_for_connection(conn, TRACE_TYPE_CLIENT, existing_tp);
+                    bpf_dbg_printk("setting the client info as used");
                 }
             } else {
-                bpf_d_printk("the existing client tp was already used, ignoring");
+                bpf_dbg_printk("the existing client tp was already used, ignoring");
             }
         }
     }

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -101,7 +101,7 @@ static __always_inline void http_get_or_create_trace_info(http_connection_metada
             //dbg_print_http_connection_info(conn);
 
             // For server requests, we first look for TCP info (setup by TC ingress) and then we fall back to black-box info.
-            found_tp = find_trace_for_server_request(conn, &tp_p->tp);
+            found_tp = find_trace_for_server_request(conn, &tp_p->tp, EVENT_HTTP_REQUEST);
         }
     }
 
@@ -233,10 +233,6 @@ static __always_inline u8 http_will_complete(http_info_t *info, unsigned char *b
 
 static __always_inline u8 is_duplicate_info(http_info_t *info) {
     u64 ts = bpf_ktime_get_ns();
-    bpf_printk("%d %d %d",
-               info->start_monotime_ns,
-               (ts >= info->start_monotime_ns),
-               current_immediate_epoch(ts) == current_immediate_epoch(info->start_monotime_ns));
     return info->start_monotime_ns && (ts >= info->start_monotime_ns) &&
            current_immediate_epoch(ts) == current_immediate_epoch(info->start_monotime_ns);
 }

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -75,7 +75,7 @@ tcp_get_or_set_trace_info(tcp_req_t *req, pid_connection_info_t *pid_conn, u8 ss
 
         set_tcp_trace_info(TRACE_TYPE_CLIENT, &pid_conn->conn, &req->tp, pid_conn->pid, ssl);
     } else { // Server
-        u8 found = find_trace_for_server_request(&pid_conn->conn, &req->tp);
+        u8 found = find_trace_for_server_request(&pid_conn->conn, &req->tp, TRACE_TYPE_SERVER);
         bpf_dbg_printk("Looking up server trace info, found %d", found);
         if (found) {
             urand_bytes(req->tp.span_id, SPAN_ID_SIZE_BYTES);

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -75,7 +75,7 @@ tcp_get_or_set_trace_info(tcp_req_t *req, pid_connection_info_t *pid_conn, u8 ss
 
         set_tcp_trace_info(TRACE_TYPE_CLIENT, &pid_conn->conn, &req->tp, pid_conn->pid, ssl);
     } else { // Server
-        u8 found = find_trace_for_server_request(&pid_conn->conn, &req->tp, TRACE_TYPE_SERVER);
+        u8 found = find_trace_for_server_request(&pid_conn->conn, &req->tp, EVENT_TCP_REQUEST);
         bpf_dbg_printk("Looking up server trace info, found %d", found);
         if (found) {
             urand_bytes(req->tp.span_id, SPAN_ID_SIZE_BYTES);


### PR DESCRIPTION
Fixes an issue when a client request that's not cleaned up can mess up our request tracking. It also fixes an issue where duplicate kprobes can cause black-box context propagation to not work.