### PR TITLE
Fix golangci-lint formatter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,9 @@
 version: "2"
-issues:
-  formatters:
-    enable:
-      - gci
-      - gofumpt
+
+formatters:
+  enable:
+    - gofmt
+    - gci
   settings:
     gofmt:
       # simplify code: gofmt with `-s` option, true by default
@@ -23,28 +23,28 @@ run:
 linters:
   exclusions:
     paths:
-    - ^configs
-    - ^docs
-    - ^.obi-src
-    - ^vendor
+      - ^configs
+      - ^docs
+      - ^.obi-src
+      - ^vendor
     presets:
       - std-error-handling
     # Log a warning if an exclusion rule is unused.
     warn-unused: true
     rules:
-    # revive returns false indent-error-flow errors in some cases where
-    # an "else" clause is required to access the if condition context
-    - path: .*
-      linters:
-        - revive
-      text: indent-error-flow
+      # revive returns false indent-error-flow errors in some cases where
+      # an "else" clause is required to access the if condition context
+      - path: .*
+        linters:
+          - revive
+        text: indent-error-flow
 
-    # exclude deprecated API usage errors. If we deprecate some properties is because we don't want to remove them
-    # (hide/undocument them, but keep supporting them until the next major version)
-    - path: .*
-      linters:
-        - staticcheck
-      text: "SA1019:"
+      # exclude deprecated API usage errors. If we deprecate some properties is because we don't want to remove them
+      # (hide/undocument them, but keep supporting them until the next major version)
+      - path: .*
+        linters:
+          - staticcheck
+        text: "SA1019:"
 
   enable:
     - errcheck

