### PR TITLE
cleanup: remove redundant check

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -85,11 +85,6 @@ func setupAppO11y(ctx context.Context, ctxInfo *global.ContextInfo, config *beyl
 }
 
 func setupNetO11y(ctx context.Context, ctxInfo *global.ContextInfo, cfg *beyla.Config) error {
-	if msg := mustSkip(cfg); msg != "" {
-		slog.Warn(msg + ". Skipping Network metrics component")
-		return nil
-	}
-
 	slog.Info("starting Beyla in Network metrics mode")
 	flowsAgent, err := agent.FlowsAgent(ctxInfo, cfg)
 	if err != nil {
@@ -104,14 +99,6 @@ func setupNetO11y(ctx context.Context, ctxInfo *global.ContextInfo, cfg *beyla.C
 	}
 
 	return nil
-}
-
-func mustSkip(cfg *beyla.Config) string {
-	enabled := cfg.Enabled(beyla.FeatureNetO11y)
-	if !enabled {
-		return "network not present neither in BEYLA_PROMETHEUS_FEATURES nor BEYLA_OTEL_METRICS_FEATURES"
-	}
-	return ""
 }
 
 func buildServiceNameTemplate(config *beyla.Config) (*template.Template, error) {

--- a/pkg/components/beyla_test_linux.go
+++ b/pkg/components/beyla_test_linux.go
@@ -75,5 +75,5 @@ func TestNetworkEnabled(t *testing.T) {
 	require.NoError(t, os.Setenv("BEYLA_NETWORK_METRICS", "true"))
 	cfg, err := beyla.LoadConfig(bytes.NewReader(nil))
 	assert.NoError(t, err)
-	assert.Equal(t, mustSkip(cfg), "")
+	assert.True(t, cfg.Enabled(beyla.FeatureNetO11y))
 }


### PR DESCRIPTION
When calling `setupNetO11y`, we already checked that `cfg.Enabled(beyla.FeatureNetO11y)` is `true` so there is no need to check it again inside the method