### PR TITLE
Fix bad trace propagation patch

### DIFF
--- a/bpf/common/trace_common.h
+++ b/bpf/common/trace_common.h
@@ -195,9 +195,10 @@ server_or_client_trace(u8 type, connection_info_t *conn, tp_info_pid_t *tp_p, u8
                        t_key.p_key.pid,
                        t_key.p_key.tid);
 
-        tp_info_pid_t *existing_tp = bpf_map_lookup_elem(&server_traces, &t_key);
-        if (existing_tp) {
-            existing_tp->valid = 0;
+        tp_info_pid_t *existing = bpf_map_lookup_elem(&server_traces, &t_key);
+        if (existing && (existing->req_type == tp_p->req_type) &&
+            (tp_p->req_type == EVENT_HTTP_REQUEST)) {
+            existing->valid = 0;
             bpf_dbg_printk("Found conflicting server span, marking it invalid.");
             return;
         }

--- a/bpf/common/tracing.h
+++ b/bpf/common/tracing.h
@@ -59,9 +59,9 @@ static __always_inline void
 set_trace_info_for_connection(connection_info_t *conn, u32 type, tp_info_pid_t *info) {
     trace_map_key_t key = {};
 
-    // bpf_printk("setting trace info");
+    // bpf_dbg_printk("setting trace info, type %d", info->req_type);
 
-    // d_print_http_connection_info(conn);
+    // dbg_print_http_connection_info(conn);
 
     // unsigned char tp_buf[TP_MAX_VAL_LENGTH];
     // make_tp_string(tp_buf, &info->tp);

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -1228,6 +1228,7 @@ int beyla_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
                     .pid = pid,
                     .valid = 1,
                     .written = 0,
+                    .req_type = EVENT_HTTP_CLIENT,
                 };
 
                 tp_clone(&tp_p.tp, &invocation->tp);

--- a/bpf/logger/bpf_dbg.h
+++ b/bpf/logger/bpf_dbg.h
@@ -49,8 +49,6 @@ enum bpf_func_id___x { BPF_FUNC_snprintf___x = 42 /* avoid zero */ };
                 __builtin_memcpy(__trace__->log, fmt, sizeof(__trace__->log));                     \
             }                                                                                      \
             bpf_ringbuf_submit(__trace__, 0);                                                      \
-        } else {                                                                                   \
-            bpf_printk("error allocating ringbuffer space");                                       \
         }                                                                                          \
     }
 #else // BPF_DEBUG_TC
@@ -67,8 +65,6 @@ enum bpf_func_id___x { BPF_FUNC_snprintf___x = 42 /* avoid zero */ };
             bpf_get_current_comm(&__trace__->comm, sizeof(__trace__->comm));                       \
             __trace__->pid = id >> 32;                                                             \
             bpf_ringbuf_submit(__trace__, 0);                                                      \
-        } else {                                                                                   \
-            bpf_printk("error allocating ringbuffer space");                                       \
         }                                                                                          \
     }
 #endif // BPF_DEBUG_TC


### PR DESCRIPTION
Fixes prior PR where I had the condition wrong. I also restored detection of multiple requests being handled by the same thread because we hit that with nginx. I removed the failed to get buffer message in the eBPF logs, we know this happens for the userspace logging and it's not useful as is.