### PR TITLE
fix: ensure latest gen image is updated locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ generate: obi-submodule
 docker-generate: export GOFLAGS := "-mod=mod"
 docker-generate: obi-submodule
 	@echo "### Generating files (submodule:  $(OBI_MODULE))"
+	@$(OCI_BIN) pull $(GEN_IMG)
 	@OTEL_EBPF_GENFILES_GEN_IMG=$(GEN_IMG) go generate $(OBI_MODULE)/cmd/obi-genfiles/obi_genfiles.go
 	@cd $(OBI_MODULE) && make docker-generate
 


### PR DESCRIPTION
As the `latest` tag is used for the generator image in the Makefile, an outdated image may be cached locally. In my case, an old image running go 1.24 locally meant that I was not able to `make vendor-obi`.

This PR adds a `pull` before using the image, to ensure it's running the latest `latest` 😄 