### PR TITLE
Decoupling survey_info pipeline

### DIFF
--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -151,7 +151,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
-		}, false, attributes.Selection{
+		}, attributes.Selection{
 			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 				Include: []string{"url.path"},
 			},
@@ -268,7 +268,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
-		}, false, attributes.Selection{
+		}, attributes.Selection{
 			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 				Include: []string{"url.path"},
 			},

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -227,17 +227,14 @@ func (m *MetricsConfig) Enabled() bool {
 // MetricsReporter implements the graph node that receives request.Span
 // instances and forwards them as OTEL metrics.
 type MetricsReporter struct {
-	ctx               context.Context
-	cfg               *MetricsConfig
-	surveyInfoEnabled bool
-	hostID            string
-	attributes        *attributes.AttrSelector
-	exporter          sdkmetric.Exporter
-	reporters         ReporterPool[*svc.Attrs, *Metrics]
-	systemReporter    Metrics
-	serviceMap        map[svc.UID][]attribute.KeyValue
-	pidTracker        PidServiceTracker
-	is                instrumentations.InstrumentationSelection
+	ctx        context.Context
+	cfg        *MetricsConfig
+	hostID     string
+	attributes *attributes.AttrSelector
+	exporter   sdkmetric.Exporter
+	reporters  ReporterPool[*svc.Attrs, *Metrics]
+	pidTracker PidServiceTracker
+	is         instrumentations.InstrumentationSelection
 
 	// user-selected fields for each of the reported metrics
 	attrHTTPDuration           []attributes.Field[*request.Span, attribute.KeyValue]
@@ -292,7 +289,6 @@ type Metrics struct {
 	serviceGraphTotal            *Expirer[*request.Span, instrument.Int64Counter, int64]
 	targetInfo                   instrument.Int64UpDownCounter
 	tracesTargetInfo             instrument.Int64UpDownCounter
-	surveyInfo                   instrument.Int64UpDownCounter
 	gpuKernelCallsTotal          *Expirer[*request.Span, instrument.Int64Counter, int64]
 	gpuMemoryAllocsTotal         *Expirer[*request.Span, instrument.Int64Counter, int64]
 	gpuKernelGridSize            *Expirer[*request.Span, instrument.Float64Histogram, float64]
@@ -302,7 +298,6 @@ type Metrics struct {
 func ReportMetrics(
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
-	surveyInfoEnabled bool,
 	userAttribSelection attributes.Selection,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -313,7 +308,7 @@ func ReportMetrics(
 		}
 		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
-		mr, err := newMetricsReporter(ctx, ctxInfo, cfg, surveyInfoEnabled, userAttribSelection, input, processEventCh)
+		mr, err := newMetricsReporter(ctx, ctxInfo, cfg, userAttribSelection, input, processEventCh)
 		if err != nil {
 			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
 		}
@@ -335,7 +330,6 @@ func newMetricsReporter(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
-	surveyInfoEnabled bool,
 	userAttribSelection attributes.Selection,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -352,7 +346,6 @@ func newMetricsReporter(
 	mr := MetricsReporter{
 		ctx:                 ctx,
 		cfg:                 cfg,
-		surveyInfoEnabled:   surveyInfoEnabled,
 		is:                  is,
 		attributes:          attribProvider,
 		hostID:              ctxInfo.HostID,
@@ -428,16 +421,7 @@ func newMetricsReporter(
 	}
 	mr.exporter = instrumentMetricsExporter(ctxInfo.Metrics, exporter)
 
-	mr.systemReporter = mr.newSystemMetricsInstance()
-	mr.serviceMap = map[svc.UID][]attribute.KeyValue{}
 	mr.pidTracker = NewPidServiceTracker()
-	if mr.surveyInfoEnabled {
-		// Survey info is special, created via service less reporter
-		meter := mr.systemReporter.provider.Meter(reporterName)
-		if err = mr.setupSurveyInfo(&mr.systemReporter, meter); err != nil {
-			return nil, err
-		}
-	}
 
 	return &mr, nil
 }
@@ -522,16 +506,6 @@ func (mr *MetricsReporter) setupTargetInfo(m *Metrics, meter instrument.Meter) e
 	m.targetInfo, err = meter.Int64UpDownCounter(TargetInfo)
 	if err != nil {
 		return fmt.Errorf("creating target info: %w", err)
-	}
-
-	return nil
-}
-
-func (mr *MetricsReporter) setupSurveyInfo(m *Metrics, meter instrument.Meter) error {
-	var err error
-	m.surveyInfo, err = meter.Int64UpDownCounter(SurveyInfo)
-	if err != nil {
-		return fmt.Errorf("creating survey info: %w", err)
 	}
 
 	return nil
@@ -781,28 +755,6 @@ func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) 
 		m.ctx, serviceGraphTotal, serviceGraphAttrs, timeNow, mr.cfg.TTL)
 
 	return nil
-}
-
-func (mr *MetricsReporter) newSystemMetricsInstance() Metrics {
-	mlog := mlog()
-	mlog.Debug("creating new system Metrics reporter")
-
-	opts := []metric.Option{
-		metric.WithResource(resource.Empty()),
-		metric.WithReader(metric.NewPeriodicReader(mr.exporter,
-			metric.WithInterval(mr.cfg.Interval))),
-	}
-
-	opts = append(opts, mr.otelMetricOptions(mlog)...)
-	opts = append(opts, mr.spanMetricOptions(mlog)...)
-	opts = append(opts, mr.graphMetricOptions(mlog)...)
-
-	return Metrics{
-		ctx: mr.ctx,
-		provider: metric.NewMeterProvider(
-			opts...,
-		),
-	}
 }
 
 func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
@@ -1191,26 +1143,6 @@ func (mr *MetricsReporter) deleteTargetInfo(reporter *Metrics) {
 	reporter.targetInfo.Remove(mr.ctx, attrOpt)
 }
 
-func (mr *MetricsReporter) createSurveyInfo(service *svc.Attrs) {
-	resourceAttributes := append(getAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
-	mlog().Debug("Creating survey_info", "attrs", resourceAttributes)
-	attrOpt := instrument.WithAttributeSet(attribute.NewSet(resourceAttributes...))
-	mr.systemReporter.surveyInfo.Add(mr.ctx, 1, attrOpt)
-	mr.serviceMap[service.UID] = resourceAttributes
-}
-
-func (mr *MetricsReporter) deleteSurveyInfo(s *svc.Attrs) {
-	attrs, ok := mr.serviceMap[s.UID]
-	if !ok {
-		mlog().Debug("No service map", "UID", s.UID)
-		return
-	}
-	mlog().Debug("Deleting survey_info for", "attrs", attrs)
-	attrOpt := instrument.WithAttributeSet(attribute.NewSet(attrs...))
-	mr.systemReporter.surveyInfo.Remove(mr.ctx, attrOpt)
-	delete(mr.serviceMap, s.UID)
-}
-
 func (mr *MetricsReporter) createTracesTargetInfo(reporter *Metrics) {
 	if !mr.cfg.AnySpanMetricsEnabled() {
 		return
@@ -1267,15 +1199,9 @@ func (mr *MetricsReporter) watchForProcessEvents() {
 					continue
 				}
 				mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
-				if mr.surveyInfoEnabled {
-					mr.deleteSurveyInfo(&svc)
-				}
 				mr.deleteTracesTargetInfo(reporter)
 				mr.deleteTargetInfo(reporter)
 			}
-		case exec.ProcessEventSurveyCreated:
-			mr.createSurveyInfo(&pe.File.Service)
-			mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
 		}
 	}
 }

--- a/pkg/export/otel/metrics_survey.go
+++ b/pkg/export/otel/metrics_survey.go
@@ -1,0 +1,142 @@
+package otel
+
+import (
+	"context"
+	"fmt"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"log/slog"
+
+	"github.com/grafana/beyla/v2/pkg/export/otel/metric"
+	instrument "github.com/grafana/beyla/v2/pkg/export/otel/metric/api/metric"
+	"github.com/grafana/beyla/v2/pkg/internal/exec"
+	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func smlog() *slog.Logger {
+	return slog.With("component", "otel.SystemMetricsReporter")
+}
+
+type SurveyMetricsReporter struct {
+	log *slog.Logger
+	cfg *MetricsConfig
+
+	provider *metric.MeterProvider
+
+	surveyInfo instrument.Int64UpDownCounter
+
+	hostID        string
+	processEvents <-chan exec.ProcessEvent
+	exporter      sdkmetric.Exporter
+	pidTracker    PidServiceTracker
+	serviceMap    map[svc.UID][]attribute.KeyValue
+}
+
+func SurveyInfoMetrics(
+	ctxInfo *global.ContextInfo,
+	cfg *MetricsConfig,
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
+		if !cfg.Enabled() {
+			return swarm.EmptyRunFunc()
+		}
+		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
+
+		mr, err := newSurveyMetricsReporter(ctx, ctxInfo, cfg, processEventCh)
+		if err != nil {
+			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
+		}
+
+		return mr.watchForProcessEvents, nil
+	}
+}
+
+func newSurveyMetricsReporter(
+	ctx context.Context, ctxInfo *global.ContextInfo, cfg *MetricsConfig,
+	processEventsQueue *msg.Queue[exec.ProcessEvent],
+) (*SurveyMetricsReporter, error) {
+	log := smlog()
+	smr := &SurveyMetricsReporter{
+		log:           log,
+		cfg:           cfg,
+		hostID:        ctxInfo.HostID,
+		serviceMap:    map[svc.UID][]attribute.KeyValue{},
+		processEvents: processEventsQueue.Subscribe(),
+		pidTracker:    NewPidServiceTracker(),
+	}
+	log.Debug("creating new Survey Metrics reporter")
+
+	var err error
+	smr.exporter, err = InstantiateMetricsExporter(ctx, cfg, log)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating OTEL Survey metrics exporter: %w", err)
+	}
+
+	smr.provider = metric.NewMeterProvider(
+		metric.WithResource(resource.Empty()),
+		metric.WithReader(metric.NewPeriodicReader(smr.exporter,
+			metric.WithInterval(smr.cfg.Interval))),
+	)
+	meter := smr.provider.Meter(reporterName)
+	smr.surveyInfo, err = meter.Int64UpDownCounter(SurveyInfo)
+	if err != nil {
+		return nil, fmt.Errorf("creating survey info: %w", err)
+	}
+
+	return smr, nil
+}
+
+func (smr *SurveyMetricsReporter) watchForProcessEvents(ctx context.Context) {
+	for pe := range smr.processEvents {
+		log := smr.log.With("event_type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+		log.Debug("process event received")
+
+		switch pe.Type {
+		case exec.ProcessEventTerminated:
+			if deleted, origUID := smr.disassociatePIDFromService(pe.File.Pid); deleted {
+				// We only need the UID to look up in the pool, no need to cache
+				// the whole of the attrs in the pidTracker
+				svc := svc.Attrs{UID: origUID}
+				log.Debug("deleting survey_info", "origuid", origUID)
+				smr.deleteSurveyInfo(ctx, &svc)
+			}
+			// TODO: mirar si esto no debería ser un simple ProcessEventCreated
+		case exec.ProcessEventSurveyCreated:
+			smr.createSurveyInfo(ctx, &pe.File.Service)
+			smr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
+		}
+	}
+}
+
+func (smr *SurveyMetricsReporter) setupPIDToServiceRelationship(pid int32, uid svc.UID) {
+	smr.pidTracker.AddPID(pid, uid)
+}
+
+func (smr *SurveyMetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID) {
+	return smr.pidTracker.RemovePID(pid)
+}
+
+func (smr *SurveyMetricsReporter) createSurveyInfo(ctx context.Context, service *svc.Attrs) {
+	resourceAttributes := append(getAppResourceAttrs(smr.hostID, service), ResourceAttrsFromEnv(service)...)
+	mlog().Debug("Creating survey_info", "attrs", resourceAttributes)
+	attrOpt := instrument.WithAttributeSet(attribute.NewSet(resourceAttributes...))
+	smr.surveyInfo.Add(ctx, 1, attrOpt)
+	smr.serviceMap[service.UID] = resourceAttributes
+}
+
+func (smr *SurveyMetricsReporter) deleteSurveyInfo(ctx context.Context, s *svc.Attrs) {
+	attrs, ok := smr.serviceMap[s.UID]
+	if !ok {
+		mlog().Debug("No service map", "UID", s.UID)
+		return
+	}
+	mlog().Debug("Deleting survey_info for", "attrs", attrs)
+	attrOpt := instrument.WithAttributeSet(attribute.NewSet(attrs...))
+	smr.surveyInfo.Remove(ctx, attrOpt)
+	delete(smr.serviceMap, s.UID)
+}

--- a/pkg/export/otel/metrics_survey.go
+++ b/pkg/export/otel/metrics_survey.go
@@ -3,8 +3,11 @@ package otel
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel/sdk/resource"
 	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/grafana/beyla/v2/pkg/export/otel/metric"
 	instrument "github.com/grafana/beyla/v2/pkg/export/otel/metric/api/metric"
@@ -13,8 +16,6 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/svc"
 	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 func smlog() *slog.Logger {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -155,7 +155,7 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	}, &MetricsConfig{
 		CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
 		Features: []string{FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
-	}, false, attributes.Selection{}, exportMetrics, processEvents,
+	}, attributes.Selection{}, exportMetrics, processEvents,
 	)(context.Background())
 	require.NoError(t, err)
 	go reporter(context.Background())
@@ -710,7 +710,7 @@ func makeExporter(
 			TTL:               30 * time.Minute,
 			ReportersCacheLen: 100,
 			Instrumentations:  instrumentations,
-		}, false, attributes.Selection{
+		}, attributes.Selection{
 			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 				Include: []string{"url.path"},
 			},

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -41,7 +41,6 @@ const (
 	TracesTargetInfo         = "traces_target_info"
 	TracesHostInfo           = "traces_host_info"
 	TargetInfo               = "target_info"
-	SurveyInfo               = "survey_info"
 
 	ServiceGraphClient = "traces_service_graph_request_client_seconds"
 	ServiceGraphServer = "traces_service_graph_request_server_seconds"
@@ -212,7 +211,6 @@ type metricsReporter struct {
 	httpClientRequestSize  *Expirer[prometheus.Histogram]
 	httpClientResponseSize *Expirer[prometheus.Histogram]
 	targetInfo             *prometheus.GaugeVec
-	surveyInfo             *prometheus.GaugeVec
 
 	// user-selected attributes for the application-level metrics
 	attrHTTPDuration           []attributes.Field[*request.Span, string]
@@ -268,7 +266,6 @@ type metricsReporter struct {
 func PrometheusEndpoint(
 	ctxInfo *global.ContextInfo,
 	cfg *PrometheusConfig,
-	surveyModeEnabled bool,
 	attrSelect attributes.Selection,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -277,7 +274,7 @@ func PrometheusEndpoint(
 		if !cfg.Enabled() {
 			return swarm.EmptyRunFunc()
 		}
-		reporter, err := newReporter(ctxInfo, cfg, surveyModeEnabled, attrSelect, input, processEventCh)
+		reporter, err := newReporter(ctxInfo, cfg, attrSelect, input, processEventCh)
 		if err != nil {
 			return nil, fmt.Errorf("instantiating Prometheus endpoint: %w", err)
 		}
@@ -308,7 +305,6 @@ func (p *PrometheusConfig) spanMetricsCallsName() string {
 func newReporter(
 	ctxInfo *global.ContextInfo,
 	cfg *PrometheusConfig,
-	surveyModeEnabled bool,
 	selector attributes.Selection,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -611,12 +607,6 @@ func newReporter(
 			Name: TargetInfo,
 			Help: "attributes associated to a given monitored entity",
 		}, labelNamesTargetInfo(kubeEnabled, extraMetadataLabels)),
-		surveyInfo: optionalDirectGaugeProvider(surveyModeEnabled, func() *prometheus.GaugeVec {
-			return prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: SurveyInfo,
-				Help: "attributes associated to a given surveyed entity",
-			}, labelNamesTargetInfo(kubeEnabled, extraMetadataLabels))
-		}),
 		gpuKernelCallsTotal: optionalCounterProvider(is.GPUEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: attributes.GPUKernelLaunchCalls.Prom,
@@ -655,10 +645,6 @@ func newReporter(
 
 	if !mr.cfg.DisableBuildInfo {
 		registeredMetrics = append(registeredMetrics, mr.beylaInfo)
-	}
-
-	if surveyModeEnabled {
-		registeredMetrics = append(registeredMetrics, mr.surveyInfo)
 	}
 
 	if cfg.OTelMetricsEnabled() {
@@ -1067,11 +1053,6 @@ func (r *metricsReporter) createTargetInfo(service *svc.Attrs) {
 	r.targetInfo.WithLabelValues(targetInfoLabelValues...).Set(1)
 }
 
-func (r *metricsReporter) createSurveyInfo(service *svc.Attrs) {
-	targetInfoLabelValues := r.labelValuesTargetInfo(service)
-	r.surveyInfo.WithLabelValues(targetInfoLabelValues...).Set(1)
-}
-
 func (r *metricsReporter) createTracesTargetInfo(service *svc.Attrs) {
 	if !r.cfg.AnySpanMetricsEnabled() {
 		return
@@ -1091,11 +1072,6 @@ func (r *metricsReporter) origService(uid svc.UID, service *svc.Attrs) *svc.Attr
 func (r *metricsReporter) deleteTargetInfo(uid svc.UID, service *svc.Attrs) {
 	targetInfoLabelValues := r.labelValuesTargetInfo(r.origService(uid, service))
 	r.targetInfo.DeleteLabelValues(targetInfoLabelValues...)
-}
-
-func (r *metricsReporter) deleteSurveyInfo(uid svc.UID, service *svc.Attrs) {
-	targetInfoLabelValues := r.labelValuesTargetInfo(r.origService(uid, service))
-	r.surveyInfo.DeleteLabelValues(targetInfoLabelValues...)
 }
 
 func (r *metricsReporter) deleteTracesTargetInfo(uid svc.UID, service *svc.Attrs) {
@@ -1129,18 +1105,10 @@ func (r *metricsReporter) watchForProcessEvents() {
 		case exec.ProcessEventTerminated:
 			if deleted, origUID := r.disassociatePIDFromService(pe.File.Pid); deleted {
 				mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
-
-				if r.surveyInfo != nil {
-					r.deleteSurveyInfo(origUID, &pe.File.Service)
-				}
 				r.deleteTargetInfo(origUID, &pe.File.Service)
 				r.deleteTracesTargetInfo(origUID, &pe.File.Service)
 				delete(r.serviceMap, origUID)
 			}
-		case exec.ProcessEventSurveyCreated:
-			r.createSurveyInfo(&pe.File.Service)
-			r.serviceMap[uid] = pe.File.Service
-			r.setupPIDToServiceRelationship(pe.File.Pid, uid)
 		}
 	}
 }

--- a/pkg/export/prom/prom_survey.go
+++ b/pkg/export/prom/prom_survey.go
@@ -164,8 +164,7 @@ func (r *surveyMetricsReporter) watchForProcessEvents(_ context.Context) {
 				r.deleteSurveyInfo(origUID, &pe.File.Service)
 				delete(r.serviceMap, origUID)
 			}
-			// TODO: use ProcessEventCreated?
-		case exec.ProcessEventSurveyCreated:
+		case exec.ProcessEventCreated:
 			r.createSurveyInfo(&pe.File.Service)
 			r.serviceMap[uid] = pe.File.Service
 			r.setupPIDToServiceRelationship(pe.File.Pid, uid)

--- a/pkg/export/prom/prom_survey.go
+++ b/pkg/export/prom/prom_survey.go
@@ -1,0 +1,174 @@
+package prom
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	attr "github.com/grafana/beyla/v2/pkg/export/attributes/names"
+	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/internal/connector"
+	"github.com/grafana/beyla/v2/pkg/internal/exec"
+	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/v2/pkg/internal/svc"
+	"github.com/grafana/beyla/v2/pkg/pipe/msg"
+	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
+)
+
+const (
+	SurveyInfo = "survey_info"
+)
+
+func pslog() *slog.Logger {
+	return slog.With("component", "prom.SurveyMetricsReporter")
+}
+
+type surveyMetricsReporter struct {
+	processEvents <-chan exec.ProcessEvent
+
+	surveyInfo *prometheus.GaugeVec
+
+	promConnect *connector.PrometheusManager
+
+	hostID string
+
+	serviceMap  map[svc.UID]svc.Attrs
+	pidsTracker otel.PidServiceTracker
+
+	kubeEnabled         bool
+	extraMetadataLabels []attr.Name
+}
+
+func SurveyPrometheusEndpoint(
+	ctxInfo *global.ContextInfo,
+	cfg *PrometheusConfig,
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if !cfg.EndpointEnabled() {
+			return swarm.EmptyRunFunc()
+		}
+		reporter, err := newSurveyReporter(ctxInfo, cfg, processEventCh)
+		if err != nil {
+			return nil, fmt.Errorf("instantiating Prometheus endpoint: %w", err)
+		}
+		if cfg.Registry != nil {
+			return reporter.watchForProcessEvents, nil
+		}
+		return reporter.reportMetrics, nil
+	}
+}
+
+// nolint:cyclop
+func newSurveyReporter(
+	ctxInfo *global.ContextInfo,
+	cfg *PrometheusConfig,
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) (*surveyMetricsReporter, error) {
+
+	kubeEnabled := ctxInfo.K8sInformer.IsKubeEnabled()
+	extraMetadataLabels := parseExtraMetadata(cfg.ExtraResourceLabels)
+
+	mr := &surveyMetricsReporter{
+		processEvents: processEventCh.Subscribe(),
+		serviceMap:    map[svc.UID]svc.Attrs{},
+		pidsTracker:   otel.NewPidServiceTracker(),
+		hostID:        ctxInfo.HostID,
+		promConnect:   ctxInfo.Prometheus,
+		surveyInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: SurveyInfo,
+			Help: "attributes associated to a given surveyed entity",
+		}, labelNamesTargetInfo(kubeEnabled, extraMetadataLabels)),
+		extraMetadataLabels: extraMetadataLabels,
+		kubeEnabled:         kubeEnabled,
+	}
+
+	if cfg.Registry != nil {
+		cfg.Registry.MustRegister(mr.surveyInfo)
+	} else {
+		mr.promConnect.Register(cfg.Port, cfg.Path, mr.surveyInfo)
+	}
+
+	return mr, nil
+}
+
+func (r *surveyMetricsReporter) reportMetrics(ctx context.Context) {
+	go r.promConnect.StartHTTP(ctx)
+	r.watchForProcessEvents(ctx)
+}
+
+func (r *surveyMetricsReporter) labelValues(service *svc.Attrs) []string {
+	values := []string{
+		r.hostID,
+		service.HostName,
+		service.UID.Name,
+		service.UID.Namespace,
+		service.UID.Instance, // app instance ID
+		service.Job(),
+		service.SDKLanguage.String(),
+		"beyla",
+		"beyla",
+		"linux",
+	}
+
+	if r.kubeEnabled {
+		values = appendK8sLabelValuesService(values, service)
+	}
+
+	for _, k := range r.extraMetadataLabels {
+		values = append(values, service.Metadata[k])
+	}
+
+	return values
+}
+
+func (r *surveyMetricsReporter) createSurveyInfo(service *svc.Attrs) {
+	targetInfoLabelValues := r.labelValues(service)
+	r.surveyInfo.WithLabelValues(targetInfoLabelValues...).Set(1)
+}
+
+func (r *surveyMetricsReporter) origService(uid svc.UID, service *svc.Attrs) *svc.Attrs {
+	orig := service
+	if origAttrs, ok := r.serviceMap[uid]; ok {
+		orig = &origAttrs
+	}
+	return orig
+}
+
+func (r *surveyMetricsReporter) deleteSurveyInfo(uid svc.UID, service *svc.Attrs) {
+	targetInfoLabelValues := r.labelValues(r.origService(uid, service))
+	r.surveyInfo.DeleteLabelValues(targetInfoLabelValues...)
+}
+
+func (r *surveyMetricsReporter) setupPIDToServiceRelationship(pid int32, uid svc.UID) {
+	r.pidsTracker.AddPID(pid, uid)
+}
+
+func (r *surveyMetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID) {
+	return r.pidsTracker.RemovePID(pid)
+}
+
+func (r *surveyMetricsReporter) watchForProcessEvents(_ context.Context) {
+	log := pslog()
+	for pe := range r.processEvents {
+		log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+
+		uid := pe.File.Service.UID
+
+		switch pe.Type {
+		case exec.ProcessEventTerminated:
+			if deleted, origUID := r.disassociatePIDFromService(pe.File.Pid); deleted {
+				log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+				r.deleteSurveyInfo(origUID, &pe.File.Service)
+				delete(r.serviceMap, origUID)
+			}
+			// TODO: use ProcessEventCreated?
+		case exec.ProcessEventSurveyCreated:
+			r.createSurveyInfo(&pe.File.Service)
+			r.serviceMap[uid] = pe.File.Service
+			r.setupPIDToServiceRelationship(pe.File.Pid, uid)
+		}
+	}
+}

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -54,7 +54,6 @@ func TestAppMetricsExpiration(t *testing.T) {
 			Features:                    []string{otel.FeatureApplication},
 			Instrumentations:            []string{instrumentations.InstrumentationALL},
 		},
-		false,
 		attributes.Selection{
 			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 				Include: []string{"url_path"},
@@ -509,7 +508,6 @@ func makePromExporter(
 			Features:                    []string{otel.FeatureApplication},
 			Instrumentations:            instrumentations,
 		},
-		false,
 		attributes.Selection{
 			attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 				Include: []string{"url_path"},

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -93,7 +93,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 // Returns a channel that is closed when the Instrumenter completed all its tasks.
 // This is: when the context is cancelled, it has unloaded all the eBPF probes.
 func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
-	finder := discover.NewProcessFinder(i.config, i.ctxInfo, i.tracesInput, i.processEventInput)
+	finder := discover.NewProcessFinder(i.config, i.ctxInfo, i.tracesInput)
 	processEvents, err := finder.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't start Process Finder: %w", err)

--- a/pkg/internal/discover/finder.go
+++ b/pkg/internal/discover/finder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/config"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/export/prom"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf/generictracer"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf/gotracer"
@@ -73,6 +74,7 @@ func (pf *ProcessFinder) Start(ctx context.Context) (<-chan Event[*ebpf.Instrume
 		surveyEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(pf.cfg.ChannelBufferLen))
 		swi.Add(SurveyEventGenerator(surveyExecutableTypes, surveyEvents))
 		swi.Add(otel.SurveyInfoMetrics(pf.ctxInfo, &pf.cfg.Metrics, surveyEvents))
+		swi.Add(prom.SurveyPrometheusEndpoint(pf.ctxInfo, &pf.cfg.Prometheus, surveyEvents))
 	}
 
 	swi.Add(TraceAttacherProvider(&TraceAttacher{

--- a/pkg/internal/discover/survey_informer.go
+++ b/pkg/internal/discover/survey_informer.go
@@ -2,18 +2,22 @@ package discover
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
+	"github.com/grafana/beyla/v2/pkg/internal/kube"
 	"github.com/grafana/beyla/v2/pkg/pipe/msg"
 	"github.com/grafana/beyla/v2/pkg/pipe/swarm"
+	"github.com/grafana/beyla/v2/pkg/transform"
 )
 
 // SurveyEventGenerator converts the survey discovered process events
 // into actionable events to be consumed by the metrics generation
 // logic
 func SurveyEventGenerator(
+	k8sInformer *kube.MetadataProvider,
 	input *msg.Queue[[]Event[ebpf.Instrumentable]],
 	output *msg.Queue[exec.ProcessEvent],
 ) swarm.InstanceFunc {
@@ -22,13 +26,23 @@ func SurveyEventGenerator(
 		input:  input.Subscribe(),
 		output: output,
 	}
-	return swarm.DirectInstance(m.run)
+	return func(ctx context.Context) (swarm.RunFunc, error) {
+		if k8sInformer != nil && k8sInformer.IsKubeEnabled() {
+			if store, err := k8sInformer.Get(ctx); err != nil {
+				return nil, fmt.Errorf("instantiating k8s informer in survey: %w", err)
+			} else {
+				m.store = store
+			}
+		}
+		return m.run, nil
+	}
 }
 
 type surveyor struct {
 	log    *slog.Logger
 	input  <-chan []Event[ebpf.Instrumentable]
 	output *msg.Queue[exec.ProcessEvent]
+	store  *kube.Store
 }
 
 func (m *surveyor) run(_ context.Context) {
@@ -37,13 +51,27 @@ func (m *surveyor) run(_ context.Context) {
 	for i := range m.input {
 		m.log.Debug("surveying processes", "len", len(i))
 		for _, pe := range i {
-			pe.Obj.CopyToServiceAttributes()
+			m.fetchMetadata(&pe.Obj)
 			if pe.Type == EventDeleted {
 				m.output.Send(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: pe.Obj.FileInfo})
 			} else {
-				m.output.Send(exec.ProcessEvent{Type: exec.ProcessEventSurveyCreated, File: pe.Obj.FileInfo})
+				m.output.Send(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: pe.Obj.FileInfo})
 			}
 			m.log.Debug("survey info generation", "pid", pe.Obj.FileInfo.Pid, "ns", pe.Obj.FileInfo.Ns, "cmd", pe.Obj.FileInfo.CmdExePath, "service", pe.Obj.FileInfo.Service.UID)
+		}
+	}
+}
+
+func (m *surveyor) fetchMetadata(i *ebpf.Instrumentable) {
+	// default name uses the search criteria name, if any (as set in ExecTyper).
+	// Now it will complete some information from the executable information
+	i.CopyToServiceAttributes()
+	// will try to set some information from kube metadata, if any
+	if m.store != nil {
+		// we can do this because there is a previous ContainerDBUpdater pipeline stage
+		// that has provided this information
+		if objectMeta, containerName := m.store.PodContainerByPIDNs(i.FileInfo.Ns); objectMeta != nil {
+			transform.AppendKubeMetadata(m.store, &i.FileInfo.Service, objectMeta, "cluster-deleteme", containerName)
 		}
 	}
 }

--- a/pkg/internal/exec/procevent.go
+++ b/pkg/internal/exec/procevent.go
@@ -5,7 +5,6 @@ type ProcessEventType int
 const (
 	ProcessEventCreated = ProcessEventType(iota)
 	ProcessEventTerminated
-	ProcessEventSurveyCreated
 )
 
 type ProcessEvent struct {

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -85,7 +85,7 @@ func newGraphBuilder(config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh
 
 	config.Traces.Grafana = &gb.config.Grafana.OTLP
 	swi.Add(otel.TracesReceiver(ctxInfo, config.Traces, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select, exportableSpans))
-	swi.Add(prom.PrometheusEndpoint(ctxInfo, &config.Prometheus, config.Discovery.SurveyEnabled(), config.Attributes.Select, exportableSpans, processEventsCh))
+	swi.Add(prom.PrometheusEndpoint(ctxInfo, &config.Prometheus, config.Attributes.Select, exportableSpans, processEventsCh))
 	swi.Add(prom.BPFMetrics(ctxInfo, &config.Prometheus))
 	swi.Add(alloy.TracesReceiver(ctxInfo, &config.TracesReceiver, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select, exportableSpans))
 

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -81,7 +81,7 @@ func newGraphBuilder(config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh
 		nameResolverToAttrFilter, exportableSpans))
 
 	config.Metrics.Grafana = &gb.config.Grafana.OTLP
-	swi.Add(otel.ReportMetrics(ctxInfo, &config.Metrics, config.Discovery.SurveyEnabled(), config.Attributes.Select, exportableSpans, processEventsCh))
+	swi.Add(otel.ReportMetrics(ctxInfo, &config.Metrics, config.Attributes.Select, exportableSpans, processEventsCh))
 
 	config.Traces.Grafana = &gb.config.Grafana.OTLP
 	swi.Add(otel.TracesReceiver(ctxInfo, config.Traces, config.Metrics.SpanMetricsEnabled(), config.Attributes.Select, exportableSpans))

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -157,7 +157,7 @@ func (md *procEventMetadataDecorator) k8sLoop(_ context.Context) {
 	klog().Debug("starting kubernetes process event decoration loop")
 	for pe := range md.input {
 		if podMeta, containerName := md.db.PodContainerByPIDNs(pe.File.Ns); podMeta != nil {
-			appendMetadata(md.db, &pe.File.Service, podMeta, md.clusterName, containerName)
+			AppendKubeMetadata(md.db, &pe.File.Service, podMeta, md.clusterName, containerName)
 		} else {
 			klog().Debug("can't find metadata for event", "ns", pe.File.Ns)
 			// do not leave the service attributes map as nil
@@ -173,7 +173,7 @@ func (md *procEventMetadataDecorator) k8sLoop(_ context.Context) {
 
 func (md *metadataDecorator) do(span *request.Span) {
 	if podMeta, containerName := md.db.PodContainerByPIDNs(span.Pid.Namespace); podMeta != nil {
-		appendMetadata(md.db, &span.Service, podMeta, md.clusterName, containerName)
+		AppendKubeMetadata(md.db, &span.Service, podMeta, md.clusterName, containerName)
 	} else {
 		// do not leave the service attributes map as nil
 		span.Service.Metadata = map[attr.Name]string{}
@@ -187,7 +187,10 @@ func (md *metadataDecorator) do(span *request.Span) {
 	}
 }
 
-func appendMetadata(db *kube.Store, svc *svc.Attrs, meta *kube.CachedObjMeta, clusterName, containerName string) {
+// AppendKubeMetadata populates some metadata values in the passed svc.Attrs.
+// This method should be invoked by any entity willing to follow a common policy for
+// setting metadata attributes. For example this metadataDecorator or the survey informer
+func AppendKubeMetadata(db *kube.Store, svc *svc.Attrs, meta *kube.CachedObjMeta, clusterName, containerName string) {
 	if meta.Meta.Pod == nil {
 		// if this message happen, there is a bug
 		klog().Debug("pod metadata for is nil. Ignoring decoration", "meta", meta)


### PR DESCRIPTION
Tries to decouple a bit the survey_info pipeline by decoupling the Prometheus and OTEL metrics creation and attaching them directly to the SurveyInformer component, so the events don't need to pass through the whole instrumentation pipeline. When we vendor OBI, we just need to invoke the different vendored nodes (might need to override/extend few of them).

```mermaid
flowchart TD
    classDef surveyer color: red;
    classDef optional stroke-dasharray: 3 3;
    subgraph discovery.Finder pipeline
        PW(ProcessWatcher) --> |new/removed processes| KWE
        KWE(WatcherKubeEnricher):::optional --> |process enriched with k8s metadata| CM
        CM(CriteriaMatcher) --> |processes matching the selection criteria| ET(ExecTyper)
        ET --> |ELFs and its metadata| CU
        CU(ContainerDBUpdater):::optional --> |ELFs and its metadata| TA
        TA(TraceAttacher) -.-> EBPF1(ebpf.Tracer)
        TA -.-> |creates one per executable| EBPF2(ebpf.Tracer)
        TA -.-> EBPF3(ebpf.Tracer)
        KWE --> SCM
        SCM(SurveyCriteriaMatcher):::surveyer --> SET
        SET(SurveyExecTyper):::surveyer --> SCU
        SCU(SurveyContainerDBUpdater):::surveyer --> SI
        SI(SurveyInformer):::surveyer --> SPM
        SI --> SOM
        SPM(SurveyInfoPrometheus)
        SPM(SurveyInfoOTEL)
    end
```

This architecture could be simplied even more if we rearranged the nodes. For example moving the ExecTyper and ContainerDB updater before the watcher kube enricher would prevent us from having to duplicate them in the Survey sub-pipeline. However it might consume extra CPU and memory resources as their functionality would be triggered for each process in the node, instead of only for the processes that match the selection criteria.