### PR TITLE
Fix ephemeral port info for accept4

### DIFF
--- a/bpf/maps/fd_map.h
+++ b/bpf/maps/fd_map.h
@@ -21,6 +21,12 @@ static __always_inline void get_ephemeral_info(connection_info_part_t *part,
     part->port = unordered_conn->s_port;
 }
 
+static __always_inline void get_ephemeral_accept_info(connection_info_part_t *part,
+                                                      connection_info_t *unordered_conn) {
+    __builtin_memcpy(part->addr, unordered_conn->d_addr, IP_V6_ADDR_LEN);
+    part->port = unordered_conn->d_port;
+}
+
 static __always_inline void store_connect_fd_info(int fd, connection_info_t *unordered_conn) {
     fd_info_t fdinfo = {};
     fd_info(&fdinfo, fd, FD_CLIENT);
@@ -35,7 +41,7 @@ static __always_inline void store_accept_fd_info(int fd, connection_info_t *unor
     fd_info_t fdinfo = {};
     fd_info(&fdinfo, fd, FD_SERVER);
     connection_info_part_t part = {};
-    get_ephemeral_info(&part, unordered_conn);
+    get_ephemeral_accept_info(&part, unordered_conn);
     bpf_dbg_printk("storing server info for fd=%d", fd);
     dbg_print_http_connection_info_part(&part);
     bpf_map_update_elem(&fd_map, &part, &fdinfo, BPF_ANY);


### PR DESCRIPTION
This is a follow-up fix for the code I added in https://github.com/grafana/beyla/pull/2009. We weren't using the accept information, but we'll need it for nodejs and ruby puma. I was storing the server part of the accept instead of the client, where the ephemeral port is.