### PR TITLE
Fix block in instrumentable discovery

### DIFF
--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -194,6 +194,10 @@ func (i *Instrumenter) stop() error {
 	}
 }
 
+// These process creation and deletion events are used to create/delete
+// the metrics target_info, traces_target_info. If we don't have metrics
+// enabled, not consuming them will eventually block the instrumentation
+// pipeline.
 func (i *Instrumenter) processEventsEnabled() bool {
 	return i.config.Metrics.Enabled() || i.config.Prometheus.Enabled()
 }

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -50,7 +50,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen))
 
 	newEventQueue := func() *msg.Queue[exec.ProcessEvent] {
-		return msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(config.ChannelBufferLen))
+		return msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(config.ChannelBufferLen), msg.NotBlockIfNoSubscribers())
 	}
 
 	swi := &swarm.Instancer{}
@@ -194,18 +194,8 @@ func (i *Instrumenter) stop() error {
 	}
 }
 
-// These process creation and deletion events are used to create/delete
-// the metrics target_info, traces_target_info. If we don't have metrics
-// enabled, not consuming them will eventually block the instrumentation
-// pipeline.
-func (i *Instrumenter) processEventsEnabled() bool {
-	return i.config.Metrics.Enabled() || i.config.Prometheus.Enabled()
-}
-
 func (i *Instrumenter) handleAndDispatchProcessEvent(pe exec.ProcessEvent) {
-	if i.processEventsEnabled() {
-		i.processEventInput.Send(pe)
-	}
+	i.processEventInput.Send(pe)
 }
 
 func setupFeatureContextInfo(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config) {

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/internal/discover"
+	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
@@ -109,45 +110,47 @@ func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
 
 	// In background, listen indefinitely for each new process and run its
 	// associated ebpf.ProcessTracer once it is found.
-	go func() {
-		log := log()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ev := <-processEvents:
-				switch ev.Type {
-				case discover.EventCreated:
-					pt := ev.Obj
-					log.Debug("running tracer for new process",
-						"inode", pt.FileInfo.Ino, "pid", pt.FileInfo.Pid, "exec", pt.FileInfo.CmdExePath)
-					if pt.Tracer != nil {
-						i.tracersWg.Add(1)
-						go func() {
-							defer i.tracersWg.Done()
-							pt.Tracer.Run(ctx, i.tracesInput)
-						}()
-					}
-					i.processEventInput.Send(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: pt.FileInfo})
-				case discover.EventDeleted:
-					dp := ev.Obj
-					log.Debug("stopping ProcessTracer because there are no more instances of such process",
-						"inode", dp.FileInfo.Ino, "pid", dp.FileInfo.Pid, "exec", dp.FileInfo.CmdExePath)
-					if dp.Tracer != nil {
-						dp.Tracer.UnlinkExecutable(dp.FileInfo)
-					}
-					i.processEventInput.Send(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: dp.FileInfo})
-				case discover.EventInstanceDeleted:
-					i.processEventInput.Send(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: ev.Obj.FileInfo})
-				default:
-					log.Error("BUG ALERT! unknown event type", "type", ev.Type)
-				}
-			}
-		}
-	}()
+	go i.instrumentedEventLoop(ctx, processEvents)
 
 	// TODO: wait until all the resources have been freed/unmounted
 	return nil
+}
+
+func (i *Instrumenter) instrumentedEventLoop(ctx context.Context, processEvents <-chan discover.Event[*ebpf.Instrumentable]) {
+	log := log()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-processEvents:
+			switch ev.Type {
+			case discover.EventCreated:
+				pt := ev.Obj
+				log.Debug("running tracer for new process",
+					"inode", pt.FileInfo.Ino, "pid", pt.FileInfo.Pid, "exec", pt.FileInfo.CmdExePath)
+				if pt.Tracer != nil {
+					i.tracersWg.Add(1)
+					go func() {
+						defer i.tracersWg.Done()
+						pt.Tracer.Run(ctx, i.tracesInput)
+					}()
+				}
+				i.handleAndDispatchProcessEvent(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: pt.FileInfo})
+			case discover.EventDeleted:
+				dp := ev.Obj
+				log.Debug("stopping ProcessTracer because there are no more instances of such process",
+					"inode", dp.FileInfo.Ino, "pid", dp.FileInfo.Pid, "exec", dp.FileInfo.CmdExePath)
+				if dp.Tracer != nil {
+					dp.Tracer.UnlinkExecutable(dp.FileInfo)
+				}
+				i.handleAndDispatchProcessEvent(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: dp.FileInfo})
+			case discover.EventInstanceDeleted:
+				i.handleAndDispatchProcessEvent(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: ev.Obj.FileInfo})
+			default:
+				log.Error("BUG ALERT! unknown event type", "type", ev.Type)
+			}
+		}
+	}
 }
 
 // ReadAndForward keeps listening for traces in the BPF map, then reads,
@@ -188,6 +191,16 @@ func (i *Instrumenter) stop() error {
 		return errShutdownTimeout
 	case <-stopped:
 		return nil
+	}
+}
+
+func (i *Instrumenter) processEventsEnabled() bool {
+	return i.config.Metrics.Enabled() || i.config.Prometheus.Enabled()
+}
+
+func (i *Instrumenter) handleAndDispatchProcessEvent(pe exec.ProcessEvent) {
+	if i.processEventsEnabled() {
+		i.processEventInput.Send(pe)
 	}
 }
 

