### PR TITLE
Deprecate top-level service selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,17 @@ other languages).
 
 For getting started, we'll tell Beyla to instrument the service running on port 8080 (our example service) and expose metrics in Prometheus format on port 9400.
 
+Create a `config.yml` file:
+
+```yaml
+discovery:
+  instrument:
+    - open_ports: 8080
+```
+
 ```
 export BEYLA_PROMETHEUS_PORT=9400
-export BEYLA_OPEN_PORT=8080
-sudo -E ./beyla
+sudo -E beyla -config config.yml
 ```
 
 Now, you should see metrics on [http://localhost:9400/metrics](http://localhost:9400/metrics).

--- a/docs/sources/configure/export-modes.md
+++ b/docs/sources/configure/export-modes.md
@@ -133,7 +133,7 @@ This tutorial assumes Beyla and Alloy are running natively on the same host, so 
 
 Install [Grafana Beyla](../../setup/) and download the example [configuration file](https://github.com/grafana/beyla/blob/main/docs/sources/configure/resources/instrumenter-config.yml).
 
-First, specify the executable to instrument. For a service executable running on port `443`, add the `open_port` property to the YAML document:
+First, specify the executable to instrument. For a service executable running on port `443`, add the `open_ports` property to the YAML document:
 
 ```yaml
 discovery:

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -48,30 +48,12 @@ channel_buffer_len: 33
 ```
 
 | YAML<p>environment variable</p>                   | Description                                                                                                                                | Type    | Default    |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------- |
-| _(No YAML)_<p>`BEYLA_AUTO_TARGET_EXE`</p>         | Selects the process to instrument by [Glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) matching against the full executable path. | string  | unset      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------- ||
 | `shutdown_timeout`<p>`BEYLA_SHUTDOWN_TIMEOUT`</p> | Sets the timeout for a graceful shutdown                                                                                                   | string  | "10s"      |
 | `log_level`<p>`BEYLA_LOG_LEVEL`</p>               | Sets process logger verbosity. Valid values: `DEBUG`, `INFO`, `WARN`, `ERROR`.                                                             | string  | `INFO`     |
 | `trace_printer`<p>`BEYLA_TRACE_PRINTER`</p>       | Prints instrumented traces to the standard output in a specified format, refer to [trace printer formats](#trace-printer-formats).         | string  | `disabled` |
 | `enforce_sys_caps`<p>`BEYLA_ENFORCE_SYS_CAPS`</p> | Controls how Beyla handles missing system capabilities at startup.                                                                         | boolean | `false`    |
 
-## Executable name matching
-
-This property accepts a [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) matched against the full executable command line, including the directory where the executable resides on the file system.
-Beyla selects one process, or multiple processes with similar characteristics.
-For more detailed process selection and grouping, refer to the [service discovery documentation](../service-discovery/).
-
-When you instrument by executable name, choose a non-ambiguous name that matches one executable on the target system.
-For example, if you set `BEYLA_AUTO_TARGET_EXE=*/server` and have two processes that match the Glob, Beyla selects both.
-Instead use the full application path for exact matches, for example `BEYLA_AUTO_TARGET_EXE=/opt/app/server` or `BEYLA_AUTO_TARGET_EXE=/server`.
-
-## Service name and namespace
-
-These configuration options are deprecated.
-
-Defining these properties is equivalent to adding a `name` entry to the [`discovery.instrument` YAML section](../service-discovery/).
-When a single instance of Beyla instruments multiple processes, they share the same service name even if they differ.
-To give multiple services different names, see how to [override the service name and namespace](../service-discovery/) in the service discovery documentation.
 
 ## Trace printer formats
 

--- a/docs/sources/configure/options.md
+++ b/docs/sources/configure/options.md
@@ -50,7 +50,6 @@ channel_buffer_len: 33
 | YAML<p>environment variable</p>                   | Description                                                                                                                                | Type    | Default    |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------- |
 | _(No YAML)_<p>`BEYLA_AUTO_TARGET_EXE`</p>         | Selects the process to instrument by [Glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) matching against the full executable path. | string  | unset      |
-| `open_port`<p>`BEYLA_OPEN_PORT`</p>               | Selects a process to instrument by open ports. Accepts comma-separated lists of ports and port ranges.                                     | string  | unset      |
 | `shutdown_timeout`<p>`BEYLA_SHUTDOWN_TIMEOUT`</p> | Sets the timeout for a graceful shutdown                                                                                                   | string  | "10s"      |
 | `log_level`<p>`BEYLA_LOG_LEVEL`</p>               | Sets process logger verbosity. Valid values: `DEBUG`, `INFO`, `WARN`, `ERROR`.                                                             | string  | `INFO`     |
 | `trace_printer`<p>`BEYLA_TRACE_PRINTER`</p>       | Prints instrumented traces to the standard output in a specified format, refer to [trace printer formats](#trace-printer-formats).         | string  | `disabled` |
@@ -65,29 +64,6 @@ For more detailed process selection and grouping, refer to the [service discover
 When you instrument by executable name, choose a non-ambiguous name that matches one executable on the target system.
 For example, if you set `BEYLA_AUTO_TARGET_EXE=*/server` and have two processes that match the Glob, Beyla selects both.
 Instead use the full application path for exact matches, for example `BEYLA_AUTO_TARGET_EXE=/opt/app/server` or `BEYLA_AUTO_TARGET_EXE=/server`.
-
-If you set both `BEYLA_AUTO_TARGET_EXE` and `BEYLA_OPEN_PORT` properties, Beyla selects only executables
-matching both selection criteria.
-
-## Open port matching
-
-This property accepts a comma-separated list of ports or port ranges. If an executable matches any of the ports Beyla selects it. For example:
-
-```
-BEYLA_OPEN_PORT=80,443,8000-8999
-```
-
-In this example, Beyla selects any executable that opens port `80`, `443`, or any port between `8000` and `8999`.
-It can select one process or multiple processes with similar characteristics.
-For more detailed process selection and grouping, follow the instructions in the [service discovery documentation](../service-discovery/).
-
-If an executable opens multiple ports, specifying one of those ports is enough for Beyla to instrument all HTTP/S and GRPC requests on all application ports.
-Currently, there's no way to limit instrumentation to requests on a specific port.
-
-If the specified port range is wide, for example `1-65535`, Beyla tries to execute all processes that own one of the ports in that range.
-
-If you set both `BEYLA_AUTO_TARGET_EXE` and `BEYLA_OPEN_PORT` properties, Beyla selects only executables
-matching both selection criteria.
 
 ## Service name and namespace
 

--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -10,7 +10,7 @@ keywords:
 
 # Configure Beyla service discovery
 
-The `BEYLA_AUTO_TARGET_EXE` environment variable and the `discovery.instrument` configuration section make it easier to configure Beyla to instrument services.
+The `discovery.instrument` configuration section allows you to configure Beyla to instrument services using various selection criteria.
 
 In some scenarios, Beyla instruments many services. For example, as a [Kubernetes DaemonSet](../../setup/kubernetes/) that instruments all the services in a node. The `discovery` YAML section lets you specify more granular selection criteria for the services Beyla can instrument.
 

--- a/docs/sources/configure/service-discovery.md
+++ b/docs/sources/configure/service-discovery.md
@@ -10,7 +10,7 @@ keywords:
 
 # Configure Beyla service discovery
 
-The `BEYLA_AUTO_TARGET_EXE` and `BEYLA_OPEN_PORT` are environment variables that make it easier to configure Beyla to instrument a single service or a group of related services.
+The `BEYLA_AUTO_TARGET_EXE` environment variable and the `discovery.instrument` configuration section make it easier to configure Beyla to instrument services.
 
 In some scenarios, Beyla instruments many services. For example, as a [Kubernetes DaemonSet](../../setup/kubernetes/) that instruments all the services in a node. The `discovery` YAML section lets you specify more granular selection criteria for the services Beyla can instrument.
 

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -46,22 +46,28 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -51,25 +51,29 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
   variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using
-  (for example, `80` or `443`). If using the example service in the
-  first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/quickstart/java.md
+++ b/docs/sources/quickstart/java.md
@@ -42,22 +42,28 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/quickstart/kubernetes.md
+++ b/docs/sources/quickstart/kubernetes.md
@@ -31,9 +31,9 @@ to be instrumented.
 
 When Beyla is deployed as a regular operating system process that instrument other processes,
 the unique service selectors are the network port where the instrumented process should
-be listening to (can be specified with the `BEYLA_OPEN_PORT` environment variable) or
+be listening to (specified in the configuration file under `discovery.instrument.open_ports`) or
 a [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) to match against the executable filename of the process to
-instrument (`BEYLA_AUTO_TARGET_EXE` environment variable).
+instrument (specified with `discovery.instrument.exe` or the `BEYLA_AUTO_TARGET_EXE` environment variable).
 
 To select multiple groups of processes, the Beyla YAML configuration file format
 provides a `discovery.instrument` section that accepts multiple selector groups:

--- a/docs/sources/quickstart/kubernetes.md
+++ b/docs/sources/quickstart/kubernetes.md
@@ -33,7 +33,7 @@ When Beyla is deployed as a regular operating system process that instrument oth
 the unique service selectors are the network port where the instrumented process should
 be listening to (specified in the configuration file under `discovery.instrument.open_ports`) or
 a [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) to match against the executable filename of the process to
-instrument (specified with `discovery.instrument.exe` or the `BEYLA_AUTO_TARGET_EXE` environment variable).
+instrument (specified with `discovery.instrument.exe_path`).
 
 To select multiple groups of processes, the Beyla YAML configuration file format
 provides a `discovery.instrument` section that accepts multiple selector groups:

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -45,13 +45,18 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
   variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using
-  (for example, `80` or `443`). If using the example service in the
-  first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
@@ -62,12 +67,11 @@ documentation section.
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -43,13 +43,6 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
-To run Beyla, first set the following environment variables:
-
-- The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
-  variables copied from the previous step.
-
-For service discovery, you have two options:
-
 For service discovery, create a `config.yml` file:
 
 ```yml
@@ -58,6 +51,11 @@ discovery:
     - open_ports: 8080  # the port your service is using
 ```
 
+To run Beyla, first set the following environment variables:
+
+- The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
+  variables copied from the previous step.
+
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Beyla automatically reports the name of the process executable as service name: `python3`.
@@ -65,8 +63,6 @@ To override it, refer to the [override service name and namespace](../configure/
 documentation section.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
-
-**Using configuration file:**
 
 ```sh
 export BEYLA_TRACE_PRINTER=text

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -47,9 +47,16 @@ To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
   variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using
-  (for example, `80` or `443`). If using the example service in the
-  first section of this guide, set this variable to `8080`.
+
+For service discovery, you have two options:
+
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
@@ -59,13 +66,14 @@ documentation section.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
+**Using configuration file:**
+
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service
@@ -111,14 +119,17 @@ Configure routing to tell Beyla about expected routes.
 
 For this quickstart, let Beyla to heuristically group the routes.
 
-First, create a `config.yml` file with the following content:
+Update your `config.yml` file with the following content:
 
 ```yml
+discovery:
+  instrument:
+    - open_ports: 8080
 routes:
   unmatched: heuristic
 ```
 
-Then, run Beyla with the `-config` argument (or use the `BEYLA_CONFIG_PATH` environment variable instead):
+Then, run Beyla with the configuration file:
 
 ```
 sudo -E beyla -config config.yml

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -43,13 +43,18 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
   variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using
-  (for example, `80` or `443`). If using the example service in the
-  first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
@@ -60,12 +65,11 @@ documentation section.
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -42,22 +42,28 @@ Copy the **Environment Variables** and keep it for the next step.
 
 ## 4. Run Beyla with minimal configuration
 
+For service discovery, create a `config.yml` file:
+
+```yml
+discovery:
+  instrument:
+    - open_ports: 8080  # the port your service is using
+```
+
 To run Beyla, first set the following environment variables:
 
 - The `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables copied from the previous step.
-- `BEYLA_OPEN_PORT`: the port the instrumented service is using (for example, `80` or `443`). If using the example service in the first section of this guide, set this variable to `8080`.
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
 Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
 
 ```sh
-export BEYLA_OPEN_PORT=8080
 export BEYLA_TRACE_PRINTER=text
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ...your-encoded-credentials..."
-sudo -E beyla
+sudo -E beyla -config config.yml
 ```
 
 ## 5. Test the service

--- a/docs/sources/security.md
+++ b/docs/sources/security.md
@@ -184,7 +184,11 @@ Set the required capabilities and start Beyla:
 
 ```shell
 sudo setcap cap_bpf,cap_dac_read_search,cap_perfmon,cap_net_raw,cap_sys_ptrace+ep ./bin/beyla
-BEYLA_OPEN_PORT=8080 BEYLA_TRACE_PRINTER=text bin/beyla
+echo "discovery:
+  instrument:
+    - open_ports: 8080
+trace_printer: text" > config.yml
+bin/beyla -config config.yml
 ```
 
 ### Application observability with trace context propagation
@@ -203,7 +207,12 @@ Set the required capabilities and start Beyla:
 
 ```shell
 sudo setcap cap_bpf,cap_dac_read_search,cap_perfmon,cap_net_raw,cap_sys_ptrace,cap_net_admin+ep ./bin/beyla
-BEYLA_ENABLE_CONTEXT_PROPAGATION=all BEYLA_OPEN_PORT=8080 BEYLA_TRACE_PRINTER=text bin/beyla
+echo "discovery:
+  instrument:
+    - open_ports: 8080
+trace_printer: text
+enable_context_propagation: all" > config.yml
+bin/beyla -config config.yml
 ```
 
 ## Internal eBPF tracer capability requirement reference

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -64,17 +64,13 @@ Beyla requires administrative (sudo) privileges, or at least it needs to be gran
 
 ## Examples
 
-Let's instrument the process that owns the port 443, and expose the metrics as a Prometheus endpoint listening on the port 8999. In this example, the configuration is passed exclusively through environment variables:
-
-```sh
-BEYLA_PROMETHEUS_PORT=8999 BEYLA_OPEN_PORT=443 sudo -E beyla
-```
-
-The equivalent execution, but configured via a YAML file would look like:
+Let's instrument the process that owns the port 443, and expose the metrics as a Prometheus endpoint listening on the port 8999:
 
 ```yaml
 cat > config.yml <<EOF
-open_port: 443
+discovery:
+  instrument:
+    - open_ports: 443
 prometheus_export:
   port: 8999
 EOF

--- a/ops/troubleshooting.md
+++ b/ops/troubleshooting.md
@@ -23,8 +23,7 @@ check that Beyla is finding any process to instrument. The logs should show a me
 level=INFO msg="instrumenting process" component=discover.TraceAttacher cmd=/frontend pid=1
 ```
 
-If you don't see any message like the preceding, make sure that the process is properly selected, either with the
-`BEYLA_EXECUTABLE_NAME`, `BEYLA_OPEN_PORT` or with the [discovery YAML section](https://github.com/grafana/beyla/blob/main/docs/sources/configure/options.md#global-configuration-properties).
+If you don't see any message like the preceding, make sure that the process is properly selected with the [discovery YAML section](https://github.com/grafana/beyla/blob/main/docs/sources/configure/options.md#global-configuration-properties).
 
 If you still don't see any message like the preceding, check [Deploy Beyla in Kubernetes](https://github.com/grafana/beyla/blob/main/docs/sources/setup/kubernetes.md) to see if the process is properly selected.
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -208,6 +208,7 @@ type Config struct {
 	// different to zero), the value of the Exec property won't take effect.
 	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter
 	// will instrument all the service calls in all the ports, not only the port specified here.
+	// Deprecated: use discovery.services instead
 	Port services.PortEnum `yaml:"open_port" env:"BEYLA_OPEN_PORT"`
 
 	// ServiceName is taken from either BEYLA_SERVICE_NAME env var or OTEL_SERVICE_NAME (for OTEL spec compatibility)

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -195,13 +195,13 @@ type Config struct {
 	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"BEYLA_TRACE_PRINTER"`
 
 	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
-	// Deprecated: Use BEYLA_AUTO_TARGET_EXE
-	//nolint:undoc
+	// Deprecated: use discovery.services instead
 	Exec services.RegexpAttr `yaml:"executable_name" env:"BEYLA_EXECUTABLE_NAME"`
 
 	// AutoTargetExe selects the executable to instrument matching a Glob against the executable path.
 	// To set this value via YAML, use discovery > instrument.
 	// It also accepts BEYLA_AUTO_TARGET_EXE for compatibility with opentelemetry-go-instrumentation
+	// Deprecated: use discovery.services instead
 	AutoTargetExe services.GlobAttr `env:"BEYLA_AUTO_TARGET_EXE,expand" envDefault:"${OTEL_GO_AUTO_TARGET_EXE}"`
 
 	// Port allows selecting the instrumented executable that owns the Port value. If this value is set (and
@@ -215,11 +215,9 @@ type Config struct {
 	// Using env and envDefault is a trick to get the value either from one of either variables.
 	// Deprecated: Service name should be set in the instrumentation target (env vars, kube metadata...)
 	// as this is a reminiscence of past times when we only supported one executable per instance.
-	//nolint:undoc
 	ServiceName string `yaml:"service_name" env:"OTEL_SERVICE_NAME,expand" envDefault:"${BEYLA_SERVICE_NAME}"`
 	// Deprecated: Service namespace should be set in the instrumentation target (env vars, kube metadata...)
 	// as this is a reminiscence of past times when we only supported one executable per instance.
-	//nolint:undoc
 	ServiceNamespace string `yaml:"service_namespace" env:"BEYLA_SERVICE_NAMESPACE"`
 
 	// Discovery configuration

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -20,13 +20,11 @@ type BeylaDiscoveryConfig struct {
 	// ExcludeServices works analogously to Services, but the applications matching this section won't be instrumented
 	// even if they match the Services selection.
 	// Deprecated: Use ExcludeInstrument instead
-	//nolint:undoc
 	ExcludeServices services.RegexDefinitionCriteria `yaml:"exclude_services"`
 
 	// DefaultExcludeServices by default prevents self-instrumentation of Beyla as well as related services (Alloy and OpenTelemetry collector)
 	// It must be set to an empty string or a different value if self-instrumentation is desired.
 	// Deprecated: Use DefaultExcludeInstrument instead
-	//nolint:undoc
 	DefaultExcludeServices services.RegexDefinitionCriteria `yaml:"default_exclude_services"`
 
 	// Instrument selects the services to instrument via Globs. If this section is set,


### PR DESCRIPTION
This PR removes top-level service selection from the docs and marks the fields as deprecated.
Beyla still would be able to be configured that we want to keep deprecated/undocumented.

Fixes #1684 
Fixes #1206