### PR TITLE
Standardise to service_name everywhere and provide k8s_kind label

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -317,7 +317,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 				attr.Server:            false,
 				attr.ServerNamespace:   false,
 				attr.Source:            false,
-				attr.Service:           false,
+				attr.ServiceName:       false,
 				attr.ServiceInstanceID: false,
 				attr.ServiceNamespace:  false,
 				attr.SpanKind:          false,

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -137,6 +137,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 			attr.K8sPodStartTime:    true,
 			attr.K8sClusterName:     true,
 			attr.K8sOwnerName:       true,
+			attr.K8sKind:            true,
 		},
 	}
 

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -37,7 +37,6 @@ const (
 	SpanName               = Name("span.name")
 	StatusCode             = Name("status.code")
 	Source                 = Name("source")
-	Service                = Name("service")
 	Client                 = Name("client")
 	ClientNamespace        = Name("client_service_namespace")
 	Server                 = Name("server")

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -66,6 +66,7 @@ const (
 	K8sNodeName        = Name("k8s.node.name")
 	K8sPodUID          = Name("k8s.pod.uid")
 	K8sPodStartTime    = Name("k8s.pod.start_time")
+	K8sKind            = Name("k8s.kind")
 )
 
 // Beyla-specific network attributes

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -940,7 +940,7 @@ func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribut
 		return *attribute.EmptySet()
 	}
 	baseAttrs := []attribute.KeyValue{
-		request.ServiceMetric(service.UID.Name),
+		semconv.ServiceName(service.UID.Name),
 		semconv.ServiceInstanceID(service.UID.Instance),
 		semconv.ServiceNamespace(service.UID.Namespace),
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
@@ -974,7 +974,7 @@ func (mr *MetricsReporter) metricHostAttributes() attribute.Set {
 func (mr *MetricsReporter) spanMetricAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
 	return append(attributes.OpenTelemetryGetters(
 		request.SpanOTELGetters, []attr.Name{
-			attr.Service,
+			attr.ServiceName,
 			attr.ServiceInstanceID,
 			attr.ServiceNamespace,
 			attr.SpanKind,

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -749,7 +749,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 			},
 			attributeSelect: attributes.Selection{},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -787,7 +787,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -826,7 +826,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -865,7 +865,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -46,7 +46,7 @@ const (
 	ServiceGraphFailed = "traces_service_graph_request_failed_total"
 	ServiceGraphTotal  = "traces_service_graph_request_total"
 
-	serviceKey          = "service"
+	serviceNameKey      = "service_name"
 	serviceNamespaceKey = "service_namespace"
 
 	hostIDKey        = "host_id"
@@ -911,7 +911,7 @@ func appendK8sLabelValuesService(values []string, service *svc.Attrs) []string {
 }
 
 func labelNamesSpans() []string {
-	return []string{serviceKey, serviceNamespaceKey, spanNameKey, statusCodeKey, spanKindKey, serviceInstanceKey, serviceJobKey, sourceKey}
+	return []string{serviceNameKey, serviceNamespaceKey, spanNameKey, statusCodeKey, spanKindKey, serviceInstanceKey, serviceJobKey, sourceKey}
 }
 
 func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
@@ -931,7 +931,7 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 	names := []string{
 		hostIDKey,
 		hostNameKey,
-		serviceKey,
+		serviceNameKey,
 		serviceNamespaceKey,
 		serviceInstanceKey,
 		serviceJobKey,

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -65,6 +65,8 @@ const (
 	k8sPodUID          = "k8s_pod_uid"
 	k8sPodStartTime    = "k8s_pod_start_time"
 	k8sClusterName     = "k8s_cluster_name"
+	k8sKind            = "k8s_kind"
+	k8sOwnerName       = "k8s_owner_name"
 
 	spanNameKey          = "span_name"
 	statusCodeKey        = "status_code"
@@ -884,7 +886,7 @@ func (r *metricsReporter) observe(span *request.Span) {
 
 func appendK8sLabelNames(names []string) []string {
 	names = append(names, k8sNamespaceName, k8sPodName, k8sContainerName, k8sNodeName, k8sPodUID, k8sPodStartTime,
-		k8sDeploymentName, k8sReplicaSetName, k8sStatefulSetName, k8sDaemonSetName, k8sClusterName)
+		k8sDeploymentName, k8sReplicaSetName, k8sStatefulSetName, k8sDaemonSetName, k8sClusterName, k8sKind, k8sOwnerName)
 	return names
 }
 
@@ -902,6 +904,8 @@ func appendK8sLabelValuesService(values []string, service *svc.Attrs) []string {
 		service.Metadata[(attr.K8sStatefulSetName)],
 		service.Metadata[(attr.K8sDaemonSetName)],
 		service.Metadata[(attr.K8sClusterName)],
+		service.Metadata[(attr.K8sKind)],
+		service.Metadata[(attr.K8sOwnerName)],
 	)
 	return values
 }

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -56,10 +56,6 @@ func SourceMetric(val string) attribute.KeyValue {
 	return attribute.Key(attr.Source).String(val)
 }
 
-func ServiceMetric(val string) attribute.KeyValue {
-	return attribute.Key(attr.Service).String(val)
-}
-
 func StatusCodeMetric(val string) attribute.KeyValue {
 	return attribute.Key(attr.StatusCode).String(val)
 }

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -59,8 +59,6 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			}
 			return ServerNamespaceMetric(s.Service.UID.Namespace)
 		}
-	case attr.Service:
-		getter = func(s *Span) attribute.KeyValue { return ServiceMetric(s.Service.UID.Name) }
 	case attr.ServiceInstanceID:
 		getter = func(s *Span) attribute.KeyValue { return semconv.ServiceInstanceID(string(s.Service.UID.Instance)) }
 	case attr.ServiceName:

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -228,9 +228,13 @@ func appendMetadata(db *kube.Store, svc *svc.Attrs, meta *kube.CachedObjMeta, cl
 	// growing cardinality
 	if topOwner != nil {
 		svc.Metadata[attr.K8sOwnerName] = topOwner.Name
+		svc.Metadata[attr.K8sKind] = topOwner.Kind
 	}
 
 	for _, owner := range meta.Meta.Pod.Owners {
+		if _, ok := svc.Metadata[attr.K8sKind]; !ok {
+			svc.Metadata[attr.K8sKind] = owner.Kind
+		}
 		if kindLabel := OwnerLabelName(owner.Kind); kindLabel != "" {
 			svc.Metadata[kindLabel] = owner.Name
 		}

--- a/pkg/transform/k8s_test.go
+++ b/pkg/transform/k8s_test.go
@@ -153,6 +153,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.owner.name":      "deployment-12",
 			"k8s.pod.start_time":  "2020-01-02 12:12:56",
 			"k8s.cluster.name":    "the-cluster",
+			"k8s.kind":            "Deployment",
 		}, deco[0].Service.Metadata)
 	})
 	t.Run("pod info whose replicaset did not have an Owner should set the replicaSet name", func(t *testing.T) {
@@ -174,6 +175,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.pod.uid":         "uid-34",
 			"k8s.pod.start_time":  "2020-01-02 12:34:56",
 			"k8s.cluster.name":    "the-cluster",
+			"k8s.kind":            "ReplicaSet",
 		}, deco[0].Service.Metadata)
 	})
 	t.Run("pod info with only pod name should set pod name as name", func(t *testing.T) {
@@ -289,6 +291,7 @@ func TestDecoration(t *testing.T) {
 			"k8s.owner.name":      "deployment-12",
 			"k8s.pod.start_time":  "2020-01-02 12:12:56",
 			"k8s.cluster.name":    "the-cluster",
+			"k8s.kind":            "Deployment",
 		}, deco[0].Service.Metadata)
 	})
 }