--- a/pkg/internal/appolly/appolly_test.go
+++ b/pkg/internal/appolly/appolly_test.go
@@ -1,0 +1,97 @@
+package appolly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/beyla/v2/pkg/beyla"
+	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/export/prom"
+	"github.com/grafana/beyla/v2/pkg/internal/connector"
+	"github.com/grafana/beyla/v2/pkg/internal/discover"
+	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
+	"github.com/grafana/beyla/v2/pkg/internal/exec"
+	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessEventsHandled(t *testing.T) {
+	instr, err := New(
+		context.Background(),
+		&global.ContextInfo{
+			Prometheus: &connector.PrometheusManager{},
+		},
+		&beyla.Config{
+			Prometheus: prom.PrometheusConfig{
+				Path:     "/metrics",
+				Port:     8080,
+				Features: []string{otel.FeatureApplication},
+				TTL:      time.Hour,
+			},
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.True(t, instr.processEventsEnabled())
+
+	instr, err = New(
+		context.Background(),
+		&global.ContextInfo{
+			Prometheus: &connector.PrometheusManager{},
+		},
+		&beyla.Config{
+			Metrics: otel.MetricsConfig{
+				MetricsEndpoint:   "http://something",
+				ReportersCacheLen: 10,
+				Features:          []string{otel.FeatureApplication},
+			},
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.True(t, instr.processEventsEnabled())
+
+	instr, err = New(
+		context.Background(),
+		&global.ContextInfo{
+			Prometheus: &connector.PrometheusManager{},
+		},
+		&beyla.Config{
+			Traces: otel.TracesConfig{
+				TracesEndpoint: "http://something",
+			},
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.False(t, instr.processEventsEnabled())
+}
+
+func TestProcessEventsLoopDoesntBlock(t *testing.T) {
+	instr, err := New(
+		context.Background(),
+		&global.ContextInfo{
+			Prometheus: &connector.PrometheusManager{},
+		},
+		&beyla.Config{
+			ChannelBufferLen: 1,
+			Traces: otel.TracesConfig{
+				TracesEndpoint: "http://something",
+			},
+		},
+	)
+
+	events := make(chan discover.Event[*ebpf.Instrumentable])
+
+	go instr.instrumentedEventLoop(context.Background(), events)
+
+	for i := 0; i < 100; i++ {
+		events <- discover.Event[*ebpf.Instrumentable]{
+			Obj:  &ebpf.Instrumentable{FileInfo: &exec.FileInfo{Pid: int32(i)}},
+			Type: discover.EventCreated,
+		}
+	}
+
+	assert.NoError(t, err)
+}

--- a/pkg/internal/appolly/appolly_test.go
+++ b/pkg/internal/appolly/appolly_test.go
@@ -3,71 +3,17 @@ package appolly
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
-	"github.com/grafana/beyla/v2/pkg/export/prom"
 	"github.com/grafana/beyla/v2/pkg/internal/connector"
 	"github.com/grafana/beyla/v2/pkg/internal/discover"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
 )
-
-func TestProcessEventsHandled(t *testing.T) {
-	instr, err := New(
-		context.Background(),
-		&global.ContextInfo{
-			Prometheus: &connector.PrometheusManager{},
-		},
-		&beyla.Config{
-			Prometheus: prom.PrometheusConfig{
-				Path:     "/metrics",
-				Port:     8080,
-				Features: []string{otel.FeatureApplication},
-				TTL:      time.Hour,
-			},
-		},
-	)
-
-	assert.NoError(t, err)
-	assert.True(t, instr.processEventsEnabled())
-
-	instr, err = New(
-		context.Background(),
-		&global.ContextInfo{
-			Prometheus: &connector.PrometheusManager{},
-		},
-		&beyla.Config{
-			Metrics: otel.MetricsConfig{
-				MetricsEndpoint:   "http://something",
-				ReportersCacheLen: 10,
-				Features:          []string{otel.FeatureApplication},
-			},
-		},
-	)
-
-	assert.NoError(t, err)
-	assert.True(t, instr.processEventsEnabled())
-
-	instr, err = New(
-		context.Background(),
-		&global.ContextInfo{
-			Prometheus: &connector.PrometheusManager{},
-		},
-		&beyla.Config{
-			Traces: otel.TracesConfig{
-				TracesEndpoint: "http://something",
-			},
-		},
-	)
-
-	assert.NoError(t, err)
-	assert.False(t, instr.processEventsEnabled())
-}
 
 func TestProcessEventsLoopDoesntBlock(t *testing.T) {
 	instr, err := New(

--- a/pkg/internal/appolly/appolly_test.go
+++ b/pkg/internal/appolly/appolly_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
 	"github.com/grafana/beyla/v2/pkg/export/prom"
@@ -13,7 +15,6 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessEventsHandled(t *testing.T) {


### PR DESCRIPTION
Recent change to create the target_info metric based on process discovery would block the discovery pipeline if no metric exporter was loaded. This would happen because neither Prometheus nor OTel metrics exporter would be created to consume the process events.