### PR TITLE
Allow Beyla to be reloaded as a component

### DIFF
--- a/pkg/internal/discover/matcher.go
+++ b/pkg/internal/discover/matcher.go
@@ -80,15 +80,25 @@ type ProcessMatch struct {
 	Process  *services.ProcessInfo
 }
 
-func (m *matcher) run(_ context.Context) {
+func (m *matcher) run(ctx context.Context) {
 	defer m.output.Close()
 	m.log.Debug("starting criteria matcher node")
-	for i := range m.input {
-		m.log.Debug("filtering processes", "len", len(i))
-		o := m.filter(i)
-		m.log.Debug("processes matching selection criteria", "len", len(o))
-		if len(o) > 0 {
-			m.output.Send(o)
+	for {
+		select {
+		case <-ctx.Done():
+			m.log.Debug("context cancelled, stopping criteria matcher node")
+			return
+		case i, ok := <-m.input:
+			if !ok {
+				m.log.Debug("input channel closed, stopping criteria matcher node")
+				return
+			}
+			m.log.Debug("filtering processes", "len", len(i))
+			o := m.filter(i)
+			m.log.Debug("processes matching selection criteria", "len", len(o))
+			if len(o) > 0 {
+				m.output.Send(o)
+			}
 		}
 	}
 }

--- a/pkg/internal/discover/watcher_proc_test.go
+++ b/pkg/internal/discover/watcher_proc_test.go
@@ -53,10 +53,10 @@ func TestWatcher_Poll(t *testing.T) {
 		executableReady: func(PID) (string, bool) {
 			return "", true
 		},
-		loadBPFWatcher: func(*beyla.Config, chan<- watcher.Event) error {
+		loadBPFWatcher: func(context.Context, *beyla.Config, chan<- watcher.Event) error {
 			return nil
 		},
-		loadBPFLogger: func(*beyla.Config) error {
+		loadBPFLogger: func(context.Context, *beyla.Config) error {
 			return nil
 		},
 		output: msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(1)),
@@ -137,10 +137,10 @@ func TestProcessNotReady(t *testing.T) {
 		executableReady: func(pid PID) (string, bool) {
 			return "", pid >= 3
 		},
-		loadBPFWatcher: func(*beyla.Config, chan<- watcher.Event) error {
+		loadBPFWatcher: func(context.Context, *beyla.Config, chan<- watcher.Event) error {
 			return nil
 		},
-		loadBPFLogger: func(*beyla.Config) error {
+		loadBPFLogger: func(context.Context, *beyla.Config) error {
 			return nil
 		},
 	}
@@ -188,11 +188,11 @@ func TestPortsFetchRequired(t *testing.T) {
 		executableReady: func(_ PID) (string, bool) {
 			return "", true
 		},
-		loadBPFWatcher: func(_ *beyla.Config, events chan<- watcher.Event) error {
+		loadBPFWatcher: func(_ context.Context, _ *beyla.Config, events chan<- watcher.Event) error {
 			channelReturner <- events
 			return nil
 		},
-		loadBPFLogger: func(*beyla.Config) error {
+		loadBPFLogger: func(context.Context, *beyla.Config) error {
 			return nil
 		},
 		stateMux:          sync.Mutex{},

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -462,8 +462,8 @@ func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span])
 
 	timeoutTicker := time.NewTicker(2 * time.Second)
 
-	go p.watchForMisclassifedEvents()
-	go p.lookForTimeouts(timeoutTicker, eventsChan)
+	go p.watchForMisclassifedEvents(ctx)
+	go p.lookForTimeouts(ctx, timeoutTicker, eventsChan)
 	defer timeoutTicker.Stop()
 
 	ebpfcommon.SharedRingbuf(
@@ -482,43 +482,48 @@ func kernelTime(ktime uint64) time.Time {
 }
 
 //nolint:cyclop
-func (p *Tracer) lookForTimeouts(ticker *time.Ticker, eventsChan *msg.Queue[[]request.Span]) {
-	for t := range ticker.C {
-		if p.bpfObjects.OngoingHttp != nil {
-			i := p.bpfObjects.OngoingHttp.Iterate()
-			var k bpfPidConnectionInfoT
-			var v bpfHttpInfoT
-			for i.Next(&k, &v) {
-				// Check if we have a lingering request which we've completed, as in it has EndMonotimeNs
-				// but it hasn't been posted yet, likely missed by the logic that looks at finishing requests
-				// where we track the full response. If we haven't updated the EndMonotimeNs in more than some
-				// short interval, we are likely not going to finish this request from eBPF, so let's do it here.
-				if v.EndMonotimeNs != 0 && t.After(kernelTime(v.EndMonotimeNs).Add(2*time.Second)) {
-					// Must use unsafe here, the two bpfHttpInfoTs are the same but generated from different
-					// ebpf2go outputs
-					s, ignore, err := ebpfcommon.HTTPInfoEventToSpan((*ebpfcommon.BPFHTTPInfo)(unsafe.Pointer(&v)))
-					if !ignore && err == nil {
-						eventsChan.Send(p.pidsFilter.Filter([]request.Span{s}))
-					}
-					if err := p.bpfObjects.OngoingHttp.Delete(k); err != nil {
-						p.log.Debug("Error deleting ongoing request", "error", err)
-					}
-				} else if v.EndMonotimeNs == 0 && p.cfg.EBPF.HTTPRequestTimeout.Milliseconds() > 0 && t.After(kernelTime(v.StartMonotimeNs).Add(p.cfg.EBPF.HTTPRequestTimeout)) {
-					// If we don't have a request finish with endTime by the configured request timeout, terminate the
-					// waiting request with a timeout 408
-					s, ignore, err := ebpfcommon.HTTPInfoEventToSpan((*ebpfcommon.BPFHTTPInfo)(unsafe.Pointer(&v)))
-
-					if !ignore && err == nil {
-						s.Status = 408 // timeout
-						if s.RequestStart == 0 {
-							s.RequestStart = s.Start
+func (p *Tracer) lookForTimeouts(ctx context.Context, ticker *time.Ticker, eventsChan *msg.Queue[[]request.Span]) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			if p.bpfObjects.OngoingHttp != nil {
+				i := p.bpfObjects.OngoingHttp.Iterate()
+				var k bpfPidConnectionInfoT
+				var v bpfHttpInfoT
+				for i.Next(&k, &v) {
+					// Check if we have a lingering request which we've completed, as in it has EndMonotimeNs
+					// but it hasn't been posted yet, likely missed by the logic that looks at finishing requests
+					// where we track the full response. If we haven't updated the EndMonotimeNs in more than some
+					// short interval, we are likely not going to finish this request from eBPF, so let's do it here.
+					if v.EndMonotimeNs != 0 && t.After(kernelTime(v.EndMonotimeNs).Add(2*time.Second)) {
+						// Must use unsafe here, the two bpfHttpInfoTs are the same but generated from different
+						// ebpf2go outputs
+						s, ignore, err := ebpfcommon.HTTPInfoEventToSpan((*ebpfcommon.BPFHTTPInfo)(unsafe.Pointer(&v)))
+						if !ignore && err == nil {
+							eventsChan.Send(p.pidsFilter.Filter([]request.Span{s}))
 						}
-						s.End = s.Start + p.cfg.EBPF.HTTPRequestTimeout.Nanoseconds()
+						if err := p.bpfObjects.OngoingHttp.Delete(k); err != nil {
+							p.log.Debug("Error deleting ongoing request", "error", err)
+						}
+					} else if v.EndMonotimeNs == 0 && p.cfg.EBPF.HTTPRequestTimeout.Milliseconds() > 0 && t.After(kernelTime(v.StartMonotimeNs).Add(p.cfg.EBPF.HTTPRequestTimeout)) {
+						// If we don't have a request finish with endTime by the configured request timeout, terminate the
+						// waiting request with a timeout 408
+						s, ignore, err := ebpfcommon.HTTPInfoEventToSpan((*ebpfcommon.BPFHTTPInfo)(unsafe.Pointer(&v)))
 
-						eventsChan.Send(p.pidsFilter.Filter([]request.Span{s}))
-					}
-					if err := p.bpfObjects.OngoingHttp.Delete(k); err != nil {
-						p.log.Debug("Error deleting ongoing request", "error", err)
+						if !ignore && err == nil {
+							s.Status = 408 // timeout
+							if s.RequestStart == 0 {
+								s.RequestStart = s.Start
+							}
+							s.End = s.Start + p.cfg.EBPF.HTTPRequestTimeout.Nanoseconds()
+
+							eventsChan.Send(p.pidsFilter.Filter([]request.Span{s}))
+						}
+						if err := p.bpfObjects.OngoingHttp.Delete(k); err != nil {
+							p.log.Debug("Error deleting ongoing request", "error", err)
+						}
 					}
 				}
 			}
@@ -526,16 +531,21 @@ func (p *Tracer) lookForTimeouts(ticker *time.Ticker, eventsChan *msg.Queue[[]re
 	}
 }
 
-func (p *Tracer) watchForMisclassifedEvents() {
-	for e := range ebpfcommon.MisclassifiedEvents {
-		if e.EventType == ebpfcommon.EventTypeKHTTP2 {
-			if p.bpfObjects.OngoingHttp2Connections != nil {
-				err := p.bpfObjects.OngoingHttp2Connections.Put(
-					&bpfPidConnectionInfoT{Conn: bpfConnectionInfoT(e.TCPInfo.ConnInfo), Pid: e.TCPInfo.Pid.HostPid},
-					bpfHttp2ConnInfoDataT{Flags: e.TCPInfo.Ssl, Id: 0}, // no new connection flag (0x3)
-				)
-				if err != nil {
-					p.log.Debug("error writing HTTP2/gRPC connection info", "error", err)
+func (p *Tracer) watchForMisclassifedEvents(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-ebpfcommon.MisclassifiedEvents:
+			if e.EventType == ebpfcommon.EventTypeKHTTP2 {
+				if p.bpfObjects.OngoingHttp2Connections != nil {
+					err := p.bpfObjects.OngoingHttp2Connections.Put(
+						&bpfPidConnectionInfoT{Conn: bpfConnectionInfoT(e.TCPInfo.ConnInfo), Pid: e.TCPInfo.Pid.HostPid},
+						bpfHttp2ConnInfoDataT{Flags: e.TCPInfo.Ssl, Id: 0}, // no new connection flag (0x3)
+					)
+					if err != nil {
+						p.log.Debug("error writing HTTP2/gRPC connection info", "error", err)
+					}
 				}
 			}
 		}

--- a/pkg/internal/ebpf/tracer_darwin.go
+++ b/pkg/internal/ebpf/tracer_darwin.go
@@ -35,6 +35,6 @@ func (pt *ProcessTracer) NewExecutableInstance(_ *Instrumentable) error {
 
 func (pt *ProcessTracer) UnlinkExecutable(_ *exec.FileInfo) {}
 
-func RunUtilityTracer(_ UtilityTracer) error {
+func RunUtilityTracer(_ context.Context, _ UtilityTracer) error {
 	return nil
 }

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -319,7 +319,7 @@ func printVerifierErrorInfo(err error) {
 	}
 }
 
-func RunUtilityTracer(p UtilityTracer) error {
+func RunUtilityTracer(ctx context.Context, p UtilityTracer) error {
 	i := instrumenter{}
 	plog := ptlog()
 	plog.Debug("loading independent eBPF program")
@@ -348,7 +348,7 @@ func RunUtilityTracer(p UtilityTracer) error {
 		return err
 	}
 
-	go p.Run(context.Background())
+	go p.Run(ctx)
 
 	btf.FlushKernelSpec()
 

--- a/pkg/internal/traces/read_decorator.go
+++ b/pkg/internal/traces/read_decorator.go
@@ -94,16 +94,15 @@ func HostProcessEventDecoratorProvider(
 	cfg *InstanceIDConfig,
 	input, output *msg.Queue[exec.ProcessEvent],
 ) swarm.InstanceFunc {
-	return func(ctx context.Context) (swarm.RunFunc, error) {
+	return func(_ context.Context) (swarm.RunFunc, error) {
 		decorate := hostNamePIDDecorator(cfg)
 		in := input.Subscribe()
-		cancelChan := ctx.Done()
 		log := rlog().With("function", "instance_ID_hostNamePIDDecorator")
 		// if kubernetes decoration is disabled, we just bypass the node
 		return func(ctx context.Context) {
 			for {
 				select {
-				case <-cancelChan:
+				case <-ctx.Done():
 					return
 				case pe, ok := <-in:
 					if !ok {

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -91,29 +91,34 @@ func (rn *routerNode) provideRoutes(_ context.Context) (swarm.RunFunc, error) {
 
 	in := rn.input.Subscribe()
 	out := rn.output
-	return func(_ context.Context) {
+	return func(ctx context.Context) {
 		// output channel must be closed so later stages in the pipeline can finish in cascade
 		defer rn.output.Close()
 
-		for spans := range in {
-			for i := range spans {
-				s := &spans[i]
-				if ignoreEnabled {
-					if discarder.Find(s.Path) != "" {
-						if ignoreMode == IgnoreAll {
-							s.SetIgnoreMetrics()
-							s.SetIgnoreTraces()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case spans := <-in:
+				for i := range spans {
+					s := &spans[i]
+					if ignoreEnabled {
+						if discarder.Find(s.Path) != "" {
+							if ignoreMode == IgnoreAll {
+								s.SetIgnoreMetrics()
+								s.SetIgnoreTraces()
+							}
+							// we can't discard it here, ignoring is selective (metrics | traces)
+							setSpanIgnoreMode(ignoreMode, s)
 						}
-						// we can't discard it here, ignoring is selective (metrics | traces)
-						setSpanIgnoreMode(ignoreMode, s)
 					}
+					if routesEnabled {
+						s.Route = matcher.Find(s.Path)
+					}
+					unmatchAction(rc, s)
 				}
-				if routesEnabled {
-					s.Route = matcher.Find(s.Path)
-				}
-				unmatchAction(rc, s)
+				out.Send(spans)
 			}
-			out.Send(spans)
 		}
 	}, nil
 }


### PR DESCRIPTION
We were missing proper handling of the cancellation context in number of places which lead to Beyla not properly shutting down sometimes or not being able to reload as a component inside Alloy. This is also important when we integrate OBI into the OTel Collector.