### PR TITLE
Introduce Required() method

### DIFF
--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -3,7 +3,6 @@ package discover
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/config"
@@ -83,27 +82,16 @@ func newCommonTracersGroup(cfg *beyla.Config) []ebpf.Tracer {
 		return []ebpf.Tracer{httptracer.New(cfg)}
 	}
 
-	tracers := []ebpf.Tracer{}
-
 	switch cfg.EBPF.ContextPropagation {
 	case config.ContextPropagationAll:
-		if tctracer.CanRun() {
-			tracers = append(tracers, tctracer.New(cfg))
-		} else {
-			slog.Warn("L4 trace context propagation cannot be enabled, missing host PID or host network access")
-		}
-		tracers = append(tracers, tpinjector.New(cfg))
+		return []ebpf.Tracer{tctracer.New(cfg), tpinjector.New(cfg)}
 	case config.ContextPropagationHeadersOnly:
-		tracers = append(tracers, tpinjector.New(cfg))
+		return []ebpf.Tracer{tpinjector.New(cfg)}
 	case config.ContextPropagationIPOptionsOnly:
-		if tctracer.CanRun() {
-			tracers = append(tracers, tctracer.New(cfg))
-		} else {
-			slog.Warn("L4 trace context propagation cannot be enabled, missing host PID or host network access")
-		}
+		return []ebpf.Tracer{tctracer.New(cfg)}
 	}
 
-	return tracers
+	return []ebpf.Tracer{}
 }
 
 func newGoTracersGroup(cfg *beyla.Config, metrics imetrics.Reporter) []ebpf.Tracer {

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -532,3 +532,7 @@ func (p *Tracer) watchForMisclassifedEvents() {
 		}
 	}
 }
+
+func (p *Tracer) Required() bool {
+	return true
+}

--- a/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
@@ -44,3 +44,4 @@ func (p *Tracer) Constants() map[string]any                              { retur
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                         {}
+func (p *Tracer) Required() bool                                         { return false }

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -422,3 +422,7 @@ func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span])
 		p.metrics,
 	)(ctx, append(p.closers, &p.bpfObjects), eventsChan)
 }
+
+func (p *Tracer) Required() bool {
+	return true
+}

--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -538,3 +538,7 @@ func (p *Tracer) findSymbolAddresses(f *elf.File) (*SymbolTree, error) {
 
 	return &t, nil
 }
+
+func (p *Tracer) Required() bool {
+	return false
+}

--- a/pkg/internal/ebpf/httptracer/httptracer.go
+++ b/pkg/internal/ebpf/httptracer/httptracer.go
@@ -173,3 +173,7 @@ func (p *Tracer) stopTC() {
 	p.tcManager.Shutdown()
 	p.tcManager = nil
 }
+
+func (p *Tracer) Required() bool {
+	return false
+}

--- a/pkg/internal/ebpf/httptracer/httptracer_notlinux.go
+++ b/pkg/internal/ebpf/httptracer/httptracer_notlinux.go
@@ -43,3 +43,4 @@ func (p *Tracer) Constants() map[string]any                              { retur
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                         {}
+func (p *Tracer) Required() bool                                         { return false }

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -163,3 +163,7 @@ func (p *Tracer) stopTC() {
 	p.ifaceManager.Wait()
 	p.ifaceManager = nil
 }
+
+func (p *Tracer) Required() bool {
+	return false
+}

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -41,11 +41,6 @@ func New(cfg *beyla.Config) *Tracer {
 	}
 }
 
-func CanRun() bool {
-	hostNet, err := ebpfcommon.HasHostNetworkAccess()
-	return err == nil && hostNet && ebpfcommon.HasHostPidAccess()
-}
-
 func (p *Tracer) AllowPID(uint32, uint32, *svc.Attrs) {}
 
 func (p *Tracer) BlockPID(uint32, uint32) {}

