### PR TITLE
Make k8s on when we are running on k8s

### DIFF
--- a/pkg/kubeflags/kubeflags.go
+++ b/pkg/kubeflags/kubeflags.go
@@ -6,5 +6,5 @@ const (
 	EnabledTrue       = EnableFlag("true")
 	EnabledFalse      = EnableFlag("false")
 	EnabledAutodetect = EnableFlag("autodetect")
-	EnabledDefault    = EnabledFalse
+	EnabledDefault    = EnabledAutodetect
 )


### PR DESCRIPTION
We have an option to enable k8s labels automatically when running in Kubernetes, we should use that as default instead and not rely that this is supplied by the helm chart or the user configuration.