### PR TITLE
Remove outdated TODO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,6 @@ bpf2go:
 prereqs: install-hooks bpf2go
 	@echo "### Check if prerequisites are met, and installing missing dependencies"
 	mkdir -p $(TEST_OUTPUT)/run
-	# TODO: upgrade golangci-lint to v2
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,v2.4.0)
 	$(call go-install-tool,$(GO_OFFSETS_TRACKER),github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker,$(call gomod-version,grafana/go-offsets-tracker))
 	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses,v1.6.0)


### PR DESCRIPTION
The Makefile already installs golangci-lint v2 (`github.com/golangci/golangci-lint/v2` with `v2.4.0`). The TODO suggesting an upgrade to v2 is obsolete and misleading. I removed that comment to reflect the current state and reduce noise. 