### PR TITLE
Default Helm to Beyla 2.8.4

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: beyla
-version: 1.10.3
-appVersion: 2.8.1
+version: 1.10.4
+appVersion: 2.8.4
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/
 icon: https://grafana.com/static/img/logos/beyla-logo.svg


### PR DESCRIPTION
Beyla 2.8.4 includes a critical fix, preventing some spans from being lost when the internal OTEL sending queue was full.

This PR can't be merged until this PR finishes and we release 2.8.4: https://github.com/grafana/beyla/pull/2381