### PR TITLE
fix(docs): point attributes.select to more relevant page

### DIFF
--- a/docs/sources/network/_index.md
+++ b/docs/sources/network/_index.md
@@ -93,4 +93,4 @@ attributes:
 In this example, the bytes metric is the aggregated by the source and destination owners. This is, all the
 pods from a given Deployment/StatefulSet/ReplicaSet/DaemonSet.
 
-For more information about the `attributes.select` section, check the [Configuration options](../configure/options/).
+For more information about the `attributes.select` section, check the [Metrics attributes](../configure/metrics-traces-attributes/).


### PR DESCRIPTION
Points the section about attributes.select to the page dedicated to metrics and trace attributes. While the global options would be a nice place to document all configuration options exhaustively, that's not currently the case.