### PR TITLE
disable testserver_1.17/go.mod in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,10 @@
     },
     {
       "description": "Disable Go 1.17 testserver updates",
-      "matchFileNames": ["test/integration/components/testserver_1.17/Dockerfile"],
+      "matchFileNames": [
+        "test/integration/components/testserver_1.17/Dockerfile",
+        "test/integration/components/testserver_1.17/go.mod"
+      ],
       "matchDatasources": ["docker"],
       "matchPackageNames": ["golang"],
       "enabled": false


### PR DESCRIPTION
Renovate is trying to renew it and breaking the code because of the old Go version.