### PR TITLE
Fix Backport PR GH action and restore deleted GH action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,7 @@
 name: Backport PR creator
 on:
-  push:
+  pull_request_target:
+    types: [closed]
     branches: [ 'main' ]
 
 # Set restrictive permissions at workflow level
@@ -9,10 +10,8 @@ permissions:
 
 jobs:
   main:
-    # For security, github.event.pull_request.merged == true must be checked
-    # to make sure that the provided actions are only executed when a maintainer
-    # merges the PR
-    if: github.repository == 'grafana/beyla'
+    # Only run this job when a PR was merged (not just closed without merging)
+    if: github.repository == 'grafana/beyla' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # Grant specific permissions needed only for this job
     permissions:

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,26 @@
+name: Check Undocumented Fields
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'docs/**/*.md'
+  push:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'docs/**/*.md'
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          
+      - name: Run documentation checker
+        run: go run ./tools/doc-checker/main.go 


### PR DESCRIPTION
In https://github.com/grafana/beyla/pull/1865 we fixed some security issues for GH actions. 
As part of this task, the _Backport PR creator_ action broke and _Check Undocumented Fields_ was removed.

After merging https://github.com/grafana/beyla/pull/1894, we can safely bring back the deleted GH action.