--- a/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
+++ b/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
@@ -43,5 +43,4 @@ func (p *Tracer) Constants() map[string]any                              { retur
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                         {}
-
-func CanRun() bool { return false }
+func (p *Tracer) Required() bool                                         { return false }

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -4,7 +4,6 @@ package tpinjector
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 
@@ -43,21 +42,6 @@ func (p *Tracer) AllowPID(uint32, uint32, *svc.Attrs) {}
 func (p *Tracer) BlockPID(uint32, uint32) {}
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
-
-	if !ebpfcommon.HasHostPidAccess() {
-		return nil, fmt.Errorf("L4/L7 context-propagation requires host process ID access, e.g. hostPid:true")
-	}
-
-	hostNet, err := ebpfcommon.HasHostNetworkAccess()
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to check for host network access while enabling L7 context-propagation, error: %w", err)
-	}
-
-	if !hostNet {
-		return nil, fmt.Errorf("L7 context-propagation requires host network access, e.g. hostNetwork:true")
-	}
-
 	if p.cfg.EBPF.BpfDebug {
 		return loadBpf_debug()
 	}
@@ -168,4 +152,8 @@ func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
 	p.bpfObjects.Close()
 
 	p.log.Debug("tpinjector terminated")
+}
+
+func (p *Tracer) Required() bool {
+	return false
 }

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -4,6 +4,7 @@ package tpinjector
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 
@@ -42,6 +43,21 @@ func (p *Tracer) AllowPID(uint32, uint32, *svc.Attrs) {}
 func (p *Tracer) BlockPID(uint32, uint32) {}
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
+
+	if !ebpfcommon.HasHostPidAccess() {
+		return nil, fmt.Errorf("L4/L7 context-propagation requires host process ID access, e.g. hostPid:true")
+	}
+
+	hostNet, err := ebpfcommon.HasHostNetworkAccess()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for host network access while enabling L7 context-propagation, error: %w", err)
+	}
+
+	if !hostNet {
+		return nil, fmt.Errorf("L7 context-propagation requires host network access, e.g. hostNetwork:true")
+	}
+
 	if p.cfg.EBPF.BpfDebug {
 		return loadBpf_debug()
 	}

--- a/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
@@ -43,3 +43,4 @@ func (p *Tracer) Constants() map[string]any                              { retur
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                         {}
+func (p *Tracer) Required() bool                                         { return false }

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -95,6 +95,7 @@ type Tracer interface {
 	UnlinkInstrumentedLib(uint64)
 	RegisterOffsets(*exec.FileInfo, *goexec.Offsets)
 	ProcessBinary(*exec.FileInfo)
+	Required() bool
 	// Run will do the action of listening for eBPF traces and forward them
 	// periodically to the output channel.
 	Run(context.Context, *msg.Queue[[]request.Span])

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -222,20 +222,14 @@ func (pt *ProcessTracer) loadTracers() error {
 	defer loadMux.Unlock()
 
 	var log = ptlog()
-	anyLoaded := false
+
 	for _, p := range pt.Programs {
 		if err := pt.loadTracer(p, log); err != nil {
-			log.Warn("couldn't load tracer", "error", err)
-		} else {
-			anyLoaded = true
+			return err
 		}
 	}
 
 	btf.FlushKernelSpec()
-
-	if !anyLoaded {
-		return fmt.Errorf("failed to load all tracers for this program type")
-	}
 
 	return nil
 }

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -223,11 +223,21 @@ func (pt *ProcessTracer) loadTracers() error {
 
 	var log = ptlog()
 
+	loadedPrograms := make([]Tracer, 0, len(pt.Programs))
+
 	for _, p := range pt.Programs {
 		if err := pt.loadTracer(p, log); err != nil {
-			return err
+			log.Warn("couldn't load tracer", "error", err, "required", p.Required())
+
+			if p.Required() {
+				return err
+			}
+		} else {
+			loadedPrograms = append(loadedPrograms, p)
 		}
 	}
+
+	pt.Programs = loadedPrograms
 
 	btf.FlushKernelSpec()
 


### PR DESCRIPTION
This relates to #1887 - it should have been part of the PR but it ended up being left out accidentally.

The idea is to introduction the notion of whether a tracer is required, rather than have an explicit `CanRun()` method.