### PR TITLE
Use v2 of publishing workflow that checks out HEAD of version branch on tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: 'false'
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@8cc658b604c6e05c275af30163a1c7728dfe19b2 # publish-technical-documentation-release/v2
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
         with:
           release_tag_regexp: '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'


### PR DESCRIPTION
This uses a script check in the first step of tag events that switches the checkout to the version branch that the tag refers to: https://github.com/grafana/writers-toolkit/blob/main/publish-technical-documentation-release/determine-release-branch.

Implemented in:

- https://github.com/grafana/writers-toolkit/commit/305f9896c4edb0a90ef95fc477ebe46598d26458
- https://github.com/grafana/writers-toolkit/commit/541fb6e8bde2eb477c14a4e975603464ac557429

Because the script uses Bash regular expression pattern matching, inputs must use Extended Regular Expression syntax.
