### PR TITLE
feat(helm): cache-only deployment

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.9.9
+version: 1.10.0
 appVersion: 2.7.5
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
@@ -21,3 +21,5 @@ maintainers:
     url: https://github.com/marctc
   - name: rafaelroquetto
     url: https://github.com/rafaelroquetto
+  - name: skl
+    url: https://github.com/skl

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.5](https://img.shields.io/badge/AppVersion-2.7.5-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -14,6 +14,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | grcevski |  | <https://github.com/grcevski> |
 | marctc |  | <https://github.com/marctc> |
 | rafaelroquetto |  | <https://github.com/rafaelroquetto> |
+| skl |  | <https://github.com/skl> |
 
 ## Source Code
 
@@ -30,6 +31,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | config.skipConfigMapCheck | bool | `false` | set to true, to skip the check around the ConfigMap creation |
 | contextPropagation | object | `{"enabled":true}` | Enables context propagation support. |
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` | Determines how DNS resolution is handled for that pod. If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Beyla requires `hostNetwork` access, causing cluster service DNS resolution to fail. It is recommended not to change this if Beyla sends traces and metrics to Grafana components via k8s service. |
+| enabled | bool | `true` | Whether to deploy the Beyla DaemonSet. Defaults to true. Set to false to deploy only the Kubernetes metadata cache. |
 | env | object | `{}` | extra environment variables |
 | envValueFrom | object | `{}` | extra environment variables to be set from resources such as k8s configMaps/secrets |
 | extraCapabilities | list | `[]` | Extra capabilities for unprivileged / less privileged setup. |

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -149,3 +150,4 @@ spec:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/beyla/tests/integration/cache-only/test-plan.yaml
+++ b/charts/beyla/tests/integration/cache-only/test-plan.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm-chart-toolbox.grafana.com/v1
+kind: TestPlan
+name: cache-only
+
+subject:
+  path: ../../..
+  valuesFile: values.yaml
+
+cluster:
+  type: kind
+
+tests:
+  - type: kubernetes-objects-test
+    values:
+      checks:
+        - kind: Deployment
+          name: beyla-k8s-cache
+          namespace: default
+        - kind: Service
+          name: beyla-k8s-cache
+          namespace: default
+        - kind: ConfigMap
+          name: cache-only-beyla
+          namespace: default
+      checkAbsent:
+        - kind: DaemonSet
+          name: cache-only-beyla
+          namespace: default

--- a/charts/beyla/tests/integration/cache-only/values.yaml
+++ b/charts/beyla/tests/integration/cache-only/values.yaml
@@ -1,0 +1,4 @@
+---
+enabled: false
+k8sCache:
+  replicas: 1

--- a/charts/beyla/tests/integration/default/test-plan.yaml
+++ b/charts/beyla/tests/integration/default/test-plan.yaml
@@ -2,6 +2,7 @@
 apiVersion: helm-chart-toolbox.grafana.com/v1
 kind: TestPlan
 name: defaults
+
 subject:
   path: ../../..
 

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -7,6 +7,9 @@ global:
     # -- Optional set of global image pull secrets.
     pullSecrets: []
 
+# -- Whether to deploy the Beyla DaemonSet. Defaults to true. Set to false to deploy only the Kubernetes metadata cache.
+enabled: true
+
 image:
   # -- Beyla image registry (defaults to docker.io)
   registry: "docker.io"


### PR DESCRIPTION
Adds a new top-level helm value `enabled` (default `true`) to guard the deployment of the Beyla DaemonSet.

The intention is to allow the Beyla helm chart to be deployed with an optional cache-only configuration, which would deploy the k8s-cache Deployment without the Beyla DaemonSet.