--- a/test/integration/k8s/daemonset/k8s_daemonset_y_metrics_test.go
+++ b/test/integration/k8s/daemonset/k8s_daemonset_y_metrics_test.go
@@ -17,6 +17,7 @@ func TestSurveyMetrics(t *testing.T) {
 		"k8s_replicaset_name": "^otherinstance-.*",
 		"k8s_pod_name":        "^otherinstance-.*",
 		"k8s_owner_name":      "^otherinstance$",
+		"k8s_kind":            "Deployment",
 		"service_instance_id": "^default\\.otherinstance-.+\\.otherinstance",
 	}))
 }

--- a/test/integration/k8s/prom/k8s_prom_test.go
+++ b/test/integration/k8s/prom/k8s_prom_test.go
@@ -39,6 +39,7 @@ func TestPrometheus_SurveyMetrics(t *testing.T) {
 		"k8s_container_name":  "^testserver$",
 		"k8s_deployment_name": "^testserver$",
 		"k8s_replicaset_name": "^testserver-",
+		"k8s_kind":            "Deployment",
 		"k8s_cluster_name":    "^beyla-k8s-test-cluster$",
 	}))
 }

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -130,7 +130,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 			`span_kind="SPAN_KIND_SERVER",` +
 			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
 			`service_namespace="` + svcNs + `",` +
-			`service="` + svcName + `",` +
+			`service_name="` + svcName + `",` +
 			`span_name="GET /basic/:rnd"` +
 			`}`)
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 			`span_kind="SPAN_KIND_SERVER",` +
 			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
 			`service_namespace="` + svcNs + `",` +
-			`service="` + svcName + `",` +
+			`service_name="` + svcName + `",` +
 			`span_name="GET /basic/:rnd"` +
 			`}`)
 		require.NoError(t, err)
@@ -160,7 +160,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 		var err error
 		results, err = pq.Query(`traces_target_info{` +
 			`service_namespace="` + svcNs + `",` +
-			`service="` + svcName + `",` +
+			`service_name="` + svcName + `",` +
 			`telemetry_sdk_language="go"` +
 			`}`)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR fixes couple of minor issues:

1. Prometheus metrics weren't using `service_name` as label and we using the outdated `service` label.
2. Prometheus metrics weren't exporting `k8s_owner_name`, like OTel metrics do.
3. I added `k8s_kind` as exported label so we can easily identify what kind of k8s object we are dealing with in target_info and survey_info.
4. I removed the use of `service` in span metrics, it should be service_name. Grafana Application Observability would not be impacted as it doesn't read this field, only reads `job` which was consistent.