### PR TITLE
chore: Fix typos

### DIFF
--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
@@ -417,7 +417,7 @@ type SubResourceGetOptions struct {
 	Raw *metav1.GetOptions
 }
 
-// ApplyToSubResourceGet updates the configuaration to the given get options.
+// ApplyToSubResourceGet updates the configuration to the given get options.
 func (getOpt *SubResourceGetOptions) ApplyToSubResourceGet(o *SubResourceGetOptions) {
 	if getOpt.Raw != nil {
 		o.Raw = getOpt.Raw

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
@@ -55,7 +55,7 @@ type Object interface {
 // is a kubernetes list wrapper (has items, pagination fields, etc) -- think
 // the wrapper used in a response from a `kubectl list --output yaml` call.
 //
-// Code-wise, this means that any object which embedds both ListMeta (which
+// Code-wise, this means that any object which embeds both ListMeta (which
 // provides metav1.ListInterface) and TypeMeta (which provides half of
 // runtime.Object) and has a `DeepCopyObject` implementation (the other half of
 // runtime.Object) will implement this by default.

--- a/vendor/sigs.k8s.io/e2e-framework/klient/k8s/resources/resources.go
+++ b/vendor/sigs.k8s.io/e2e-framework/klient/k8s/resources/resources.go
@@ -255,7 +255,7 @@ func (r *Resources) PatchStatus(ctx context.Context, objs k8s.Object, patch k8s.
 	return r.PatchSubresource(ctx, objs, "status", patch, opts...)
 }
 
-// Annotate attach annotations to an existing resource objec
+// Annotate attach annotations to an existing resource object
 func (r *Resources) Annotate(obj k8s.Object, annotation map[string]string) {
 	obj.SetAnnotations(annotation)
 }

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/types/types.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/types/types.go
@@ -212,7 +212,7 @@ type E2EClusterProvider interface {
 	// attributes are setup accordingly if any.
 	SetDefaults() E2EClusterProvider
 
-	// WaitForControlPlane is a helper function that can be used to indiate the Provider based cluster create workflow
+	// WaitForControlPlane is a helper function that can be used to indicate the Provider based cluster create workflow
 	// that the control plane is fully up and running. This method is invoked after the Create/CreateWithConfig handlers
 	// and is expected to return an error if the control plane doesn't stabilize. If the provider being implemented
 	// does not have a clear mechanism to identify the Control plane readiness or is not required to wait for the control

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/utils/command.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/utils/command.go
@@ -33,7 +33,7 @@ var commandRunner = gexe.New()
 // install the provider and setup the required binaries to perform the tests. In case if the install
 // is done by this helper, it will return the value for installed binary as provider which can then
 // be set in the invoker to make sure the right path is used for the binaries while invoking
-// rest of the workfow after this helper is triggered.
+// rest of the workflow after this helper is triggered.
 func FindOrInstallGoBasedProvider(pPath, provider, module, version string) (string, error) {
 	if gexe.ProgAvail(pPath) != "" {
 		log.V(4).InfoS("Found Provider tooling already installed on the machine", "command", pPath)

--- a/vendor/sigs.k8s.io/e2e-framework/support/README.md
+++ b/vendor/sigs.k8s.io/e2e-framework/support/README.md
@@ -1,3 +1,3 @@
-### This entire package and it's sub packages are present only to account for backward compatiblity.
+### This entire package and it's sub packages are present only to account for backward compatibility.
 
 Any new Provider should be added under `third_party/<provider>`


### PR DESCRIPTION
 Fixed 6 typos in vendored controller-runtime and e2e-framework packages:
  - `configuaration` → `configuration` (client.go:420)
  - `embedds` → `embeds` (object.go:58)
  - `objec` → `object` (resources.go:258)
  - `indiate` → `indicate` (types.go:215)
  - `workfow` → `workflow` (command.go:36)
  - `compatiblity` → `compatibility` (README.md:1)
  
  All changes are in code comments/documentation only with no functional impact.