### PR TITLE
build: upgrade spotless for JDK 25 compat

### DIFF
--- a/pkg/internal/java/agent/build.gradle.kts
+++ b/pkg/internal/java/agent/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     id("com.gradleup.shadow") version "8.3.9"
     id("me.champeau.jmh") version "0.7.3"
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "8.0.0"
 }
 
 group = "io.opentelemetry.obi"

--- a/pkg/internal/java/loader/build.gradle.kts
+++ b/pkg/internal/java/loader/build.gradle.kts
@@ -3,7 +3,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 plugins {
     java
     id("com.gradleup.shadow") version "8.3.9"
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "8.0.0"
 }
 
 // We need this dependency to load the resource JNA shared libraries


### PR DESCRIPTION
The spotless plugin includes `google-java-format`, the version of which is currently incompatible with JDK 25. Bumping spotless to a newer version also includes a newer version of `google-java-format` which is compatible with JDK 25.