### PR TITLE
Update docs to reflect of required privileges

### DIFF
--- a/docs/sources/network/quickstart.md
+++ b/docs/sources/network/quickstart.md
@@ -47,10 +47,7 @@ Or export the following environment variable
 export BEYLA_KUBE_METADATA_ENABLE=true
 ```
 
-Finally, network metrics requires administrative `sudo` privileges with the following capabilities:
-
-- Full privileged access, `root`, `sudo`, or `privileged: true` for Kubernetes
-- The following capabilities: `BPF`, `PERFMON`, `NET_ADMIN`, `SYS_RESOURCE`
+Finally, network metrics requires elevated privileges. Running with `sudo` or `privileged: true` for Kubernetes is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 To learn more about Beyla configuration, consult the [Beyla configuration documentation](../../configure/options/).
 

--- a/docs/sources/quickstart/cpp.md
+++ b/docs/sources/quickstart/cpp.md
@@ -53,7 +53,7 @@ To run Beyla, first set the following environment variables:
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -61,7 +61,7 @@ To run Beyla, first set the following environment variables:
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/java.md
+++ b/docs/sources/quickstart/java.md
@@ -49,7 +49,7 @@ To run Beyla, first set the following environment variables:
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/nodejs.md
+++ b/docs/sources/quickstart/nodejs.md
@@ -59,7 +59,7 @@ Beyla automatically reports the name of the process executable as service name: 
 To override it, refer to the [override service name and namespace](../configure/service-discovery#override-service-name-and-namespace)
 documentation section.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/python.md
+++ b/docs/sources/quickstart/python.md
@@ -57,7 +57,7 @@ Beyla automatically reports the name of the process executable as service name: 
 To override it, refer to the [override service name and namespace](../configure/service-discovery#override-service-name-and-namespace)
 documentation section.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/ruby.md
+++ b/docs/sources/quickstart/ruby.md
@@ -57,7 +57,7 @@ Beyla automatically reports the name of the process executable as service name: 
 To override it, refer to the [override service name and namespace](../configure/service-discovery#override-service-name-and-namespace)
 documentation section.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/quickstart/rust.md
+++ b/docs/sources/quickstart/rust.md
@@ -49,7 +49,7 @@ To run Beyla, first set the following environment variables:
 
 To facilitate local testing, set the `BEYLA_TRACE_PRINTER=text` environment variable. When this option is set, Beyla prints traces in text format to the standard output.
 
-Notice: Beyla requires administrative (sudo) privileges, or at least it needs to be granted the `CAP_SYS_ADMIN` capability.
+Notice: Beyla requires elevated privileges. Running with `sudo` is the simplest approach. For more restrictive environments, Beyla can run with specific Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for details on the required capabilities for your use case.
 
 ```sh
 export BEYLA_OPEN_PORT=8080

--- a/docs/sources/setup/docker.md
+++ b/docs/sources/setup/docker.md
@@ -23,8 +23,7 @@ grafana/beyla:latest
 
 The Beyla container must be configured in following way:
 
-- run as a **privileged** container, or as a container with the `SYS_ADMIN` capability (but
-  this last option might not work in some container environments)
+- run as a **privileged** container, or with the required Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for the list of capabilities required for your use case
 - share the PID space with the container that is being instrumented
 
 ## Docker CLI example
@@ -46,8 +45,7 @@ export BEYLA_OPEN_PORT=8443
 
 Beyla needs to be run with the following settings:
 
-- in `--privileged` mode, or with `SYS_ADMIN` capability (despite `SYS_ADMIN` might
-  not be enough privileges in some container environments)
+- in `--privileged` mode, or with the required Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for the list of capabilities required for your use case
 - a container PID namespace, with the option `--pid="container:goblog"`.
 
 ```sh

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -123,18 +123,7 @@ requirements:
 - The process namespace must be shared between all containers in the Pod (`shareProcessNamespace: true`
   pod variable)
 - The auto-instrument container must run in privileged mode (`securityContext.privileged: true` property of the
-  container configuration).
-  - Some Kubernetes installation allow the following `securityContext` configuration,
-    but it might not work with all the container runtime configurations, as some of them confine
-    the containers and remove some permissions:
-    ```yaml
-    securityContext:
-      runAsUser: 0
-      capabilities:
-        add:
-          - SYS_ADMIN
-          - SYS_RESOURCE # not required for kernels 5.11+
-    ```
+  container configuration), or with the required Linux capabilities. Refer to [Security, permissions and capabilities](../../security/) for the list of capabilities required for your use case, or check the [Deploy Beyla unprivileged](#deploy-beyla-unprivileged) section below.
 
 The following example instruments the `goblog` pod by attaching Beyla
 as a container (image available at `grafana/beyla:latest`). The


### PR DESCRIPTION
Current docs refer to use `sudo` or `CAP_SYS_ADMIN`, so its better to just point to security section.

Follow up of #2415
Fixes #1678