### PR TITLE
[Draft] Adds support for tracing JSON-RPC 2.0 requests

### DIFF
--- a/bpf/common/http_info.h
+++ b/bpf/common/http_info.h
@@ -8,6 +8,8 @@
 #include <pid/pid_helpers.h>
 
 #define FULL_BUF_SIZE 256
+#define JSONRPC_METHOD_SIZE 64
+#define JSONRPC_ID_SIZE 32
 
 // Here we keep the information that is sent on the ring buffer
 typedef struct http_info {
@@ -27,4 +29,9 @@ typedef struct http_info {
     u16 status;
     unsigned char buf[FULL_BUF_SIZE];
     u8 _pad[6];
+    // JSON-RPC specific fields
+    unsigned char jsonrpc_method[JSONRPC_METHOD_SIZE];
+    unsigned char jsonrpc_id[JSONRPC_ID_SIZE];
+    u32 jsonrpc_params_len;
+    u8 is_jsonrpc;
 } http_info_t;

--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -17,6 +17,7 @@
 #define EVENT_GO_KAFKA 9
 #define EVENT_GO_REDIS 10
 #define EVENT_GO_KAFKA_SEG 11 // the segment-io version (kafka-go) has different format
+#define EVENT_JSONRPC 12 // JSON-RPC 2.0 events
 
 // setting here the following map definitions without pinning them to a global namespace
 // would lead that services running both HTTP and GRPC server would duplicate

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,3 @@
+prometheus_export:
+  port: 8999
+  path: /metrics

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  # Service to instrument. Change it to any
+  # other container that you want to instrument.
+  jsonrpc:
+    image: ghcr.io/4406arthur/mock-server:jsonrpc
+    ports:
+      - "8899:8899"
+
+  autoinstrumenter:
+    image: ghcr.io/4406arthur/beyla:v0.1.0
+    pull_policy: always
+    command: ["-config", "/etc/beyla/config.yaml"]
+    pid: "service:jsonrpc"
+    privileged: true
+    environment:
+      BEYLA_TRACE_PRINTER: text
+      BEYLA_OPEN_PORT: 8899
+      BEYLA_PROTOCOL_DEBUG_PRINT: "TRUE"
+      BEYLA_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph,ebpf"
+      BEYLA_BPF_DEBUG: "TRUE"
+      BEYLA_LOG_LEVEL: "DEBUG"
+    volumes:
+      - ./configs/config.yaml:/etc/beyla/config.yaml
+    ports:
+      # Expose Prometheus metrics port
+      - "8999:8999"

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -35,6 +35,7 @@ const (
 	EventTypeKafkaServer
 	EventTypeGPUKernelLaunch
 	EventTypeGPUMalloc
+	EventTypeJSONRPC
 )
 
 const (
@@ -83,6 +84,8 @@ func (t EventType) String() string {
 		return "CUDALaunch"
 	case EventTypeGPUMalloc:
 		return "CUDAMalloc"
+	case EventTypeJSONRPC:
+		return "JSONRPC"
 	default:
 		return fmt.Sprintf("UNKNOWN (%d)", t)
 	}
@@ -246,16 +249,17 @@ func spanAttributes(s *Span) SpanAttributes {
 			"operation":  s.Method,
 			"clientId":   s.OtherNamespace,
 		}
-	case EventTypeGPUKernelLaunch:
+	case EventTypeJSONRPC:
 		return SpanAttributes{
-			"function":  s.Method,
-			"callStack": s.Path,
-			"gridSize":  strconv.FormatInt(s.ContentLength, 10),
-			"blockSize": strconv.Itoa(s.SubType),
-		}
-	case EventTypeGPUMalloc:
-		return SpanAttributes{
-			"size": strconv.FormatInt(s.ContentLength, 10),
+			"method":      "POST", // JSON-RPC uses POST
+			"rpc.method":  s.Path, // JSON-RPC method will be in the Path field
+			"status":      strconv.Itoa(s.Status),
+			"contentLen":  strconv.FormatInt(s.ContentLength, 10),
+			"responseLen": strconv.FormatInt(s.ResponseLength, 10),
+			"clientAddr":  SpanPeer(s),
+			"serverAddr":  SpanHost(s),
+			"serverPort":  strconv.Itoa(s.HostPort),
+			"rpc.system":  "jsonrpc",
 		}
 	}
 

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -47,7 +47,14 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.RPCMethod:
 		getter = func(s *Span) attribute.KeyValue { return semconv.RPCMethod(s.Path) }
 	case attr.RPCSystem:
-		getter = func(_ *Span) attribute.KeyValue { return semconv.RPCSystemGRPC }
+		getter = func(s *Span) attribute.KeyValue {
+			switch s.Type {
+			case EventTypeJSONRPC:
+				return semconv.RPCSystemKey.String("jsonrpc")
+			default:
+				return semconv.RPCSystemGRPC
+			}
+		}
 	case attr.RPCGRPCStatusCode:
 		getter = func(s *Span) attribute.KeyValue { return semconv.RPCGRPCStatusCodeKey.Int(s.Status) }
 	case attr.Server:


### PR DESCRIPTION
Adds support for tracing JSON-RPC 2.0 requests.
This enables more detailed monitoring and analysis of JSON-RPC based applications.


currently still cannot turn JSONRPC request into the new event_type (still with eventType 1) while send a JSONRPC request
<img width="800" alt="image" src="https://github.com/user-attachments/assets/a4ad2d57-ffb2-47a5-b351-ae84603310f9" />


can debug with the docker-compose 
```
docker-compose up -d

#send a test request
curl http://localhost:8899 -X POST -H "Content-Type: application/json" --data '{"method":"getSlot","id":1,"jsonrpc":"2.0"}'
```



