### PR TITLE
Associate gen image version with the current branch/release

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -1,6 +1,8 @@
 name: Publish Beyla Docker Generator Image
 on:
   workflow_dispatch:
+  push:
+    branches: [ 'main', 'release-*' ]
 
 # Set restrictive permissions at workflow level
 permissions:
@@ -13,6 +15,9 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    # compute VERSION = "x.y" if branch is release-x.y, otherwise "main"
+    env:
+      VERSION: ${{ startsWith(github.ref, 'refs/heads/release-') && substring(github.ref, 19) || 'main' }}
 
     permissions:
       contents: read
@@ -58,4 +63,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.timestamp.outputs.ts }}"
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the autoinstrumenter binary
-FROM ghcr.io/grafana/beyla-ebpf-generator:main AS builder
+ARG VER=main
+
+FROM ghcr.io/grafana/beyla-ebpf-generator:$VER AS builder
 
 # TODO: embed software version in executable
 


### PR DESCRIPTION
Ensure that release branches will reference the docker generator image with the corresponding version. Other branches will default to referencing `beyla-ebpf-generator:main`.

For example, `release-2.3`would always reference `beyla-ebpf-generator:2.3`, ensuring breaking changes on `main` do not spill back to the release branches.

I've also updated the generator image workflow to push it to registry every time there's a commit in main or release-, ensuring it's always up to date (hopefully that will work).