### PR TITLE
Remove more statics

### DIFF
--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 		processEventInput: processEventsInput,
 		bp:                bp,
 		peGraphBuilder:    swi,
-		ebpfEventContext:  &ebpfcommon.EBPFEventContext{},
+		ebpfEventContext:  ebpfcommon.NewEBPFEventContext(),
 	}, nil
 }
 

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/internal/discover"
 	"github.com/grafana/beyla/v2/pkg/internal/ebpf"
+	ebpfcommon "github.com/grafana/beyla/v2/pkg/internal/ebpf/common"
 	"github.com/grafana/beyla/v2/pkg/internal/exec"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
@@ -41,6 +42,9 @@ type Instrumenter struct {
 	tracesInput       *msg.Queue[[]request.Span]
 	processEventInput *msg.Queue[exec.ProcessEvent]
 	peGraphBuilder    *swarm.Instancer
+
+	// global data structures for all eBPF tracers
+	ebpfEventContext *ebpfcommon.EBPFEventContext
 }
 
 // New Instrumenter, given a Config
@@ -85,6 +89,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 		processEventInput: processEventsInput,
 		bp:                bp,
 		peGraphBuilder:    swi,
+		ebpfEventContext:  &ebpfcommon.EBPFEventContext{},
 	}, nil
 }
 
@@ -93,7 +98,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 // Returns a channel that is closed when the Instrumenter completed all its tasks.
 // This is: when the context is cancelled, it has unloaded all the eBPF probes.
 func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
-	finder := discover.NewProcessFinder(i.config, i.ctxInfo, i.tracesInput)
+	finder := discover.NewProcessFinder(i.config, i.ctxInfo, i.tracesInput, i.ebpfEventContext)
 	processEvents, err := finder.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't start Process Finder: %w", err)
