### PR TITLE
Add the first integration test

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -22,6 +22,7 @@ permissions:
 
 env:
   CT_CONFIGFILE: "${{ github.workspace }}/.github/configs/ct.yml"
+  INTEGRARION_TESTS_DIR: "charts/beyla/tests/integration"
 
 jobs:
   lint-helm-chart:
@@ -57,3 +58,69 @@ jobs:
 
       - name: Linting with chart-testing
         run: ct lint --config "${CT_CONFIGFILE}"
+
+  list-integration-tests:
+    name: List integration tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list_tests.outputs.tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: 'false'
+
+      - name: List tests
+        id: list_tests
+        working-directory: "${{ env.INTEGRARION_TESTS_DIR }}"
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          tests=$(find . -name test-plan.yaml -exec dirname {} \; | sed -e "s/^\.\///g")
+          echo "Tests: ${tests}"
+          echo "tests=$(echo "${tests}" | jq --raw-input --slurp --compact-output 'split("\n") | map(select(. != ""))')" >> "${GITHUB_OUTPUT}"
+
+  run-integration-tests:
+    name: Integration Test
+    needs: list-integration-tests
+    runs-on: ubuntu-latest
+    if: needs.list-integration-tests.outputs.tests != '[]'
+    strategy:
+      matrix:
+        test: ${{ fromJson(needs.list-integration-tests.outputs.tests) }}
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: source
+          persist-credentials: 'false'
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: helm-chart-toolbox
+          repository: grafana/helm-chart-toolbox
+          persist-credentials: 'false'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+
+      - name: Install Flux CLI
+        uses: fluxcd/flux2/action@6bf37f6a560fd84982d67f853162e4b3c2235edb  # v2.6.4
+
+      - name: Install Kind CLI
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0
+        with:
+          install_only: true
+
+      - name: Install Minikube CLI
+        uses: medyagh/setup-minikube@e3c7f79eb1e997eabccc536a6cf318a2b0fe19d9  # v0.0.20
+        with:
+          start: false
+
+      - name: Run test
+        run: helm-chart-toolbox/tools/helm-test/helm-test "${TEST_DIRECTORY}"
+        env:
+          TEST_DIRECTORY: "source/${{ env.INTEGRARION_TESTS_DIR }}/${{ matrix.test }}"
+          DELETE_CLUSTER: true

--- a/charts/beyla/.helmignore
+++ b/charts/beyla/.helmignore
@@ -22,3 +22,5 @@
 *.tmproj
 .vscode/
 .github
+
+tests

--- a/charts/beyla/tests/integration/default/test-plan.yaml
+++ b/charts/beyla/tests/integration/default/test-plan.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: helm-chart-toolbox.grafana.com/v1
+kind: TestPlan
+name: defaults
+subject:
+  path: ../../..
+
+cluster:
+  type: kind
+
+tests:
+  - type: kubernetes-objects-test
+    values:
+      checks:
+        - kind: Daemonset
+          name: defaults-beyla
+          namespace: default
+        - kind: ConfigMap
+          name: defaults-beyla
+          namespace: default


### PR DESCRIPTION
This adds an integration test to the Beyla Helm chart.
In this test, it simply installs Beyla with its defaults and verifies that the Daemonset and the configmap are deployed.
It also updates the test-helm workflow to invoke any tests inside the `tests/integration` directory.