### PR TITLE
Improve accuracy of inter-cluster spans reporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.133.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.133.0
 	go.opentelemetry.io/collector/pdata v1.39.0
-	go.opentelemetry.io/obi v0.0.0-20250925065457-652a072327c6
+	go.opentelemetry.io/obi v0.0.0-20250926075427-b6d5c4e9f2da
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0

--- a/pkg/internal/appolly/traces/external.go
+++ b/pkg/internal/appolly/traces/external.go
@@ -3,7 +3,6 @@ package traces
 import (
 	"context"
 	"log/slog"
-	"net/netip"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -11,41 +10,42 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
 )
 
+type isInternalIPFn func(ip string) bool
+
 // SelectExternal node filters spans whose source or destination could not be
 // resolved, indicating that they might belong to connections from/to external
 // services.
-func SelectExternal(input, out *msg.Queue[[]request.Span]) swarm.InstanceFunc {
+func SelectExternal(isClusterIP isInternalIPFn, input, out *msg.Queue[[]request.Span]) swarm.InstanceFunc {
 	in := input.Subscribe()
+	esp := externalSpanFilter{isClusterIP: isClusterIP}
 	return swarm.DirectInstance(func(ctx context.Context) {
 		log := slog.With("component", "traces.SelectExternal")
 		defer out.Close()
 		swarms.ForEachInput(ctx, in, log.Debug, func(spans []request.Span) {
-			if extern := filter(spans); len(extern) > 0 {
+			if extern := esp.filter(spans); len(extern) > 0 {
 				out.Send(extern)
 			}
 		})
 	})
 }
 
-func filter(spans []request.Span) []request.Span {
+type externalSpanFilter struct {
+	isClusterIP isInternalIPFn
+}
+
+func (esp *externalSpanFilter) filter(spans []request.Span) []request.Span {
 	var extern []request.Span
 	for i := range spans {
-		if isExternalSelectable(&spans[i]) {
+		if esp.isExternalSelectable(&spans[i]) {
 			extern = append(extern, spans[i])
 		}
 	}
 	return extern
 }
 
-// this code might not work if the eBPF-based reverse DNS is enabled and it hits a known host name.
-func isExternalSelectable(span *request.Span) bool {
+func (esp *externalSpanFilter) isExternalSelectable(span *request.Span) bool {
 	isClient := span.IsClientSpan()
 	return span.TraceID.IsValid() &&
-		((!isClient && validIP(span.PeerName)) ||
-			(isClient && validIP(span.HostName)))
-}
-
-func validIP(ip string) bool {
-	addr, err := netip.ParseAddr(ip)
-	return err == nil && addr.IsValid()
+		((!isClient && !esp.isClusterIP(span.Peer)) ||
+			(isClient && !esp.isClusterIP(span.Host)))
 }

--- a/pkg/internal/appolly/traces/external_test.go
+++ b/pkg/internal/appolly/traces/external_test.go
@@ -16,38 +16,41 @@ func TestSelectExternal(t *testing.T) {
 	in := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	outQ := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	out := outQ.Subscribe()
-	se, err := SelectExternal(in, outQ)(t.Context())
+	var isClusterIP = func(ip string) bool {
+		return ip == "10.0.0.1"
+	}
+	se, err := SelectExternal(isClusterIP, in, outQ)(t.Context())
 	require.NoError(t, err)
 	go se(t.Context())
 	in.Send([]request.Span{{
 		Type: request.EventTypeHTTP, Method: "GET", Route: "/foo",
-		PeerName: "1.2.3.4", HostName: "foo.com",
+		Peer: "1.2.3.4", Host: "10.0.0.1",
 		TraceID: [16]byte{1},
 	}, {
 		Type: request.EventTypeHTTPClient, Method: "POST", Route: "/bar",
-		PeerName: "foo.com", HostName: "1.2.3.4",
+		Peer: "10.0.0.1", Host: "1.2.3.4",
 		TraceID: [16]byte{2},
-	}, { // TO BE EXCLUDED (client is known in an HTTP service)
+	}, { // TO BE EXCLUDED (client is cluster-internal)
 		Type: request.EventTypeHTTP, Method: "GET", Route: "/baz",
-		PeerName: "foo.com", HostName: "1.2.3.4",
+		Peer: "10.0.0.1", Host: "1.2.3.4",
 		TraceID: [16]byte{3},
-	}, { // TO BE EXCLUDED (server is known in an HTTP client)
+	}, { // TO BE EXCLUDED (server is cluster-internal)
 		Type: request.EventTypeHTTPClient, Method: "POST", Route: "/bae",
-		PeerName: "1.2.3.4", HostName: "foo.com",
+		Peer: "1.2.3.4", Host: "10.0.0.1",
 		TraceID: [16]byte{4},
 	}, { // TO BE EXCLUDED (Trace ID is not valid)
 		Type: request.EventTypeHTTP, Method: "GET", Route: "/foo",
-		PeerName: "1.2.3.4", HostName: "foo.com",
+		Peer: "1.2.3.4", Host: "10.0.0.1",
 	}})
 
 	external := testutil.ReadChannel(t, out, 5*time.Second)
 	assert.Equal(t, []request.Span{{
 		Type: request.EventTypeHTTP, Method: "GET", Route: "/foo",
-		PeerName: "1.2.3.4", HostName: "foo.com",
+		Peer: "1.2.3.4", Host: "10.0.0.1",
 		TraceID: [16]byte{1},
 	}, {
 		Type: request.EventTypeHTTPClient, Method: "POST", Route: "/bar",
-		PeerName: "foo.com", HostName: "1.2.3.4",
+		Peer: "10.0.0.1", Host: "1.2.3.4",
 		TraceID: [16]byte{2},
 	}}, external)
 }

--- a/test/integration/k8s/manifests/06-beyla-daemonset-topology-extern.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-topology-extern.yml
@@ -79,6 +79,6 @@ spec:
             - name: BEYLA_OTEL_METRICS_FEATURES
               value: "application,application_process"
             - name: BEYLA_NAME_RESOLVER_SOURCES
-              value: "k8s"
+              value: "k8s,dns"
             - name: BEYLA_TOPOLOGY_SPANS
               value: "inter_cluster"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -741,7 +741,7 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
-# go.opentelemetry.io/obi v0.0.0-20250925065457-652a072327c6 => ./.obi-src
+# go.opentelemetry.io/obi v0.0.0-20250926075427-b6d5c4e9f2da => ./.obi-src
 ## explicit; go 1.25.0
 go.opentelemetry.io/obi/pkg/app/request
 go.opentelemetry.io/obi/pkg/buildinfo


### PR DESCRIPTION
The previous implementation assumed that any resolved hostname was cluster internal. However reverse DNS might resolve some cluster-external IPs anyway. 

The current implementation validates the IPs towards Beyla's K8s store to know whether they belong to the cluster or not.