@@ -132,7 +137,7 @@ func (i *Instrumenter) instrumentedEventLoop(ctx context.Context, processEvents 
 					i.tracersWg.Add(1)
 					go func() {
 						defer i.tracersWg.Done()
-						pt.Tracer.Run(ctx, i.tracesInput)
+						pt.Tracer.Run(ctx, i.ebpfEventContext, i.tracesInput)
 					}()
 				}
 				i.handleAndDispatchProcessEvent(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: pt.FileInfo})

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -57,7 +57,7 @@ type TraceAttacher struct {
 	OutputTracerEvents *msg.Queue[Event[*ebpf.Instrumentable]]
 
 	// The common PID filter that's used to filter out events we don't need
-	commonPIDsFilter ebpfcommon.ServiceFilter
+	ebpfEventContext *ebpfcommon.EBPFEventContext
 }
 
 func TraceAttacherProvider(ta *TraceAttacher) swarm.InstanceFunc {
@@ -70,7 +70,7 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.sdkInjector = otelsdk.NewSDKInjector(ta.Cfg)
 	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.beylaPID = os.Getpid()
-	ta.commonPIDsFilter = ebpfcommon.CommonPIDsFilter(&ta.Cfg.Discovery)
+	ta.ebpfEventContext.CommonPIDsFilter = ebpfcommon.CommonPIDsFilter(&ta.Cfg.Discovery)
 
 	if err := ta.init(); err != nil {
 		ta.log.Error("can't start process tracer. Stopping it", "error", err)
@@ -168,20 +168,20 @@ func (ta *TraceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 				// instance of the executable has different DLLs loaded, e.g. libssl.so.
 				return ta.reuseTracer(ta.reusableTracer, ie)
 			} else {
-				programs = ta.withCommonTracersGroup(newGenericTracersGroup(ta.commonPIDsFilter, ta.Cfg, ta.Metrics))
+				programs = ta.withCommonTracersGroup(newGenericTracersGroup(ta.ebpfEventContext.CommonPIDsFilter, ta.Cfg, ta.Metrics))
 			}
 		} else {
 			if ta.reusableGoTracer != nil {
 				return ta.reuseTracer(ta.reusableGoTracer, ie)
 			}
 			tracerType = ebpf.Go
-			programs = ta.withCommonTracersGroup(newGoTracersGroup(ta.commonPIDsFilter, ta.Cfg, ta.Metrics))
+			programs = ta.withCommonTracersGroup(newGoTracersGroup(ta.ebpfEventContext.CommonPIDsFilter, ta.Cfg, ta.Metrics))
 		}
 	case svc.InstrumentableNodejs, svc.InstrumentableJava, svc.InstrumentableRuby, svc.InstrumentablePython, svc.InstrumentableDotnet, svc.InstrumentableGeneric, svc.InstrumentableRust, svc.InstrumentablePHP:
 		if ta.reusableTracer != nil {
 			return ta.reuseTracer(ta.reusableTracer, ie)
 		}
-		programs = ta.withCommonTracersGroup(newGenericTracersGroup(ta.commonPIDsFilter, ta.Cfg, ta.Metrics))
+		programs = ta.withCommonTracersGroup(newGenericTracersGroup(ta.ebpfEventContext.CommonPIDsFilter, ta.Cfg, ta.Metrics))
 	default:
 		ta.log.Warn("unexpected instrumentable type. This is basically a bug", "type", ie.Type)
 	}

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -201,7 +201,7 @@ func (ta *TraceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 
 	tracer := ebpf.NewProcessTracer(tracerType, programs)
 
-	if err := tracer.Init(); err != nil {
+	if err := tracer.Init(ta.ebpfEventContext); err != nil {
 		ta.log.Error("couldn't trace process. Stopping process tracer", "error", err)
 		return false
 	}

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -93,6 +94,14 @@ type MisclassifiedEvent struct {
 
 type EBPFParseContext struct {
 	h2c *lru.Cache[uint64, h2Connection]
+}
+
+type EBPFEventContext struct {
+	CommonPIDsFilter ServiceFilter
+	SharedRingBuffer *ringBufForwarder
+	EBPFMaps         map[string]*ebpf.Map
+	RingBufLock      sync.Mutex
+	MapsLock         sync.Mutex
 }
 
 var MisclassifiedEvents = make(chan MisclassifiedEvent)

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -102,6 +102,7 @@ type EBPFEventContext struct {
 	EBPFMaps         map[string]*ebpf.Map
 	RingBufLock      sync.Mutex
 	MapsLock         sync.Mutex
+	LoadLock         sync.Mutex
 }
 
 var MisclassifiedEvents = make(chan MisclassifiedEvent)
@@ -112,6 +113,15 @@ func NewEBPFParseContext() *EBPFParseContext {
 	h2c, _ := lru.New[uint64, h2Connection](1024 * 10)
 	return &EBPFParseContext{
 		h2c: h2c,
+	}
+}
+
+func NewEBPFEventContext() *EBPFEventContext {
+	return &EBPFEventContext{
+		EBPFMaps:    map[string]*ebpf.Map{},
+		RingBufLock: sync.Mutex{},
+		MapsLock:    sync.Mutex{},
+		LoadLock:    sync.Mutex{},
 	}
 }
 

--- a/pkg/internal/ebpf/common/spanner.go
+++ b/pkg/internal/ebpf/common/spanner.go
@@ -11,8 +11,6 @@ import (
 	"github.com/grafana/beyla/v2/pkg/internal/sqlprune"
 )
 
-var log = slog.With("component", "goexec.spanner")
-
 func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 	// From C, assuming 0-ended strings
 	method := cstr(trace.Method[:])
@@ -64,7 +62,7 @@ func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 
 func SQLRequestTraceToSpan(trace *SQLRequestTrace) request.Span {
 	if request.EventType(trace.Type) != request.EventTypeSQLClient {
-		log.Warn("unknown trace type", "type", trace.Type)
+		slog.With("component", "goexec.spanner").Warn("unknown trace type", "type", trace.Type)
 		return request.Span{}
 	}
 

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -454,7 +454,7 @@ func (p *Tracer) AlreadyInstrumentedLib(id uint64) bool {
 	return module != nil
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span]) {
+func (p *Tracer) Run(ctx context.Context, ebpfEventContext *ebpfcommon.EBPFEventContext, eventsChan *msg.Queue[[]request.Span]) {
 	// At this point we now have loaded the bpf objects, which means we should insert any
 	// pids that are allowed into the bpf map
 	if p.bpfObjects.ValidPids != nil {
@@ -472,6 +472,7 @@ func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span])
 	p.log.Info("Launching p.Tracer")
 
 	ebpfcommon.SharedRingbuf(
+		ebpfEventContext,
 		&p.cfg.EBPF,
 		p.pidsFilter,
 		p.bpfObjects.Events,

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -424,8 +424,9 @@ func (p *Tracer) AlreadyInstrumentedLib(_ uint64) bool {
 	return false
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span]) {
+func (p *Tracer) Run(ctx context.Context, ebpfEventContext *ebpfcommon.EBPFEventContext, eventsChan *msg.Queue[[]request.Span]) {
 	ebpfcommon.SharedRingbuf(
+		ebpfEventContext,
 		p.cfg,
 		p.pidsFilter,
 		p.bpfObjects.Events,

--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -214,11 +214,11 @@ func (p *Tracer) AlreadyInstrumentedLib(id uint64) bool {
 	return module != nil
 }
 
-func (p *Tracer) Run(ctx context.Context, eventsChan *msg.Queue[[]request.Span]) {
+func (p *Tracer) Run(ctx context.Context, ebpfEventContext *ebpfcommon.EBPFEventContext, eventsChan *msg.Queue[[]request.Span]) {
 	ebpfcommon.ForwardRingbuf(
 		&p.cfg.EBPF,
 		p.bpfObjects.Rb,
-		ebpfcommon.CommonPIDsFilter(&p.cfg.Discovery),
+		ebpfEventContext.CommonPIDsFilter,
 		p.processCudaEvent,
 		p.log,
 		p.metrics,

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -138,7 +138,7 @@ func (p *Tracer) startTC(ctx context.Context) {
 	p.ifaceManager.Start(ctx)
 }
 
-func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
+func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
 	p.startTC(ctx)
 
 	errorCh := p.tcManager.Errors()

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -144,7 +144,7 @@ func (p *Tracer) AlreadyInstrumentedLib(uint64) bool {
 	return false
 }
 
-func (p *Tracer) Run(ctx context.Context, _ *msg.Queue[[]request.Span]) {
+func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
 	p.log.Debug("tpinjector started")
 
 	<-ctx.Done()

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -111,7 +111,7 @@ type Tracer interface {
 	Required() bool
 	// Run will do the action of listening for eBPF traces and forward them
 	// periodically to the output channel.
-	Run(context.Context, *msg.Queue[[]request.Span])
+	Run(context.Context, *ebpfcommon.EBPFEventContext, *msg.Queue[[]request.Span])
 }
 
 // Subset of the above interface, which supports loading eBPF programs which

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -114,7 +114,7 @@ func NewProcessTracer(tracerType ProcessTracerType, programs []Tracer) *ProcessT
 	}
 }
 
-func (pt *ProcessTracer) Run(ctx context.Context, out *msg.Queue[[]request.Span]) {
+func (pt *ProcessTracer) Run(ctx context.Context, ebpfEventContext *common.EBPFEventContext, out *msg.Queue[[]request.Span]) {
 	pt.log = ptlog().With("type", pt.Type)
 
 	pt.log.Debug("starting process tracer")
@@ -127,7 +127,7 @@ func (pt *ProcessTracer) Run(ctx context.Context, out *msg.Queue[[]request.Span]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			t.Run(ctx, out)
+			t.Run(ctx, ebpfEventContext, out)
 		}()
 	}
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/grafana/beyla/pull/2017. There were two main remaining statics that were in the code, which we properly handled for unloading by the previous PR, but there was one drawback, as they are statics they would disallow us to be bundled as multiple components in a bundler, for example, as two Alloy or OTel Collector components. 