### PR TITLE
Fix race condition in K8s informers

### DIFF
--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -54,7 +54,10 @@ func (inf *Informers) Subscribe(observer Observer) {
 	storedEntities = append(storedEntities, pods...)
 	storedEntities = append(storedEntities, nodes...)
 	storedEntities = append(storedEntities, services...)
-	for _, entity := range inf.sortAndCut(storedEntities, fromEpoch) {
+	storedEntities = inf.sortAndCut(storedEntities, fromEpoch)
+	inf.log.Debug("sending welcome snapshot to new observer",
+		"observerID", observer.ID(), "count", len(storedEntities))
+	for _, entity := range storedEntities {
 		if err := observer.On(&informer.Event{
 			Type:     informer.EventType_CREATED,
 			Resource: entity.(*indexableEntity).EncodedMeta,

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -381,6 +381,7 @@ func (inf *Informers) podToIndexableEntity(pod *v1.Pod) (interface{}, error) {
 				Owners:       ownersFrom(&pod.ObjectMeta),
 				HostIp:       pod.Status.HostIP,
 			},
+			StatusTimeEpoch: objLastUpdateTime(&pod.ObjectMeta, pod.Status.Conditions, nil),
 		},
 	}, nil
 }
@@ -457,11 +458,12 @@ func (inf *Informers) initNodeIPInformer(ctx context.Context, informerFactory in
 		return &indexableEntity{
 			ObjectMeta: minimalIndex(&node.ObjectMeta),
 			EncodedMeta: &informer.ObjectMeta{
-				Name:      node.Name,
-				Namespace: node.Namespace,
-				Labels:    node.Labels,
-				Ips:       ips,
-				Kind:      typeNode,
+				Name:            node.Name,
+				Namespace:       node.Namespace,
+				Labels:          node.Labels,
+				Ips:             ips,
+				Kind:            typeNode,
+				StatusTimeEpoch: objLastUpdateTime(&node.ObjectMeta, nil, node.Status.Conditions),
 			},
 		}, nil
 	}); err != nil {
@@ -499,14 +501,16 @@ func (inf *Informers) initServiceIPInformer(ctx context.Context, informerFactory
 		if svc.Spec.ClusterIP != v1.ClusterIPNone {
 			ips = svc.Spec.ClusterIPs
 		}
+
 		return &indexableEntity{
 			ObjectMeta: minimalIndex(&svc.ObjectMeta),
 			EncodedMeta: &informer.ObjectMeta{
-				Name:      svc.Name,
-				Namespace: svc.Namespace,
-				Labels:    svc.Labels,
-				Ips:       ips,
-				Kind:      typeService,
+				Name:            svc.Name,
+				Namespace:       svc.Namespace,
+				Labels:          svc.Labels,
+				Ips:             ips,
+				Kind:            typeService,
+				StatusTimeEpoch: objLastUpdateTime(&svc.ObjectMeta, nil, nil),
 			},
 		}, nil
 	}); err != nil {
@@ -520,6 +524,26 @@ func (inf *Informers) initServiceIPInformer(ctx context.Context, informerFactory
 
 	inf.services = services
 	return nil
+}
+
+func objLastUpdateTime(
+	om *metav1.ObjectMeta, podConditions []v1.PodCondition, nodeConditions []v1.NodeCondition,
+) int64 {
+	if om.DeletionTimestamp != nil {
+		return om.DeletionTimestamp.Unix()
+	}
+	lastStatus := om.CreationTimestamp
+	for i := range podConditions {
+		if podConditions[i].LastTransitionTime.After(lastStatus.Time) {
+			lastStatus = podConditions[i].LastTransitionTime
+		}
+	}
+	for i := range nodeConditions {
+		if nodeConditions[i].LastTransitionTime.After(lastStatus.Time) {
+			lastStatus = podConditions[i].LastTransitionTime
+		}
+	}
+	return lastStatus.Unix()
 }
 
 func headlessService(om *informer.ObjectMeta) bool {

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -540,7 +540,7 @@ func objLastUpdateTime(
 	}
 	for i := range nodeConditions {
 		if nodeConditions[i].LastTransitionTime.After(lastStatus.Time) {
-			lastStatus = podConditions[i].LastTransitionTime
+			lastStatus = nodeConditions[i].LastTransitionTime
 		}
 	}
 	return lastStatus.Unix()

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -97,7 +97,9 @@ func (ic *InformersCache) Subscribe(msg *informer.SubscribeMessage, server infor
 		fromEpoch:   msg.GetFromTimestampEpoch(),
 		messages:    sync.NewQueue[*informer.Event](),
 	}
-	ic.log.Info("client subscribed", "id", o.ID())
+	ic.log.Info("client subscribed", "id", o.ID(),
+		"fromEpoch", o.fromEpoch,
+		"fromLast", time.Since(time.Unix(o.fromEpoch, 0)))
 	ic.informers.Subscribe(o)
 
 	// Keep the connection open


### PR DESCRIPTION
Since the Kubernetes event handler do not have a defined order, using them to define the last status update of the stored entities was a bad Idea because they could be modified before the data is stored (and accessed e.g. for ordering).

This patch makes sure that the kubernetes entities are immutable, since the `StatusTimeEpoch` field is inferred from metadata before it is stored in the Informer storage.