### PR TITLE
Add export mode traces receiver

### DIFF
--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -88,6 +88,10 @@ func (tr *tracesReceiver) provideLoop(ctx context.Context) {
 			for _, spanGroup := range spanGroups {
 				if len(spanGroup) > 0 {
 					sample := spanGroup[0]
+					if !sample.Span.Service.ExportModes.CanExportTraces() {
+						continue
+					}
+
 					envResourceAttrs := otel.ResourceAttrsFromEnv(&sample.Span.Service)
 					for _, tc := range tr.cfg.Traces {
 						traces := otel.GenerateTraces(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.hostID, spanGroup)

--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -36,10 +36,8 @@ func TracesReceiver(
 
 		tr := &tracesReceiver{
 			cfg: cfg, hostID: ctxInfo.HostID, spanMetricsEnabled: spanMetricsEnabled,
-			input: input.Subscribe(),
-			is: instrumentations.NewInstrumentationSelection([]string{
-				instrumentations.InstrumentationALL,
-			}),
+			input:          input.Subscribe(),
+			is:             instrumentations.NewInstrumentationSelection(cfg.Instrumentations),
 			attributeCache: expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute),
 		}
 		// Get user attributes

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -240,7 +240,7 @@ type mockTraceConsumer struct {
 	mu             sync.Mutex
 }
 
-func (m *mockTraceConsumer) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {
+func (m *mockTraceConsumer) ConsumeTraces(_ context.Context, traces ptrace.Traces) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.consumedTraces = append(m.consumedTraces, traces)
@@ -259,7 +259,7 @@ func (m *mockTraceConsumer) getConsumedTraces() []ptrace.Traces {
 	return result
 }
 
-func testProvideLoopWithSpans(receiver *tracesReceiver, mockConsumer *mockTraceConsumer, traces []request.Span) {
+func testProvideLoopWithSpans(receiver *tracesReceiver, _ *mockTraceConsumer, traces []request.Span) {
 	// Create a channel to send traces to provideLoop
 	tracesCh := make(chan []request.Span, 1)
 	tracesCh <- traces

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -14,11 +14,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/svc"
-	"go.opentelemetry.io/obi/pkg/services"
 	attributes "go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/services"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -222,7 +222,7 @@ func TestTracesExportModeFiltering(t *testing.T) {
 
 			receiver := makeTracesTestReceiver()
 			traces := generateTracesForSpans(t, receiver, []request.Span{span})
-			
+
 			assert.Equal(t, tt.expectedTraces, len(traces), tt.description)
 		})
 	}


### PR DESCRIPTION
This is needed to make this feature configurable in Alloy.