### PR TITLE
[2.2] Fixes for target info and Alloy integration

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -727,11 +727,11 @@ func optionalDirectGaugeProvider(enable bool, provider func() *prometheus.GaugeV
 
 func (r *metricsReporter) reportMetrics(ctx context.Context) {
 	go r.promConnect.StartHTTP(ctx)
-	go r.watchForProcessEvents()
 	r.collectMetrics(ctx)
 }
 
 func (r *metricsReporter) collectMetrics(_ context.Context) {
+	go r.watchForProcessEvents()
 	for spans := range r.input {
 		// clock needs to be updated to let the expirer
 		// remove the old metrics

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -52,7 +51,6 @@ const (
 	hostIDKey        = "host_id"
 	hostNameKey      = "host_name"
 	grafanaHostIDKey = "grafana_host_id"
-	processPIDKey    = "process_pid"
 	osTypeKey        = "os_type"
 
 	k8sNamespaceName   = "k8s_namespace_name"
@@ -918,7 +916,6 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 		telemetryLanguageKey,
 		telemetrySDKKey,
 		sourceKey,
-		processPIDKey,
 		osTypeKey,
 	}
 
@@ -944,7 +941,6 @@ func (r *metricsReporter) labelValuesTargetInfo(service *svc.Attrs) []string {
 		service.SDKLanguage.String(),
 		"beyla",
 		"beyla",
-		strconv.Itoa(int(service.ProcPID)),
 		"linux",
 	}
 


### PR DESCRIPTION
This PR fixes two issues:

- Ports the change from main https://github.com/grafana/beyla/pull/1960/files#diff-9d59fb01efb252d4c7a0eef931ba39644853ba4d4393223c55c5bef58c5340a7L56 related to removal of PID from target_info to prevent cardinality explosion.
- Ensures that the new processing of executable events is also active for Alloy. `reportMetrics` is specific to standalone Beyla where it also initialises the port, but we should be activating the event processing for Alloy too.