### PR TITLE
Fix typos in Helm chart and documentation

### DIFF
--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -70,8 +70,8 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | preset | string | `"application"` | Preconfigures some default properties for network or application observability. Accepted values are "network" or "application". |
 | priorityClassName | string | `""` |  |
 | privileged | bool | `true` | If set to false, deploys an unprivileged / less privileged setup. |
-| rbac.create | bool | `true` | Whether to create RBAC resources for Belya |
-| rbac.extraClusterRoleRules | list | `[]` | Extra custer roles to be created for Belya |
+| rbac.create | bool | `true` | Whether to create RBAC resources for Beyla |
+| rbac.extraClusterRoleRules | list | `[]` | Extra cluster roles to be created for Beyla |
 | resources | object | `{}` |  |
 | securityContext | object | `{"privileged":true}` | Security context for privileged setup. |
 | service.annotations | object | `{}` | Service annotations. |

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -35,9 +35,9 @@ namespaceOverride: ""
 # annotations: {}
 
 rbac:
-  # -- Whether to create RBAC resources for Belya
+  # -- Whether to create RBAC resources for Beyla
   create: true
-  # -- Extra custer roles to be created for Belya
+  # -- Extra cluster roles to be created for Beyla
   extraClusterRoleRules: []
   # - apiGroups: []
   #   resources: []

--- a/devdocs/new-tracer.md
+++ b/devdocs/new-tracer.md
@@ -1,6 +1,6 @@
 # Add new TCP based BPF tracer
 
-This document the steps required to add a new TCP protocol based BPF tracer to Beyla.
+This documents the steps required to add a new TCP protocol based BPF tracer to Beyla.
 
 ## Investigate the protocol
 


### PR DESCRIPTION
Fixes three typos found in the codebase:

1. **Helm chart** (`charts/beyla/`): Corrects product name from "Belya" to "Beyla" and fixes "custer roles" to "cluster roles" in both `values.yaml` and `README.md`
2. **Developer docs** (`devdocs/new-tracer.md`): Fixes grammar - "This document the steps" → "This documents the steps"

These are straightforward spelling/grammar corrections with no functional changes.