### PR TITLE
Remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.o filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/generate-binaries.yml
+++ b/.github/workflows/generate-binaries.yml
@@ -31,12 +31,6 @@ jobs:
 
       - name: Generate eBPF binaries
         run: make docker-generate
-        
-      - name: Generate Java agent
-        run: |
-          cd pkg/internal/otelsdk
-          go generate
-          cd -
 
       - name: Force add generated binaries
         run: |


### PR DESCRIPTION
- We removed git lfs but wed didn't remove .gitattributes, which prevents pushing binaries to release branchs.
- Remove Generate java agent from step from GH actions that generates binaries. That is generated with `make docker-generate`.