### PR TITLE
Handle event channel closure gracefully

### DIFF
--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -130,7 +130,12 @@ func (i *Instrumenter) instrumentedEventLoop(ctx context.Context, processEvents 
 		select {
 		case <-ctx.Done():
 			return
-		case ev := <-processEvents:
+		case ev, ok := <-processEvents:
+			if !ok {
+				log.Debug("processEvents channel closed, stopping")
+				return
+			}
+
 			switch ev.Type {
 			case obiDiscover.EventCreated:
 				pt := ev.Obj


### PR DESCRIPTION
Check if the event channel has been closed before handling the events - this is particularly relevant for events whose payload are a pointer type: a closing channel would return the zero value, which gets treated as a null pointer - and has the potential to crash the program if de-referenced.

Close #2114 