### PR TITLE
Align span status to http semantic conventions

### DIFF
--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -1242,18 +1242,18 @@ func TestTraces_HTTPStatus(t *testing.T) {
 
 	t.Run("HTTP server testing", func(t *testing.T) {
 		for _, p := range []testPair{
-			{100, request.StatusCodeOk},
-			{103, request.StatusCodeOk},
-			{199, request.StatusCodeOk},
-			{200, request.StatusCodeOk},
-			{204, request.StatusCodeOk},
-			{299, request.StatusCodeOk},
-			{300, request.StatusCodeOk},
-			{399, request.StatusCodeOk},
-			{400, request.StatusCodeOk},
-			{404, request.StatusCodeOk},
-			{405, request.StatusCodeOk},
-			{499, request.StatusCodeOk},
+			{100, request.StatusCodeUnset},
+			{103, request.StatusCodeUnset},
+			{199, request.StatusCodeUnset},
+			{200, request.StatusCodeUnset},
+			{204, request.StatusCodeUnset},
+			{299, request.StatusCodeUnset},
+			{300, request.StatusCodeUnset},
+			{399, request.StatusCodeUnset},
+			{400, request.StatusCodeUnset},
+			{404, request.StatusCodeUnset},
+			{405, request.StatusCodeUnset},
+			{499, request.StatusCodeUnset},
 			{500, request.StatusCodeError},
 			{5999, request.StatusCodeError},
 		} {
@@ -1266,14 +1266,14 @@ func TestTraces_HTTPStatus(t *testing.T) {
 
 	t.Run("HTTP client testing", func(t *testing.T) {
 		for _, p := range []testPair{
-			{100, request.StatusCodeOk},
-			{103, request.StatusCodeOk},
-			{199, request.StatusCodeOk},
-			{200, request.StatusCodeOk},
-			{204, request.StatusCodeOk},
-			{299, request.StatusCodeOk},
-			{300, request.StatusCodeOk},
-			{399, request.StatusCodeOk},
+			{100, request.StatusCodeUnset},
+			{103, request.StatusCodeUnset},
+			{199, request.StatusCodeUnset},
+			{200, request.StatusCodeUnset},
+			{204, request.StatusCodeUnset},
+			{299, request.StatusCodeUnset},
+			{300, request.StatusCodeUnset},
+			{399, request.StatusCodeUnset},
 			{400, request.StatusCodeError},
 			{404, request.StatusCodeError},
 			{405, request.StatusCodeError},
@@ -1297,7 +1297,7 @@ func TestTraces_GRPCStatus(t *testing.T) {
 
 	t.Run("gRPC server testing", func(t *testing.T) {
 		for _, p := range []testPair{
-			{semconv.RPCGRPCStatusCodeOk, request.StatusCodeOk},
+			{semconv.RPCGRPCStatusCodeOk, request.StatusCodeUnset},
 			{semconv.RPCGRPCStatusCodeCancelled, request.StatusCodeUnset},
 			{semconv.RPCGRPCStatusCodeUnknown, request.StatusCodeError},
 			{semconv.RPCGRPCStatusCodeInvalidArgument, request.StatusCodeUnset},
@@ -1324,7 +1324,7 @@ func TestTraces_GRPCStatus(t *testing.T) {
 
 	t.Run("gRPC client testing", func(t *testing.T) {
 		for _, p := range []testPair{
-			{semconv.RPCGRPCStatusCodeOk, request.StatusCodeOk},
+			{semconv.RPCGRPCStatusCodeOk, request.StatusCodeUnset},
 			{semconv.RPCGRPCStatusCodeCancelled, request.StatusCodeError},
 			{semconv.RPCGRPCStatusCodeUnknown, request.StatusCodeError},
 			{semconv.RPCGRPCStatusCodeInvalidArgument, request.StatusCodeError},

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -394,10 +394,10 @@ func HTTPSpanStatusCode(span *Span) string {
 
 	if span.Type == EventTypeHTTPClient {
 		if span.Status < 400 {
-			return StatusCodeOk
+			return StatusCodeUnset
 		}
 	} else if span.Status < 500 {
-		return StatusCodeOk
+		return StatusCodeUnset
 	}
 
 	return StatusCodeError
@@ -415,16 +415,13 @@ var (
 
 // https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/rpc/#grpc-status
 func GrpcSpanStatusCode(span *Span) string {
-	if span.Status == grpcStatusCodeOK {
-		return StatusCodeOk
-	}
-
-	if span.Type == EventTypeGRPCClient {
+	if span.Type == EventTypeGRPCClient && span.Status != grpcStatusCodeOK {
 		return StatusCodeError
 	}
+
 	switch span.Status {
 	case grpcStatusCodeOK:
-		return StatusCodeOk
+		return StatusCodeUnset
 	case grpcStatusCodeUnknown, grpcStatusCodeDeadlineExceeded, grpcStatusCodeUnimplemented,
 		grpcStatusCodeInternal, grpcStatusCodeUnavailable, grpcStatusCodeDataLoss:
 		return StatusCodeError
@@ -531,7 +528,7 @@ func (s *Span) isTracesExportURL() bool {
 
 func (s *Span) IsExportMetricsSpan() bool {
 	// check if it's a successful client call
-	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeOk) {
+	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeUnset) {
 		return false
 	}
 
@@ -540,7 +537,7 @@ func (s *Span) IsExportMetricsSpan() bool {
 
 func (s *Span) IsExportTracesSpan() bool {
 	// check if it's a successful client call
-	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeOk) {
+	if !s.isHTTPOrGRPCClient() || (SpanStatusCode(s) != StatusCodeUnset) {
 		return false
 	}
 

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -128,7 +128,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 		var err error
 		results, err = pq.Query(`traces_spanmetrics_latency_count{` +
 			`span_kind="SPAN_KIND_SERVER",` +
-			`status_code="STATUS_CODE_OK",` + // 404 is OK for server spans
+			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
 			`service_namespace="` + svcNs + `",` +
 			`service="` + svcName + `",` +
 			`span_name="GET /basic/:rnd"` +
@@ -144,7 +144,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 		var err error
 		results, err = pq.Query(`traces_spanmetrics_calls_total{` +
 			`span_kind="SPAN_KIND_SERVER",` +
-			`status_code="STATUS_CODE_OK",` + // 404 is OK for server spans
+			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
 			`service_namespace="` + svcNs + `",` +
 			`service="` + svcName + `",` +
 			`span_name="GET /basic/:rnd"` +


### PR DESCRIPTION
See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status

Though I must admit, this took a lot of squinting and is easy to get wrong. I wonder if there is any way we can automate testing the data against semantic conventions to make sure that we're not missing anything else.