### PR TITLE
Helm: fix prometheus port set to 0

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.10.0
-appVersion: 2.7.5
+version: 1.10.1
+appVersion: 2.7.11
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -73,12 +73,22 @@ spec:
                 - ALL
           {{- end }}
           ports:
-          {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+          {{- if (and
+                    (or (.Values.service.targetPort) (.Values.config.data.prometheus_export))
+                    (ne .Values.service.targetPort 0)
+                    (ne (int .Values.config.data.prometheus_export.port) 0)
+                 ) }}
           - name: {{ .Values.service.portName }}
             containerPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
             protocol: TCP
           {{- end }}
-          {{- if (and (or (.Values.service.internalMetrics.targetPort) ((and .Values.config.data.internal_metrics .Values.config.data.internal_metrics.prometheus))) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
+          {{- if (and
+                    (or (.Values.service.internalMetrics.targetPort) ((and .Values.config.data.internal_metrics .Values.config.data.internal_metrics.prometheus)))
+                    (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))
+                    (ne .Values.service.internalMetrics.targetPort 0)
+                    (ne .Values.config.data.internal_metrics.prometheus.port 0)
+                  )
+          }}
           - name: {{ .Values.service.internalMetrics.portName }}
             containerPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
             protocol: TCP


### PR DESCRIPTION
Due to a breaking change in Helm (zero values are now treated as existing), people trying to disable prometheus port by setting it to 0 caused an error:

```
Error: INSTALLATION FAILED: DaemonSet.apps "beyla" is invalid: spec.template.spec.containers[0].ports[0].containerPort: Required value
```