### PR TITLE
fix Beyla cache ports in helm chart

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.7.4
-appVersion: 2.1.0
+version: 1.7.5
+appVersion: 2.2.3
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -25,7 +25,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 |-----|------|---------|-------------|
 | affinity | object | `{}` | used for scheduling of pods based on affinity rules |
 | config.create | bool | `true` | set to true, to use the below default configurations |
-| config.data | object | `{"attributes":{"kubernetes":{"enable":true},"select":{"beyla_network_flow_bytes":{"include":["k8s.src.owner.type","k8s.dst.owner.type","direction"]}}},"filter":{"network":{"k8s_dst_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"},"k8s_src_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"}}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
+| config.data | object | `{"attributes":{"kubernetes":{"enable":true}},"filter":{"network":{"k8s_dst_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"},"k8s_src_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"}}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
 | config.name | string | `""` |  |
 | config.skipConfigMapCheck | bool | `false` | set to true, to skip the check around the ConfigMap creation |
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` | Determines how DNS resolution is handled for that pod. If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Beyla requires `hostNetwork` access, causing cluster service DNS resolution to fail. It is recommended not to change this if Beyla sends traces and metrics to Grafana components via k8s service. |
@@ -101,7 +101,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | serviceMonitor.metrics.endpoint | object | `{"interval":"15s"}` | ServiceMonitor Prometheus scraping endpoint. Target port and path is set based on service and `prometheus_export` values. For additional values, see the ServiceMonitor spec |
 | tolerations | list | `[]` | Tolerations allow pods to be scheduled on nodes with specific taints |
 | updateStrategy.type | string | `"RollingUpdate"` | update strategy type |
-| volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
+| volumeMounts | list | `[]` | Additional volumeMounts on the output daemonset definition. |
 | volumes | list | `[]` | Additional volumes on the output daemonset definition. |
 
 ----------------------------------------------

--- a/charts/beyla/templates/cache-deployment.yaml
+++ b/charts/beyla/templates/cache-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.k8sCache.replicas }}
+{{- if and .Values.k8sCache.replicas (gt (int .Values.k8sCache.replicas) 0) }}
 {{- $root := . }}
 apiVersion: apps/v1
 kind: Deployment
@@ -45,12 +45,14 @@ spec:
             - containerPort: {{ .Values.k8sCache.service.port }}
               protocol: TCP
               name: grpc
-          {{- if .Values.k8sCache.profilePort }}
+          {{- if and .Values.k8sCache.profilePort
+              (gt (int .Values.k8sCache.profilePort) 0)}}
             - name: profile
               containerPort: {{ .Values.k8sCache.profilePort }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.k8sCache.internalMetrics.port }}
+          {{- if and .Values.k8sCache.internalMetrics.port
+                (gt (int .Values.k8sCache.internalMetrics.port) 0) }}
             - name: {{ .Values.k8sCache.internalMetrics.portName }}
               containerPort: {{ .Values.k8sCache.internalMetrics.port }}
               protocol: TCP
@@ -62,11 +64,13 @@ spec:
           env:
             - name: BEYLA_K8S_CACHE_PORT
               value: "{{ .Values.k8sCache.service.port }}"
-          {{- if .Values.k8sCache.profilePort }}
+          {{- if and .Values.k8sCache.profilePort
+              (gt (int .Values.k8sCache.profilePort) 0)}}
             - name: BEYLA_K8S_CACHE_PROFILE_PORT
               value: "{{ .Values.k8sCache.profilePort }}"
           {{- end }}
-          {{- if .Values.k8sCache.internalMetrics.port }}
+          {{- if and .Values.k8sCache.internalMetrics.port
+                (gt (int .Values.k8sCache.internalMetrics.port) 0) }}
             - name: BEYLA_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PORT
               value: "{{ .Values.k8sCache.internalMetrics.port }}"
           {{- end }}

--- a/charts/beyla/templates/cache-service.yaml
+++ b/charts/beyla/templates/cache-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.k8sCache.replicas }}
+{{- if and .Values.k8sCache.replicas (gt (int .Values.k8sCache.replicas) 0) }}
 {{- $root := . }}
 apiVersion: v1
 kind: Service

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -91,7 +91,7 @@ spec:
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"
-          {{- if .Values.k8sCache.replicas }}
+          {{- if and .Values.k8sCache.replicas (gt (int .Values.k8sCache.replicas) 0) }}
             - name: BEYLA_KUBE_META_CACHE_ADDRESS
               value: {{ .Values.k8sCache.service.name }}:{{ .Values.k8sCache.service.port }}
           {{- end }}


### PR DESCRIPTION
For some reason, deploying Beyla cache started to fail with:

```
	* Deployment.apps "beyla-k8s-cache" is invalid: [spec.template.spec.containers[0].ports[1].containerPort: Required value, spec.template.spec.containers[0].ports[2].containerPort: Required value]
```

Zero values were interpreted as `false` but now they are started to be interpreted as `true`. Adding extra checks in some conditions.