### PR TITLE
Add vendor to renovate ignores

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
     // be updated.
     "configs/offsets/shopify/**",
     "NOTICES/**",
+    "vendor/**",
   ],
   packageRules: [
     {

--- a/vendor/github.com/goccy/go-json/docker-compose.yml
+++ b/vendor/github.com/goccy/go-json/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   go-json:
-    image: golang:1.18@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da
+    image: golang:1.18
     volumes:
       - '.:/go/src/go-json'
     deploy:


### PR DESCRIPTION
Renovate is trying to update some vendored files from time to time. I would have expected that renovate ignored the `vendor` folder by default.