### PR TITLE
Prevent pull requests to fail from external forks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,12 +36,14 @@ jobs:
         run: make docker-generate verify cov-exclude-generated
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/cover.txt
           flags: unittests

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -49,12 +49,14 @@ jobs:
             testoutput/kind
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt
           flags: integration-test

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -49,12 +49,14 @@ jobs:
             testoutput/kind
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt
           flags: integration-test-arm

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -49,12 +49,14 @@ jobs:
             testoutput/kind
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt
           flags: k8s-integration-test

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -42,12 +42,14 @@ jobs:
           path: test/oats/*/build/*
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt
           flags: oats-test

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -57,12 +57,14 @@ jobs:
             testoutput/kind
       - id: get-codecov-token
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        continue-on-error: true
         with:
           # Secrets placed in the ci/repo/grafana/beyla/codecov path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt
           flags: integration-test-vm-${{ inputs.arch }}-${{ inputs.kernel-version }}


### PR DESCRIPTION
Codecov required getting credentials from our internal vault. This caused that external PRs would fail on that step.

Setting a `continue-on-error` variable to prevent PRs from forks to fail. We won't get code coverage for PRs but that's it.