### PR TITLE
Fix generator image name in the workflow file

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: grafana/beyla-generator
+  IMAGE_NAME: grafana/beyla-ebpf-generator
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
When the image was renamed from `beyla-generator` to `beyla-ebpf-generator` (to avoid breaking previous images, this was done when we switched from ubuntu to alpine) we forgot to update the workflow file.