### PR TITLE
Fix Beyla selection criteria (+ Debug docker image)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,10 +210,7 @@ copy-obi-vendor:
 	go mod vendor
 
 .PHONY: vendor-obi
-vendor-obi: obi-submodule docker-generate
-	@echo "### Vendoring OBI submodule..."
-	go get go.opentelemetry.io/obi
-	go mod vendor
+vendor-obi: obi-submodule docker-generate copy-obi-vendor
 
 .PHONY: verify
 verify: prereqs lint-dashboard vendor-obi lint test

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -22,17 +22,17 @@ COPY third_party_licenses.csv third_party_licenses.csv
 
 # OBI's Makefile doesn't let to override BPF2GO env var: temporary hack until we can
 ENV TOOLS_DIR=/go/bin
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Prior to using this debug.Dockerfile, you should manually run `make generate copy-obi-vendor`
 RUN make debug
 
-FROM golang:1.25-alpine
+FROM alpine:latest
 
 WORKDIR /
 
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-
+COPY --from=builder /go/bin/dlv /
 COPY --from=builder /src/bin/beyla /
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
-ENTRYPOINT [ "dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/beyla" ]
+ENTRYPOINT [ "/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/beyla" ]

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.25-alpine
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+RUN apk add make git bash
+
+# Copy the go manifests and source
+COPY .git/ .git/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY vendor/ vendor/
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY Makefile Makefile
+COPY LICENSE LICENSE
+COPY NOTICE NOTICE
+COPY third_party_licenses.csv third_party_licenses.csv
+
+# OBI's Makefile doesn't let to override BPF2GO env var: temporary hack until we can
+ENV TOOLS_DIR=/go/bin
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Build
+# Prior to using this debug.Dockerfile, you should manually run `make generate copy-obi-vendor`
+RUN make debug
+
+ENTRYPOINT [ "dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "bin/beyla" ]

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -20,7 +20,7 @@ const (
 var K8sDefaultNamespacesRegex = services.NewRegexp("^kube-system$|^kube-node-lease$|^local-path-storage$|^grafana-alloy$|^cert-manager$|^monitoring$" + k8sGKEDefaultNamespacesRegex + k8sAKSDefaultNamespacesRegex)
 var K8sDefaultNamespacesGlob = services.NewGlob("{kube-system,kube-node-lease,local-path-storage,grafana-alloy,cert-manager,monitoring" + k8sGKEDefaultNamespacesGlob + k8sAKSDefaultNamespacesGlob + "}")
 
-var K8sDefaultNamespacesWithSurveyRegex = services.NewRegexp("^kube-system$|^kube-node-lease$|^local-path-storage$|^cert-manager$|" + k8sGKEDefaultNamespacesRegex + k8sAKSDefaultNamespacesRegex)
+var K8sDefaultNamespacesWithSurveyRegex = services.NewRegexp("^kube-system$|^kube-node-lease$|^local-path-storage$|^cert-manager$" + k8sGKEDefaultNamespacesRegex + k8sAKSDefaultNamespacesRegex)
 var K8sDefaultNamespacesWithSurveyGlob = services.NewGlob("{kube-system,kube-node-lease,local-path-storage,cert-manager" + k8sGKEDefaultNamespacesGlob + k8sAKSDefaultNamespacesGlob + "}")
 
 var DefaultExcludeServices = services.RegexDefinitionCriteria{


### PR DESCRIPTION
In the namespace exclusion criteria, there was a `||` that implicitly meant "any namespace is excluded".

This PR also publishes the delve docker image used to debug this issue in a kubernetes cluster.