### PR TITLE
fix: sync test/integration/components/dotnetserver/Program.cs

### DIFF
--- a/test/integration/components/dotnetserver/Program.cs
+++ b/test/integration/components/dotnetserver/Program.cs
@@ -1,7 +1,14 @@
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddHttpClient();
 var app = builder.Build();
 
-app.MapGet("/greeting", () => "PONG!");
+app.MapGet("/greeting", async (HttpClient httpClient) =>
+        {
+            var response = await httpClient.GetAsync("https://opentelemetry.io/");
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            return Results.Ok(content);
+        });
 app.MapGet("/smoke", () => "");
 
 app.Run();


### PR DESCRIPTION
During testing of #2258 I auto-applied a patch (#2260) but, as the PR checks weren't triggered, I missed that we also needed to update `test/integration/components/dotnetserver/Program.cs`.