### PR TITLE
Exclude testserver_1.17/go.sum also from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,8 @@
       "description": "Disable Go 1.17 testserver updates",
       "matchFileNames": [
         "test/integration/components/testserver_1.17/Dockerfile",
-        "test/integration/components/testserver_1.17/go.mod"
+        "test/integration/components/testserver_1.17/go.mod",
+        "test/integration/components/testserver_1.17/go.sum"
       ],
       "matchDatasources": ["docker"],
       "matchPackageNames": ["golang"],


### PR DESCRIPTION
It looks that we also need to exclude testserver_1.17/go.sum also from renovate:
```
Command failed: go mod tidy
go: downloading github.com/stretchr/testify v1.8.3
go: downloading github.com/go-playground/assert/v2 v2.2.0
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: downloading google.golang.org/genproto v0.0.0-20230706204954-ccb25ca9f130
go: downloading github.com/ugorji/go v1.1.7
go: github.com/grafana/beyla/v2/testserver_1.17 imports
	github.com/gin-gonic/gin imports
	github.com/gin-gonic/gin/binding imports
	gopkg.in/yaml.v2 tested by
	gopkg.in/yaml.v2.test imports
	gopkg.in/check.v1 loaded from gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405,
	but go 1.16 would select v1.0.0-20201130134442-10cb98267c6c

To upgrade to the versions selected by go 1.16:
	go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
	go mod tidy -compat=1.17
For information about 'go mod tidy' compatibility, see:
	https://go.dev/ref/mod#graph-pruning
go: github.com/grafana/beyla/v2/testserver_1.17 imports
	github.com/gin-gonic/gin imports
	github.com/gin-gonic/gin/binding imports
	gopkg.in/yaml.v2 tested by
	gopkg.in/yaml.v2.test imports
	gopkg.in/check.v1 loaded from gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405,
	but go 1.16 would select v1.0.0-20201130134442-10cb98267c6c
```