### PR TITLE
Automatic beyla.Config -> obi.Config struct conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/logr v1.4.3
-	github.com/go-logr/stdr v1.2.2
 	github.com/gobwas/glob v0.2.3
 	github.com/goccy/go-json v0.10.5
 	github.com/google/uuid v1.6.0
@@ -23,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b
 	github.com/mariomac/guara v0.0.0-20250408105519-1e4dbdfb7136
-	github.com/open-telemetry/opentelemetry-ebpf-instrumentation v0.0.0-20250613173108-d81ed64653ef
+	github.com/open-telemetry/opentelemetry-ebpf-instrumentation v0.0.0-20250616070931-013898c47d96
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
@@ -92,6 +91,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/caarlos0/env/v9"
 	"github.com/gobwas/glob"
+	obi "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/beyla"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/ebpf/tcmanager"
 	attributes "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes"
 	attr "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes/names"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/config"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
 	"github.com/grafana/beyla/v2/pkg/export/prom"
+	config2 "github.com/grafana/beyla/v2/pkg/internal/helpers/config"
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	"github.com/grafana/beyla/v2/pkg/internal/kube"
@@ -245,6 +247,9 @@ type Config struct {
 
 	// Grafana Alloy specific configuration
 	TracesReceiver TracesReceiverConfig `yaml:"-"`
+
+	// cached equivalent for the OBI conversion
+	obi *obi.Config `yaml:"-"`
 }
 
 type Consumer interface {
@@ -286,11 +291,27 @@ func (e ConfigError) Error() string {
 	return string(e)
 }
 
+func (c *Config) AsOBI() *obi.Config {
+	if c.obi == nil {
+		obiCfg := &obi.Config{}
+		config2.Convert(c, obiCfg, map[string]string{
+			// here, some hints might be useful if we need to skip values that are non-existing in OBI,
+			// or, renamed. For example:
+			// ".Some.Renamed.FieldInSrc": "NewNameInDst",
+			// ".Some.Missing.FieldInDst": config2.SkipConversion,
+		})
+		c.obi = obiCfg
+	}
+	return c.obi
+}
+
 // nolint:cyclop
 func (c *Config) Validate() error {
-	if err := c.Discovery.Validate(); err != nil {
+	obiCfg := c.AsOBI()
+	if err := obiCfg.Discovery.Validate(); err != nil {
 		return ConfigError(err.Error())
 	}
+
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) {
 		return ConfigError("missing application discovery section or network metrics configuration. Check documentation.")
 	}

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -297,8 +297,8 @@ func (c *Config) AsOBI() *obi.Config {
 		cfgutil.Convert(c, obiCfg, map[string]string{
 			// here, some hints might be useful if we need to skip values that are non-existing in OBI,
 			// or, renamed. For example:
-			// ".Some.Renamed.FieldInSrc": "NewNameInDst",
-			// ".Some.Missing.FieldInDst": cfgutil.SkipConversion,
+			// ".Some.Renamed.FieldInDst": "NameInSrc",
+			// ".Some.Missing.FieldInSrc": cfgutil.SkipConversion,
 		})
 		c.obi = obiCfg
 	}

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/grafana/beyla/v2/pkg/config"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
 	"github.com/grafana/beyla/v2/pkg/export/prom"
-	config2 "github.com/grafana/beyla/v2/pkg/internal/helpers/config"
+	cfgutil "github.com/grafana/beyla/v2/pkg/internal/helpers/config"
 	"github.com/grafana/beyla/v2/pkg/internal/imetrics"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	"github.com/grafana/beyla/v2/pkg/internal/kube"
@@ -294,11 +294,11 @@ func (e ConfigError) Error() string {
 func (c *Config) AsOBI() *obi.Config {
 	if c.obi == nil {
 		obiCfg := &obi.Config{}
-		config2.Convert(c, obiCfg, map[string]string{
+		cfgutil.Convert(c, obiCfg, map[string]string{
 			// here, some hints might be useful if we need to skip values that are non-existing in OBI,
 			// or, renamed. For example:
 			// ".Some.Renamed.FieldInSrc": "NewNameInDst",
-			// ".Some.Missing.FieldInDst": config2.SkipConversion,
+			// ".Some.Missing.FieldInDst": cfgutil.SkipConversion,
 		})
 		c.obi = obiCfg
 	}

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -70,7 +70,8 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.sdkInjector = otelsdk.NewSDKInjector(ta.Cfg)
 	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.beylaPID = os.Getpid()
-	obiCfg := ta.Cfg.Discovery.AsOBI()
+
+	obiCfg := ta.Cfg.AsOBI().Discovery
 	ta.ebpfEventContext.CommonPIDsFilter = ebpfcommon.CommonPIDsFilter(&obiCfg)
 
 	if err := ta.init(); err != nil {

--- a/pkg/internal/helpers/config/convert.go
+++ b/pkg/internal/helpers/config/convert.go
@@ -112,8 +112,10 @@ func convertStruct(
 		if sv, ok := srcVals[srcName]; ok {
 			handleFieldConversion(prefix+dn+".", sv, dv, fieldHints)
 		} else {
-			panic(fmt.Sprintf("dst field %s: cannot find field %s in source",
-				prefix+dn, srcName))
+			if srcName != SkipConversion {
+				panic(fmt.Sprintf("dst field %s: cannot find field %s in source",
+					prefix+dn, srcName))
+			}
 		}
 	}
 }

--- a/pkg/internal/helpers/config/convert.go
+++ b/pkg/internal/helpers/config/convert.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const SkipConversion = "(skip)"
+
+func Convert(
+	src, dst any,
+	fieldHints map[string]string,
+) error {
+	if fieldHints == nil {
+		fieldHints = map[string]string{}
+	}
+	return convert(".", reflect.ValueOf(src), reflect.ValueOf(dst), fieldHints)
+}
+
+func convert(
+	prefix string,
+	src, dst reflect.Value,
+	fieldHints map[string]string,
+) error {
+	// Handle pointers - make sure dst is a non-nil pointer
+	if dst.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("%s: destination must be a pointer, got %v", prefix, dst.Kind()))
+	}
+	if dst.IsNil() {
+		panic(prefix + ": destination is nil pointer")
+	}
+
+	dstElem := dst.Elem()
+
+	// Handle src pointer if needed
+	srcValue := src
+	if src.Kind() == reflect.Ptr {
+		if src.IsNil() {
+			return fmt.Errorf("source is nil pointer")
+		}
+		srcValue = src.Elem()
+	}
+
+	if srcValue.Kind() == reflect.Struct && dstElem.Kind() == reflect.Struct {
+		return convertStruct(prefix, srcValue, dstElem, fieldHints)
+	}
+
+	if srcValue.Type().AssignableTo(dstElem.Type()) {
+		dstElem.Set(srcValue)
+		return nil
+	}
+	if srcValue.Type().ConvertibleTo(dstElem.Type()) {
+		dstElem.Set(srcValue.Convert(dstElem.Type()))
+		return nil
+	}
+
+	return fmt.Errorf("field %s: cannot convert %s to %s", prefix, srcValue.Type(), dstElem.Type())
+}
+
+func handleFieldConversion(
+	prefix string,
+	srcField, dstField reflect.Value,
+	fieldHints map[string]string,
+) error {
+	// Direct assignment if types match
+	if srcField.Type().AssignableTo(dstField.Type()) {
+		dstField.Set(srcField)
+		return nil
+	}
+
+	// Type conversion if possible
+	if srcField.Type().ConvertibleTo(dstField.Type()) {
+		dstField.Set(srcField.Convert(dstField.Type()))
+		return nil
+	}
+
+	// For struct fields, we need recursive handling
+	if srcField.Kind() == reflect.Struct && dstField.Kind() == reflect.Struct {
+		return convertStruct(prefix, srcField, dstField, fieldHints)
+	}
+
+	// For pointer fields, create new instance if needed
+	if srcField.Kind() == reflect.Ptr && dstField.Kind() == reflect.Ptr {
+		if srcField.IsNil() {
+			// Source is nil, nothing to convert
+			return nil
+		}
+
+		if dstField.IsNil() {
+			// Create a new instance of the destination type
+			dstField.Set(reflect.New(dstField.Type().Elem()))
+		}
+
+		// Convert what the pointers point to
+		return convert(prefix, srcField.Elem(), dstField, fieldHints)
+	}
+
+	return fmt.Errorf("field %s: cannot convert %s to %s", prefix, srcField.Type(), dstField.Type())
+}
+
+func convertStruct(
+	prefix string,
+	src, dst reflect.Value,
+	fieldHints map[string]string,
+) error {
+	srcVals := structFieldValues(src)
+	dstVals := structFieldValues(dst)
+
+	for dn, dv := range dstVals {
+		srcName := dn
+		if hint, ok := fieldHints[prefix+dn]; ok {
+			srcName = hint
+		}
+		if sv, ok := srcVals[srcName]; ok {
+			if err := handleFieldConversion(prefix+dn+".", sv, dv, fieldHints); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("dst field %s: cannot find field %s in source",
+				prefix+dn, srcName)
+		}
+	}
+	return nil
+}
+
+func structFieldValues(str reflect.Value) map[string]reflect.Value {
+	m := make(map[string]reflect.Value, str.NumField())
+	for i := 0; i < str.NumField(); i++ {
+		// ignoring private fields
+		if f := str.Type().Field(i); f.IsExported() {
+			m[f.Name] = str.Field(i)
+		}
+	}
+	return m
+}

--- a/pkg/internal/helpers/config/convert.go
+++ b/pkg/internal/helpers/config/convert.go
@@ -111,11 +111,9 @@ func convertStruct(
 		}
 		if sv, ok := srcVals[srcName]; ok {
 			handleFieldConversion(prefix+dn+".", sv, dv, fieldHints)
-		} else {
-			if srcName != SkipConversion {
-				panic(fmt.Sprintf("dst field %s: cannot find field %s in source",
-					prefix+dn, srcName))
-			}
+		} else if srcName != SkipConversion {
+			panic(fmt.Sprintf("dst field %s: cannot find field %s in source",
+				prefix+dn, srcName))
 		}
 	}
 }

--- a/pkg/internal/helpers/config/convert.go
+++ b/pkg/internal/helpers/config/convert.go
@@ -50,21 +50,7 @@ func convert(
 		srcValue = src.Elem()
 	}
 
-	if srcValue.Kind() == reflect.Struct && dstElem.Kind() == reflect.Struct {
-		convertStruct(prefix, srcValue, dstElem, fieldHints)
-		return
-	}
-
-	if srcValue.Type().AssignableTo(dstElem.Type()) {
-		dstElem.Set(srcValue)
-		return
-	}
-	if srcValue.Type().ConvertibleTo(dstElem.Type()) {
-		dstElem.Set(srcValue.Convert(dstElem.Type()))
-		return
-	}
-
-	panic(fmt.Sprintf("field %s: cannot convert %s to %s", prefix, srcValue.Type(), dstElem.Type()))
+	handleFieldConversion(prefix, srcValue, dstElem, fieldHints)
 }
 
 func handleFieldConversion(

--- a/pkg/internal/helpers/config/convert_test.go
+++ b/pkg/internal/helpers/config/convert_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConvert(t *testing.T) {
+	t.Run("same basic type", func(t *testing.T) {
+		d := 0
+		require.NoError(t, Convert(1, &d, nil))
+		assert.Equal(t, 1, d)
+	})
+	t.Run("convertible basic type", func(t *testing.T) {
+		d := uint16(0)
+		require.NoError(t, Convert(uint8(3), &d, nil))
+		assert.Equal(t, uint16(3), d)
+	})
+	t.Run("string", func(t *testing.T) {
+		d := ""
+		require.NoError(t, Convert("foo", &d, nil))
+		assert.Equal(t, "foo", d)
+	})
+	t.Run("same struct type", func(t *testing.T) {
+		d := Foo{}
+		require.NoError(t, Convert(Foo{Str: "foo", Num: 1, OtherNum: 2}, &d, nil))
+		assert.Equal(t, Foo{Str: "foo", Num: 1, OtherNum: 2}, d)
+	})
+	t.Run("different struct type with equivalent fields", func(t *testing.T) {
+		d := Bar{}
+		require.NoError(t, Convert(Foo{Str: "foo", Num: 1, OtherNum: 2}, &d, nil))
+		assert.Equal(t, Bar{Str: "foo", Num: 1, OtherNum: 2}, d)
+	})
+	t.Run("inner struct type", func(t *testing.T) {
+		d := TheFoo{}
+		require.NoError(t, Convert(TheFoo{
+			Hiya: true, Foo: Foo{Str: "foo", Num: 1, OtherNum: 2},
+		}, &d, nil))
+		assert.Equal(t, TheFoo{
+			Hiya: true, Foo: Foo{Str: "foo", Num: 1, OtherNum: 2},
+		}, d)
+	})
+	t.Run("different struct type with invoker hints", func(t *testing.T) {
+		d := TheBae{}
+		require.NoError(t, Convert(TheFoo{
+			Hiya: true, Foo: Foo{Str: "foo", Num: 1, OtherNum: 2},
+		}, &d, map[string]string{
+			".Hello": "Hiya",
+			".Foo.AnotherNum": "OtherNum",
+			".Foo.AStr": "Str",
+		}))
+		assert.Equal(t, TheBae{
+			Hello: true, Foo: Bae{Num: 1, AnotherNum: 2, AStr: "foo"},
+		}, d)
+	})
+	t.Run("different struct type with invoker hints and nillable pointers", func(t *testing.T) {
+		d := ThePtrBae{}
+		require.NoError(t, Convert(ThePtrFoo{
+			Hiya: true, Foo: &Foo{Str: "foo", Num: 1, OtherNum: 2},
+		}, &d, map[string]string{
+			".Hello": "Hiya",
+			".Bae": "Foo",
+			".Bae.AnotherNum": "OtherNum",
+			".Bae.AStr": "Str",
+		}))
+		assert.Equal(t, ThePtrBae{
+			Hello: true, Bae: &Bae{Num: 1, AnotherNum: 2, AStr: "foo"},
+		}, d)
+	})
+}
+
+func TestError(t *testing.T) {
+	t.Run("different struct type without all the invoker hints", func(t *testing.T) {
+		d := TheBae{}
+		require.Error(t, Convert(TheFoo{
+			Hiya: true, Foo: Foo{Str: "foo", Num: 1, OtherNum: 2},
+		}, &d, map[string]string{
+			".Hello": "Hiya",
+			".Foo.AStr": "Str",
+		}))
+	})
+}
+
+type Foo struct {
+	Str      string
+	Num      int
+	OtherNum int8
+}
+
+type Bar struct {
+	Num      int
+	OtherNum int
+	Str      string
+}
+
+type Bae struct {
+	Num        int
+	AnotherNum int32
+	AStr       string
+}
+
+type TheFoo struct {
+	Hiya bool
+	Foo  Foo
+}
+
+type TheBae struct {
+	Hello bool
+	Foo   Bae
+}
+
+type ThePtrFoo struct {
+	Hiya bool
+	Foo  *Foo
+}
+
+type ThePtrBae struct {
+	Hello bool
+	Bae   *Bae
+}

--- a/pkg/internal/helpers/config/convert_test.go
+++ b/pkg/internal/helpers/config/convert_test.go
@@ -76,11 +76,12 @@ func TestConvert(t *testing.T) {
 	})
 	t.Run("the source misses a destination field, but we define skip", func(t *testing.T) {
 		d := Cake{}
-		require.Panics(t, func() {
+		require.NotPanics(t, func() {
 			Convert(Dough{Flour: "flour", Temperature: 100}, &d, map[string]string{
 				".Sugar": SkipConversion,
 			})
 		})
+		assert.Equal(t, Cake{Flour: "flour", Temperature: 100}, d)
 	})
 }
 

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -63,26 +63,6 @@ func (d *BeylaDiscoveryConfig) SurveyEnabled() bool {
 	return len(d.Survey) > 0
 }
 
-func (d *BeylaDiscoveryConfig) Validate() error {
-	obiCfg := d.AsOBI()
-	return obiCfg.Validate()
-}
-
-func (d *BeylaDiscoveryConfig) AsOBI() services.DiscoveryConfig {
-	return services.DiscoveryConfig{
-		Services:                        d.Services,
-		ExcludeServices:                 d.ExcludeServices,
-		DefaultExcludeServices:          d.DefaultExcludeServices,
-		Instrument:                      d.Instrument,
-		ExcludeInstrument:               d.ExcludeInstrument,
-		DefaultExcludeInstrument:        d.DefaultExcludeInstrument,
-		PollInterval:                    d.PollInterval,
-		SkipGoSpecificTracers:           d.SkipGoSpecificTracers,
-		BPFPidFilterOff:                 d.BPFPidFilterOff,
-		ExcludeOTelInstrumentedServices: d.ExcludeOTelInstrumentedServices,
-	}
-}
-
 func (d *BeylaDiscoveryConfig) AppDiscoveryEnabled() bool {
 	return len(d.Services) > 0 || len(d.Instrument) > 0
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/process_collector_mem_cgo_darwin.c
+++ b/vendor/github.com/prometheus/client_golang/prometheus/process_collector_mem_cgo_darwin.c
@@ -11,63 +11,74 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// go:build darwin && !ios && cgo
+//go:build darwin && !ios && cgo
 
 #include <mach/mach_init.h>
-#include <mach/mach_vm.h>
 #include <mach/task.h>
+#include <mach/mach_vm.h>
 
 // The compiler warns that mach/shared_memory_server.h is deprecated, and to use
 // mach/shared_region.h instead.  But that doesn't define
 // SHARED_DATA_REGION_SIZE or SHARED_TEXT_REGION_SIZE, so redefine them here and
 // avoid a warning message when running tests.
-#define GLOBAL_SHARED_TEXT_SEGMENT 0x90000000U
-#define SHARED_DATA_REGION_SIZE 0x10000000
-#define SHARED_TEXT_REGION_SIZE 0x10000000
+#define GLOBAL_SHARED_TEXT_SEGMENT      0x90000000U
+#define SHARED_DATA_REGION_SIZE         0x10000000
+#define SHARED_TEXT_REGION_SIZE         0x10000000
 
-int get_memory_info(unsigned long long *rss, unsigned long long *vsize) {
-  // This is lightly adapted from how ps(1) obtains its memory info.
-  // https://github.com/apple-oss-distributions/adv_cmds/blob/8744084ea0ff41ca4bb96b0f9c22407d0e48e9b7/ps/tasks.c#L109
 
-  kern_return_t error;
-  task_t task = MACH_PORT_NULL;
-  mach_task_basic_info_data_t info;
-  mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+int get_memory_info(unsigned long long *rss, unsigned long long *vsize)
+{
+    // This is lightly adapted from how ps(1) obtains its memory info.
+    // https://github.com/apple-oss-distributions/adv_cmds/blob/8744084ea0ff41ca4bb96b0f9c22407d0e48e9b7/ps/tasks.c#L109
 
-  error = task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info,
-                    &info_count);
+    kern_return_t               error;
+    task_t                      task = MACH_PORT_NULL;
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t      info_count = MACH_TASK_BASIC_INFO_COUNT;
 
-  if (error != KERN_SUCCESS) {
-    return error;
-  }
+    error = task_info(
+                mach_task_self(),
+                MACH_TASK_BASIC_INFO,
+                (task_info_t) &info,
+                &info_count );
 
-  *rss = info.resident_size;
-  *vsize = info.virtual_size;
-
-  {
-    vm_region_basic_info_data_64_t b_info;
-    mach_vm_address_t address = GLOBAL_SHARED_TEXT_SEGMENT;
-    mach_vm_size_t size;
-    mach_port_t object_name;
-
-    /*
-     * try to determine if this task has the split libraries
-     * mapped in... if so, adjust its virtual size down by
-     * the 2 segments that are used for split libraries
-     */
-    info_count = VM_REGION_BASIC_INFO_COUNT_64;
-
-    error = mach_vm_region(mach_task_self(), &address, &size,
-                           VM_REGION_BASIC_INFO_64, (vm_region_info_t)&b_info,
-                           &info_count, &object_name);
-
-    if (error == KERN_SUCCESS) {
-      if (b_info.reserved && size == (SHARED_TEXT_REGION_SIZE) &&
-          *vsize > (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE)) {
-        *vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
-      }
+    if( error != KERN_SUCCESS )
+    {
+        return error;
     }
-  }
 
-  return 0;
+    *rss   = info.resident_size;
+    *vsize = info.virtual_size;
+
+    {
+        vm_region_basic_info_data_64_t    b_info;
+        mach_vm_address_t                 address = GLOBAL_SHARED_TEXT_SEGMENT;
+        mach_vm_size_t                    size;
+        mach_port_t                       object_name;
+
+        /*
+         * try to determine if this task has the split libraries
+         * mapped in... if so, adjust its virtual size down by
+         * the 2 segments that are used for split libraries
+         */
+        info_count = VM_REGION_BASIC_INFO_COUNT_64;
+
+        error = mach_vm_region(
+                    mach_task_self(),
+                    &address,
+                    &size,
+                    VM_REGION_BASIC_INFO_64,
+                    (vm_region_info_t) &b_info,
+                    &info_count,
+                    &object_name);
+
+        if (error == KERN_SUCCESS) {
+            if (b_info.reserved && size == (SHARED_TEXT_REGION_SIZE) &&
+                *vsize > (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE)) {
+                    *vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
+            }
+        }
+    }
+
+    return 0;
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -381,7 +381,7 @@ github.com/munnerz/goautoneg
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 ## explicit
 github.com/mxk/go-flowrate/flowrate
-# github.com/open-telemetry/opentelemetry-ebpf-instrumentation v0.0.0-20250613173108-d81ed64653ef => ./.obi-src
+# github.com/open-telemetry/opentelemetry-ebpf-instrumentation v0.0.0-20250616070931-013898c47d96 => ./.obi-src
 ## explicit; go 1.24.1
 github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/app/request
 github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/beyla


### PR DESCRIPTION
Despite `obi.Config` is based on `beyla.Config` (removing some Beyla-specific attributes), they are actual different types, as they are defined in different parts of the code and they have different annotations (e.g. for `BEYLA_` vs `OTEL_BPF` environment variables).

This PR adds a tool for automatic conversion between both types (or any other equivalent arbitrary types), so user will define configuration in `beyla.Config` format, and Beyla will provide an equivalent `obi.Config` for the OBI-vendored entities.