### PR TITLE
Perf: generate otel traces

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -502,7 +502,7 @@ func generateTracesWithAttributes(svc *svc.Attrs, envResourceAttrs []attribute.K
 	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
 	resourceAttrsMap := attrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
-	resourceAttrsMap.CopyTo(rs.Resource().Attributes())
+	resourceAttrsMap.MoveTo(rs.Resource().Attributes())
 
 	for _, spanWithAttributes := range spans {
 		span := spanWithAttributes.Span
@@ -542,7 +542,7 @@ func generateTracesWithAttributes(svc *svc.Attrs, envResourceAttrs []attribute.K
 
 		// Set span attributes
 		m := attrsToMap(attrs)
-		m.CopyTo(s.Attributes())
+		m.MoveTo(s.Attributes())
 
 		// Set status code
 		statusCode := codeToStatusCode(request.SpanStatusCode(span))
@@ -587,6 +587,7 @@ func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pco
 // attrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
 func attrsToMap(attrs []attribute.KeyValue) pcommon.Map {
 	m := pcommon.NewMap()
+	m.EnsureCapacity(len(attrs))
 	for _, attr := range attrs {
 		switch v := attr.Value.AsInterface().(type) {
 		case string:


### PR DESCRIPTION
For profiling, I raised beyla as daemonset in a local minicube cluster and did load testing on the [microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) service.

In the process I found a hot spot: generateTracesWithAttributes. Flame graph showed that 27% of unused memory is used on CopyTo method and about 13% on attrsToMap. I will attach a screenshot of the original profile to the PR. Besides, the profile showed a large amount of memory allocation in AppendEmpty method, but it is inside opentelemetry library and this place will not be optimised (to create `&otlptrace.ScopeSpans{}` it would be better to use arena or sync.Pool, so as not to allocate every time a new variable in heap, it is a big load on cpu because of GC).

```bash
goos: darwin
goarch: arm64
pkg: github.com/grafana/beyla/v2/pkg/export/otel
cpu: Apple M2 Pro
                  │ perf/slow.bench.txt │         perf/fast.bench.txt         │
                  │       sec/op        │   sec/op     vs base                │
GenerateTraces-10           2.868µ ± 1%   2.335µ ± 3%  -18.59% (p=0.000 n=10)

                  │ perf/slow.bench.txt │         perf/fast.bench.txt          │
                  │        B/op         │     B/op      vs base                │
GenerateTraces-10          5.172Ki ± 0%   3.766Ki ± 0%  -27.19% (p=0.000 n=10)

                  │ perf/slow.bench.txt │        perf/fast.bench.txt         │
                  │      allocs/op      │ allocs/op   vs base                │
GenerateTraces-10            70.00 ± 0%   61.00 ± 0%  -12.86% (p=0.000 n=10)
```

![image](https://github.com/user-attachments/assets/9f379bdd-2ac9-413f-ba1f-e989ed151ecb)