### PR TITLE
Fix Typo in Documentation and Code Comments

### DIFF
--- a/docs/sources/cilium-compatibility.md
+++ b/docs/sources/cilium-compatibility.md
@@ -35,7 +35,7 @@ Beyla also refuses to run if it's configured to use Netlink attachments and it d
 
 ### Configure Cilium Netlink priority
 
-You can configure Cilium Netlink program priority via the `bpf-filter-priorty` configuration:
+You can configure Cilium Netlink program priority via the `bpf-filter-priority` configuration:
 
 ```shell
 cilium config set bpf-filter-priority 2

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -128,7 +128,7 @@ func (m *TracesConfig) OTLPTracesEndpoint() (string, bool) {
 }
 
 func (m *TracesConfig) guessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics enpdoint port
+	// If no explicit protocol is set, we guess it it from the metrics endpoint port
 	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
 	ep, _, err := parseTracesEndpoint(m)
 	if err == nil {


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in both documentation and code comments:
- Updates the spelling of "priority" in the Cilium Netlink configuration documentation.
- Fixes the spelling of "endpoint" in a comment within the `guessProtocol` function in `traces.go`.

These changes improve clarity and maintain consistency in the codebase and documentation. No functional code changes are included.