### PR TITLE
Fix Typos in Comment

### DIFF
--- a/vendor/go.opentelemetry.io/otel/semconv/v1.34.0/attribute_group.go
+++ b/vendor/go.opentelemetry.io/otel/semconv/v1.34.0/attribute_group.go
@@ -827,7 +827,7 @@ const (
 	// of the [AWS Lambda EvenSource Mapping]. An event source is mapped to a lambda
 	// function. It's contents are read by Lambda and used to trigger a function.
 	// This isn't available in the lambda execution context or the lambda runtime
-	// environtment. This is going to be populated by the AWS SDK for each language
+	// environment. This is going to be populated by the AWS SDK for each language
 	// when that UUID is present. Some of these operations are
 	// Create/Delete/Get/List/Update EventSourceMapping.
 	//

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
@@ -417,7 +417,7 @@ type SubResourceGetOptions struct {
 	Raw *metav1.GetOptions
 }
 
-// ApplyToSubResourceGet updates the configuaration to the given get options.
+// ApplyToSubResourceGet updates the configuration to the given get options.
 func (getOpt *SubResourceGetOptions) ApplyToSubResourceGet(o *SubResourceGetOptions) {
 	if getOpt.Raw != nil {
 		o.Raw = getOpt.Raw

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
@@ -55,7 +55,7 @@ type Object interface {
 // is a kubernetes list wrapper (has items, pagination fields, etc) -- think
 // the wrapper used in a response from a `kubectl list --output yaml` call.
 //
-// Code-wise, this means that any object which embedds both ListMeta (which
+// Code-wise, this means that any object which embeds both ListMeta (which
 // provides metav1.ListInterface) and TypeMeta (which provides half of
 // runtime.Object) and has a `DeepCopyObject` implementation (the other half of
 // runtime.Object) will implement this by default.


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `environtment` → `environment`
  - `configuaration` → `configuration`
  - `embedds` → `embeds`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.