### PR TITLE
Remove default k8s namespaces

### DIFF
--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -18,8 +18,8 @@ In some scenarios, Beyla instruments many services. For example, as a [Kubernete
 |------------------------------------------------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------------------------------------------- |
 | `instrument`                                                                       | Specify different selection criteria for different services, and override their reported name or namespace. Refer to the [discovery services](#discovery-services) section for details. .                                                                                                     | list of objects | (unset)                                               |
 | `survey`                                                                           | specifying different selection criteria for Beyla survey mode. Refer to the [survey mode](#survey-mode) section for details.                                                                                                                                                                  | List of objects | (unset)                                               |
-| `exclude_instrument`                                                               | Specify selection criteria for excluding services from being instrumented. Useful for avoiding instrumentation of services typically found in observability environments. Refer to the [exclude services](#exclude-services) section for details. .                                           | list of objects | (unset)                                               |
-| `default_exclude_instrument`                                                       | Disables instrumentation of Beyla itself, Grafana Alloy, and the OpenTelemetry Collector. Set to empty to allow Beyla to instrument itself and these other components. Refer to the [default exclude services](#default-exclude-services) section for details. .                              | list of objects | Path: `(?:^ | \/)(beyla$ | alloy$ | otelcol[^\/]\*$)` |
+| `exclude_instrument`                                                               | Specify selection criteria for excluding services from being instrumented. Useful for avoiding instrumentation of services typically found in observability environments. Refer to the [exclude services from instrumentation](#exclude-services-from-instrumentation) section for details. .                                           | list of objects | (unset)                                               |
+| `default_exclude_instrument`                                                       | Disables instrumentation of Beyla itself, Grafana Alloy, and the OpenTelemetry Collector. Set to empty to allow Beyla to instrument itself and these other components. Refer to the [default exclude services from instrumentation](#default-exclude-services-from-instrumentation) section for details. .                              | list of objects | Path: `(?:^ | \/)(beyla$ | alloy$ | otelcol[^\/]\*$)` and certain Kubernetes system namespaces |
 | `skip_go_specific_tracers`<br>`BEYLA_SKIP_GO_SPECIFIC_TRACERS`                     | Disables the detection of Go specifics when the **ebpf** tracer inspects executables to be instrumented. The tracer falls back to using generic instrumentation, which is generally less efficient. Refer to the [skip go specific tracers](#skip-go-specific-tracers) section for details. . | boolean         | false                                                 |
 | `exclude_otel_instrumented_services`<br>`BEYLA_EXCLUDE_OTEL_INSTRUMENTED_SERVICES` | Disables Beyla instrumentation of services already instrumented with OpenTelemetry. Refer to the [exclude instrumented services](#exclude-otel-instrumented-services) section for details.                                                                                                    | boolean         | true                                                  |
 
@@ -195,9 +195,18 @@ This option helps you avoid instrumenting services typically found in observabil
 
 ## Default exclude services from instrumentation
 
-The `default_exclude_instrument` section disables instrumentation of Beyla itself (self-instrumentation), as well as Grafana Alloy and the OpenTelemetry Collector. Set to empty to allow Beyla to instrument itself as well as these other components.
+The `default_exclude_instrument` section disables instrumentation of Beyla itself (self-instrumentation), as well as Grafana Alloy and the OpenTelemetry Collector. 
+It also disables instrumentation of various Kubernetes system namespaces to reduce the overall cost of metric generation. The following section contains all excluded
+components:
+- Excluded services by `exe_path`: `beyla`, `alloy`, `otelcol*`.
+- Excluded services by `k8s_namespace`: `kube-system`, `kube-node-lease`, `local-path-storage`, `grafana-alloy`, `cert-manager`, `monitoring`, 
+  `gke-connect`, `gke-gmp-system`, `gke-managed-cim`, `gke-managed-filestorecsi`, `gke-managed-metrics-server`, `gke-managed-system`, `gke-system`, `gke-managed-volumepopulator`,
+  `gatekeeper-system`.
 
-Note: to enable such self-instrumentation, you still need to include them in the `instrument` section.
+Change this option to allow Beyla to instrument itself or some of the other excluded components.
+
+Note: to enable such self-instrumentation, you still need to include them in the `instrument` section, or these components need to be
+a part of a encompassing inclusion criteria.
 
 ## Skip go specific tracers
 

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -225,10 +225,16 @@ network:
 				services.RegexSelector{
 					Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
 				},
+				services.RegexSelector{
+					Metadata: map[string]*services.RegexpAttr{"k8s_namespace": &k8sDefaultNamespacesRegex},
+				},
 			},
 			DefaultExcludeInstrument: services.GlobDefinitionCriteria{
 				services.GlobAttributes{
 					Path: services.NewGlob(glob.MustCompile("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}")),
+				},
+				services.GlobAttributes{
+					Metadata: map[string]*services.GlobAttr{"k8s_namespace": &k8sDefaultNamespacesGlob},
 				},
 			},
 		},

--- a/pkg/internal/discover/matcher_test.go
+++ b/pkg/internal/discover/matcher_test.go
@@ -486,7 +486,7 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
 	}
 }
 
-func criteriaMatcher_Exclude_Default_Metadata_Helper(t *testing.T, pipeConfig beyla.Config) {
+func criteriaMatcherExcludeDefaultMetadataHelper(t *testing.T, pipeConfig beyla.Config) {
 	k8sSystemNamespaces := []string{
 		"gke-connect", "gke-gmp-system", "gke-managed-cim", "gke-managed-filestorecsi",
 		"gke-managed-metrics-server", "gke-managed-system", "gke-system", "gke-managed-volumepopulator",
@@ -548,7 +548,7 @@ func TestCriteriaMatcher_Exclude_Default_Metadata_Regex(t *testing.T) {
 
 	pipeConfig.Discovery.DefaultExcludeServices = beyla.DefaultConfig.Discovery.DefaultExcludeServices
 
-	criteriaMatcher_Exclude_Default_Metadata_Helper(t, pipeConfig)
+	criteriaMatcherExcludeDefaultMetadataHelper(t, pipeConfig)
 }
 
 func TestCriteriaMatcher_Exclude_Default_Metadata_Glob(t *testing.T) {
@@ -560,5 +560,5 @@ func TestCriteriaMatcher_Exclude_Default_Metadata_Glob(t *testing.T) {
 
 	pipeConfig.Discovery.DefaultExcludeInstrument = beyla.DefaultConfig.Discovery.DefaultExcludeInstrument
 
-	criteriaMatcher_Exclude_Default_Metadata_Helper(t, pipeConfig)
+	criteriaMatcherExcludeDefaultMetadataHelper(t, pipeConfig)
 }

--- a/pkg/internal/discover/matcher_test.go
+++ b/pkg/internal/discover/matcher_test.go
@@ -485,3 +485,80 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
 		})
 	}
 }
+
+func criteriaMatcher_Exclude_Default_Metadata_Helper(t *testing.T, pipeConfig beyla.Config) {
+	k8sSystemNamespaces := []string{
+		"gke-connect", "gke-gmp-system", "gke-managed-cim", "gke-managed-filestorecsi",
+		"gke-managed-metrics-server", "gke-managed-system", "gke-system", "gke-managed-volumepopulator",
+		"gatekeeper-system", "kube-system", "kube-node-lease", "local-path-storage", "grafana-alloy",
+		"cert-manager", "monitoring",
+	}
+
+	k8sAllowedNamespaces := []string{"default", "random-service-namespace"}
+
+	discoveredProcesses := msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	matcherFunc, err := CriteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer filteredProcessesQu.Close()
+
+	processInfo = func(pp processAttrs) (*services.ProcessInfo, error) {
+		return &services.ProcessInfo{Pid: int32(pp.pid), ExePath: "/something/something", PPid: 1}, nil
+	}
+
+	pid := 1
+	events := []Event[processAttrs]{}
+
+	for _, ns := range k8sSystemNamespaces {
+		events = append(events,
+			Event[processAttrs]{Type: EventCreated, Obj: processAttrs{pid: PID(pid), metadata: map[string]string{"k8s_namespace": ns}}},
+		)
+		pid++
+	}
+
+	savePid := pid
+
+	for _, ns := range k8sAllowedNamespaces {
+		events = append(events,
+			Event[processAttrs]{Type: EventCreated, Obj: processAttrs{pid: PID(pid), metadata: map[string]string{"k8s_namespace": ns}}},
+		)
+		pid++
+	}
+
+	discoveredProcesses.Send(events)
+
+	matches := testutil.ReadChannel(t, filteredProcesses, 1000*testTimeout)
+	require.Len(t, matches, 2)
+	m := matches[0]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, services.ProcessInfo{Pid: int32(savePid), PPid: 1, ExePath: "/something/something"}, *m.Obj.Process)
+	m = matches[1]
+	assert.Equal(t, EventCreated, m.Type)
+	assert.Equal(t, services.ProcessInfo{Pid: int32(savePid + 1), PPid: 1, ExePath: "/something/something"}, *m.Obj.Process)
+}
+
+func TestCriteriaMatcher_Exclude_Default_Metadata_Regex(t *testing.T) {
+	pipeConfig := beyla.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  services:
+  - k8s_namespace: .
+`), &pipeConfig))
+
+	pipeConfig.Discovery.DefaultExcludeServices = beyla.DefaultConfig.Discovery.DefaultExcludeServices
+
+	criteriaMatcher_Exclude_Default_Metadata_Helper(t, pipeConfig)
+}
+
+func TestCriteriaMatcher_Exclude_Default_Metadata_Glob(t *testing.T) {
+	pipeConfig := beyla.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  instrument:
+  - k8s_namespace: "*"
+`), &pipeConfig))
+
+	pipeConfig.Discovery.DefaultExcludeInstrument = beyla.DefaultConfig.Discovery.DefaultExcludeInstrument
+
+	criteriaMatcher_Exclude_Default_Metadata_Helper(t, pipeConfig)
+}


### PR DESCRIPTION
Adds default exclusion criteria for various Kubernetes system namespaces. Apart from the default K8s system namespaces it adds GKE, AKS and EKS specific namespaces, as well as Grafana specific namespaces (alloy and monitoring)


Closes https://github.com/grafana/beyla/issues/1931