--- a/cmd/beyla/main.go
+++ b/cmd/beyla/main.go
@@ -14,11 +14,12 @@ import (
 	"syscall"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/obi"
 	otelsdk "go.opentelemetry.io/otel/sdk"
 	"gopkg.in/yaml.v3"
 
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
+
+	"go.opentelemetry.io/obi/pkg/obi"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/buildinfo"

--- a/cmd/k8s-cache/main.go
+++ b/cmd/k8s-cache/main.go
@@ -13,13 +13,13 @@ import (
 	"syscall"
 	"time"
 
+	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
+
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/kubecache"
 	"go.opentelemetry.io/obi/pkg/kubecache/instrument"
 	"go.opentelemetry.io/obi/pkg/kubecache/meta"
 	"go.opentelemetry.io/obi/pkg/kubecache/service"
-
-	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
 
 	"github.com/grafana/beyla/v2/cmd/k8s-cache/cfg"
 	"github.com/grafana/beyla/v2/pkg/buildinfo"

--- a/examples/k8s-meta-cache/k8s-cache-example-client/main.go
+++ b/examples/k8s-meta-cache/k8s-cache-example-client/main.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"os"
 
-	"go.opentelemetry.io/obi/pkg/kubecache/informer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"go.opentelemetry.io/obi/pkg/kubecache/informer"
 )
 
 const (

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v9"
-	"github.com/grafana/beyla/v2/pkg/export/otel/spanscfg"
 	otelconsumer "go.opentelemetry.io/collector/consumer"
+	"gopkg.in/yaml.v3"
+
 	"go.opentelemetry.io/obi/pkg/components/ebpf/tcmanager"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	"go.opentelemetry.io/obi/pkg/components/kube"
@@ -25,10 +26,10 @@ import (
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/services"
 	"go.opentelemetry.io/obi/pkg/transform"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/beyla/v2/pkg/config"
 	botel "github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/export/otel/spanscfg"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	servicesextra "github.com/grafana/beyla/v2/pkg/services"
 )

--- a/pkg/beyla/config_obi_test.go
+++ b/pkg/beyla/config_obi_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestGrafanaEndpointOverride(t *testing.T) {

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/components/ebpf/tcmanager"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	"go.opentelemetry.io/obi/pkg/components/kube"

--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -7,6 +7,10 @@ import (
 	"sync"
 	"text/template"
 
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+	"golang.org/x/sync/errgroup"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
@@ -18,9 +22,6 @@ import (
 	obiotel "go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
-	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/otel"

--- a/pkg/components/beyla_test.go
+++ b/pkg/components/beyla_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/obi/pkg/transform"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"

--- a/pkg/export/alloy/traces.go
+++ b/pkg/export/alloy/traces.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
+	"go.opentelemetry.io/otel/attribute"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
@@ -17,7 +19,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/otel"

--- a/pkg/export/alloy/traces_connect.go
+++ b/pkg/export/alloy/traces_connect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/grafana/beyla/v2/pkg/beyla"
-	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -13,7 +13,9 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
-	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/beyla/v2/pkg/beyla"
+	"github.com/grafana/beyla/v2/pkg/export/otel"
 )
 
 func etrlog() *slog.Logger {

--- a/pkg/export/alloy/traces_test.go
+++ b/pkg/export/alloy/traces_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"gopkg.in/yaml.v3"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
@@ -26,10 +31,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/services"
-	"go.opentelemetry.io/otel/attribute"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/grafana/beyla/v2/pkg/export/otel"

--- a/pkg/export/extraattributes/names/attrs.go
+++ b/pkg/export/extraattributes/names/attrs.go
@@ -3,9 +3,10 @@
 package names
 
 import (
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	semconv2 "go.opentelemetry.io/otel/semconv/v1.25.0"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 // Process Metrics following OTEL 1.26 experimental conventions

--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -3,8 +3,9 @@ package otel
 import (
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/app/request"
 	trace2 "go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/obi/pkg/app/request"
 )
 
 var timeNow = time.Now

--- a/pkg/export/otel/connect_spans.go
+++ b/pkg/export/otel/connect_spans.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
@@ -32,11 +38,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	"go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/zap"
 )
 
 // TODO: integrate with Beyla internal metrics

--- a/pkg/export/otel/connect_spans_test.go
+++ b/pkg/export/otel/connect_spans_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
@@ -14,7 +15,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/services"
-	"go.opentelemetry.io/obi/test/collector"
+
+	"github.com/grafana/beyla/v2/pkg/test/collector"
 )
 
 func TestConnection_Spans(t *testing.T) {

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -7,6 +7,11 @@ import (
 	"slices"
 	"strconv"
 
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
+
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -17,10 +22,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"github.com/grafana/beyla/v2/pkg/export/extraattributes"
 	extranames "github.com/grafana/beyla/v2/pkg/export/extraattributes/names"

--- a/pkg/export/otel/metrics_proc_test.go
+++ b/pkg/export/otel/metrics_proc_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/beyla/v2/pkg/test/collector"
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/beyla/v2/pkg/export/extraattributes"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
+	"github.com/grafana/beyla/v2/pkg/test/collector"
 )
 
 const timeout = 3 * time.Second

--- a/pkg/export/otel/metrics_survey.go
+++ b/pkg/export/otel/metrics_survey.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
@@ -14,9 +18,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func smlog() *slog.Logger {

--- a/pkg/export/prom/prom_proc.go
+++ b/pkg/export/prom/prom_proc.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"

--- a/pkg/export/prom/prom_proc_test.go
+++ b/pkg/export/prom/prom_proc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"

--- a/pkg/export/prom/prom_survey.go
+++ b/pkg/export/prom/prom_survey.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"

--- a/pkg/internal/appolly/appolly_test.go
+++ b/pkg/internal/appolly/appolly_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/beyla/v2/pkg/beyla"
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/discover"
@@ -14,6 +14,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
+
+	"github.com/grafana/beyla/v2/pkg/beyla"
 )
 
 func TestProcessEventsLoopDoesntBlock(t *testing.T) {

--- a/pkg/internal/appolly/traces/external_test.go
+++ b/pkg/internal/appolly/traces/external_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/testutil"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"

--- a/pkg/internal/infraolly/process/collect.go
+++ b/pkg/internal/infraolly/process/collect.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"

--- a/pkg/internal/infraolly/process/harvest.go
+++ b/pkg/internal/infraolly/process/harvest.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/shirou/gopsutil/v3/process"
+
 	"go.opentelemetry.io/obi/pkg/components/svc"
 )
 

--- a/pkg/internal/infraolly/process/harvest_test.go
+++ b/pkg/internal/infraolly/process/harvest_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/components/svc"
 )
 

--- a/pkg/internal/infraolly/process/snapshot.go
+++ b/pkg/internal/infraolly/process/snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/process"
+
 	"go.opentelemetry.io/obi/pkg/components/helpers"
 )
 

--- a/pkg/internal/infraolly/process/snapshot_test.go
+++ b/pkg/internal/infraolly/process/snapshot_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/components/helpers"
 )
 

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	attributes "go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-	"go.opentelemetry.io/otel/attribute"
 
 	extranames "github.com/grafana/beyla/v2/pkg/export/extraattributes/names"
 )

--- a/pkg/internal/pipe/instrumenter.go
+++ b/pkg/internal/pipe/instrumenter.go
@@ -6,11 +6,6 @@ import (
 	"log/slog"
 	"slices"
 
-	"github.com/grafana/beyla/v2/pkg/beyla"
-	"github.com/grafana/beyla/v2/pkg/export/alloy"
-	"github.com/grafana/beyla/v2/pkg/export/otel"
-	"github.com/grafana/beyla/v2/pkg/export/otel/spanscfg"
-	"github.com/grafana/beyla/v2/pkg/internal/appolly/traces"
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe"
@@ -18,6 +13,12 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+
+	"github.com/grafana/beyla/v2/pkg/beyla"
+	"github.com/grafana/beyla/v2/pkg/export/alloy"
+	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/export/otel/spanscfg"
+	"github.com/grafana/beyla/v2/pkg/internal/appolly/traces"
 )
 
 func ilog() *slog.Logger {

--- a/test/integration/k8s/connection_spans/connection_spans_test.go
+++ b/test/integration/k8s/connection_spans/connection_spans_test.go
@@ -12,17 +12,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
 	"github.com/grafana/beyla/v2/test/integration/components/docker"
 	"github.com/grafana/beyla/v2/test/integration/components/jaeger"
 	"github.com/grafana/beyla/v2/test/integration/components/kube"
 	k8s "github.com/grafana/beyla/v2/test/integration/k8s/common"
 	"github.com/grafana/beyla/v2/test/integration/k8s/common/testpath"
 	"github.com/grafana/beyla/v2/test/tools"
-	"github.com/mariomac/guara/pkg/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/e2e-framework/pkg/envconf"
-	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 const (

--- a/test/integration/red_test_kafka.go
+++ b/test/integration/red_test_kafka.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/beyla/v2/test/integration/components/jaeger"

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/pkg/obi"
 
 	"github.com/grafana/beyla/v2/test/integration/components/docker"

--- a/test/oats/mongo/oats_test.go
+++ b/test/oats/mongo/oats_test.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/oats/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/grafana/oats/yaml"
 )
 
 func TestYaml(t *testing.T) {

--- a/test/oats/redis/oats_test.go
+++ b/test/oats/redis/oats_test.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/oats/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/grafana/oats/yaml"
 )
 
 func TestYaml(t *testing.T) {


### PR DESCRIPTION
The golangci-lint YAML was not correct and the imports were not properly sorted.