### PR TITLE
Fix Typographical Errors in Comments

### DIFF
--- a/pkg/export/otel/metric/internal/exemplar/rand.go
+++ b/pkg/export/otel/metric/internal/exemplar/rand.go
@@ -19,7 +19,7 @@ var (
 	// Do not use crypto/rand. There is no reason for the decrease in performance
 	// given this is not a security sensitive decision.
 	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
-	// Ensure concurrent safe accecess to rng and its underlying source.
+	// Ensure concurrent safe access to rng and its underlying source.
 	rngMu sync.Mutex
 )
 

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -151,7 +151,7 @@ func (m *MetricsConfig) GetInterval() time.Duration {
 }
 
 func (m *MetricsConfig) GuessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics enpdoint port
+	// If no explicit protocol is set, we guess it it from the metrics endpoint port
 	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
 	ep, _, err := parseMetricsEndpoint(m)
 	if err == nil {


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments within the codebase. Specifically, it changes "acccess" to "access" in pkg/export/otel/metric/internal/exemplar/rand.go and "endpoint" to "endpoint" (fixing a typo) in pkg/export/otel/metrics.go. These changes improve code readability and maintain consistency in documentation. No functional code changes were made.