### PR TITLE
Fix permissions of helm-release GH action

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,7 +4,8 @@ on:
 
 # Set restrictive permissions at workflow level
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 jobs:
   release-beyla-helm-chart:


### PR DESCRIPTION
Helm release task does not work. It shown this error:

> The workflow is not valid. .github/workflows/helm-release.yml (Line: 10, Col: 3): Error calling workflow 'grafana/helm-charts/.github/workflows/update-helm-repo.yaml@87cb2cd95f44387e010aa49c22466dd6d86a2ae9'. The nested job 'release' is requesting 'contents: write, packages: write', but is only allowed 'contents: read, packages: none'.
