### PR TITLE
Introduce option to only generate ebpf files when modified

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -12,8 +12,6 @@ FROM base AS dist
 
 WORKDIR /src
 
-VOLUME ["/src"]
-
 ARG EBPF_VER
 
 RUN apk add clang llvm19 wget
@@ -24,6 +22,7 @@ COPY --from=builder /build/beyla_genfiles /go/bin
 RUN cat <<EOF > /generate.sh
 #!/bin/sh
 export GOCACHE=/tmp
+export GOMODCACHE=/tmp/go-mod-cache
 export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"


### PR DESCRIPTION
This partially reintroduces the functionality removed by #1786 - namely, the ability of only regenerate .o files (and the .go bindings) when the corresponding .c file has been modified, with the added caveat that this is now behind a config option and is disabled by default (so regular users shouldn't see any changes). The config option is the only new addition, the rest of the relevant code has been brought back verbatim.

The motivation is to further experiments with binary generation as discussed in the ebpf and go SIGs - I've been meaning to do this for a while and those discussions pushed me to revive this.