### PR TITLE
Move Prometheus goroutine start to work for Alloy too

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -743,11 +743,13 @@ func optionalDirectGaugeProvider(enable bool, provider func() *prometheus.GaugeV
 
 func (r *metricsReporter) reportMetrics(ctx context.Context) {
 	go r.promConnect.StartHTTP(ctx)
-	go r.watchForProcessEvents()
 	r.collectMetrics(ctx)
 }
 
+// This function is called directly by the Alloy integration. It differs from
+// reportMetrics in the fact that it doesn't setup the scrape endpoint.
 func (r *metricsReporter) collectMetrics(_ context.Context) {
+	go r.watchForProcessEvents()
 	for spans := range r.input {
 		// clock needs to be updated to let the expirer
 		// remove the old metrics


### PR DESCRIPTION
This is a port of a fix I made for Alloy here https://github.com/grafana/beyla/pull/1981.

I merged the fix to 2.2 first because I wanted to ensure the fix lands before Alloy makes the release cut. If we are not draining the events here we will miss events and not write anything to target_info.