### PR TITLE
Fix unfiltered features

### DIFF
--- a/pkg/export/otel/connect_spans.go
+++ b/pkg/export/otel/connect_spans.go
@@ -110,10 +110,6 @@ func (tr *connectionSpansExport) processSpans(ctx context.Context, exp exporter.
 		if len(spanGroup) > 0 {
 			sample := &spanGroup[0]
 
-			if !sample.Span.Service.ExportModes.CanExportTraces() {
-				continue
-			}
-
 			// append external attribute
 			sample.Attributes = make([]attribute.KeyValue, 0, len(tr.attributeProvider))
 			for _, getter := range tr.attributeProvider {

--- a/pkg/internal/appolly/traces/external.go
+++ b/pkg/internal/appolly/traces/external.go
@@ -36,7 +36,10 @@ type externalSpanFilter struct {
 func (esp *externalSpanFilter) filter(spans []request.Span) []request.Span {
 	var extern []request.Span
 	for i := range spans {
-		if esp.isExternalSelectable(&spans[i]) {
+		// this node is the entrance of this pipeline. We early discard whatever
+		// we think is not going to be exported
+		if spans[i].Service.ExportModes.CanExportTraces() &&
+			esp.isExternalSelectable(&spans[i]) {
 			extern = append(extern, spans[i])
 		}
 	}


### PR DESCRIPTION
* If process metrics are disabled in the per-app feature, process metrics should not be emitted for these processes
* Filters the connection spans in an earlier stage of the pipeline to save unnecessary resources