### PR TITLE
Switch some log lines to debug

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -244,7 +244,7 @@ func (ta *TraceAttacher) loadExecutable(ie *ebpf.Instrumentable) (*link.Executab
 	// to allow loading it from different container/pods in containerized environments
 	exe, err := link.OpenExecutable(ie.FileInfo.ProExeLinkPath)
 	if err != nil {
-		ta.log.Warn("can't open executable. Ignoring",
+		ta.log.Debug("can't open executable. Ignoring",
 			"error", err, "pid", ie.FileInfo.Pid, "cmd", ie.FileInfo.CmdExePath)
 		return nil, false
 	}

--- a/pkg/internal/ebpf/common/pids.go
+++ b/pkg/internal/ebpf/common/pids.go
@@ -181,7 +181,7 @@ func (pf *PIDsFilter) addPID(pid, nsid uint32, s *svc.Attrs, t PIDType) {
 	allPids, err := readNamespacePIDs(int32(pid))
 
 	if err != nil {
-		pf.log.Error("Error looking up namespaced pids", "pid", pid, "error", err)
+		pf.log.Debug("Error looking up namespaced pids", "pid", pid, "error", err)
 		return
 	}
 


### PR DESCRIPTION
These two lines can produce false positives and commonly happen for short lived processes:

Closes https://github.com/grafana/beyla/issues/1986