### PR TITLE
Fix sql docs

### DIFF
--- a/docs/sources/cardinality.md
+++ b/docs/sources/cardinality.md
@@ -109,8 +109,7 @@ However, here is a list of factors that can influence the overall cardinality:
   * `http.client.request.duration`
   * `http.client.request.body.size`
   * `rpc.client.duration`
-  * `sql.client.duration`
-  * `redis.client.duration`
+  * `db.client.operation.duration`
   * `messaging.publish.duration`
   * `messaging.process.duration`
 * Server-side metrics, when Beyla instruments application that dispatches requests from other applications:
@@ -162,7 +161,7 @@ The numbers taken as reference:
   * Backend as an SQL and HTTP client
     * `http.client.request.duration`
     * `http.client.request.body.size`
-    * `sql.client.duration`
+    * `db.client.operation.duration`
 * 17 histogram metrics, as most metrics are duration-based
 * 7 operations: RPC Add/List/Delete, HTTP PUT, SQL Insert/Select/Delete
 * 3 endpoints: backend, Identity provider, and DB
@@ -192,12 +191,12 @@ In this simple scenario, we can manually count more the maximum cardinality to 3
 | 16  | Backend  | `http.client.request.body.size` | Identity Prov | PUT /login | 200  |
 | 17  | Backend  | `http.client.request.body.size` | Identity Prov | PUT /login | 401  |
 | 18  | Backend  | `http.client.request.body.size` | Identity Prov | PUT /login | 500  |
-| 19  | Backend  | `sql.client.duration`           | DB            | Insert     | Ok   |
-| 20  | Backend  | `sql.client.duration`           | DB            | Insert     | Err  |
-| 21  | Backend  | `sql.client.duration`           | DB            | Select     | Ok   |
-| 22  | Backend  | `sql.client.duration`           | DB            | Select     | Err  |
-| 23  | Backend  | `sql.client.duration`           | DB            | Delete     | Ok   |
-| 24  | Backend  | `sql.client.duration`           | DB            | Delete     | Err  |
+| 19  | Backend  | `db.client.operation.duration`  | DB            | Insert     | Ok   |
+| 20  | Backend  | `db.client.operation.duration`  | DB            | Insert     | Err  |
+| 21  | Backend  | `db.client.operation.duration`  | DB            | Select     | Ok   |
+| 22  | Backend  | `db.client.operation.duration`  | DB            | Select     | Err  |
+| 23  | Backend  | `db.client.operation.duration`  | DB            | Delete     | Ok   |
+| 24  | Backend  | `db.client.operation.duration`  | DB            | Delete     | Err  |
 
 <!-- vale Grafana.OK = YES -->
 
@@ -339,7 +338,7 @@ The total, maximum calculated limit for HTTP metrics is:
 
 This shows how ineffective the formula is for the application-level metrics, as the measured number is much lower, even for all the known application metric types:
 
-`count({__name__=~"http_.*|rpc_.*|sql_.*|redis_.*|messaging_.*"})` **→ 9,600**
+`count({__name__=~"http_.*|rpc_.*|db_client.*|messaging_.*"})` **→ 9,600**
 
 ### Measure network-level metrics
 

--- a/docs/sources/configure/filter-metrics-traces.md
+++ b/docs/sources/configure/filter-metrics-traces.md
@@ -45,3 +45,12 @@ filter:
     dst_port:
       match: "53"
 ```
+
+The following example filters application metrics to only report database operations for PostgreSQL and MongoDB:
+
+```yaml
+filter:
+  application:
+    db.system.name:
+      match: "{postgresql,mongodb}"
+```

--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -30,10 +30,10 @@ attributes:
         - beyla.ip
         - src.name
         - dst.port
-    sql_client_duration:
-      # report all the possible attributes but db_statement
+    db_client_operation_duration:
+      # report all the possible attributes but db_query_text
       include: ["*"]
-      exclude: ["db_statement"]
+      exclude: ["db_query_text"]
     http_client_request_duration:
       # report the default attribute set but exclude the Kubernetes Pod information
       exclude: ["k8s.pod.*"]

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -25,8 +25,7 @@ The following table describes the exported metrics in both OpenTelemetry and Pro
 | Application         | `http.server.response.body.size` | `http_server_response_body_size_bytes`  | Histogram     | bytes   | Size of the HTTP response body as received at the server side                                                                         |
 | Application         | `rpc.client.duration`           | `rpc_client_duration_seconds`          | Histogram     | seconds | Duration of GRPC service calls from the client side                                                                                  |
 | Application         | `rpc.server.duration`           | `rpc_server_duration_seconds`          | Histogram     | seconds | Duration of RPC service calls from the server side                                                                                   |
-| Application         | `sql.client.duration`           | `sql_client_duration_seconds`          | Histogram     | seconds | Duration of SQL client operations (Experimental)                                                                                     |
-| Application         | `redis.client.duration`         | `redis_client_duration_seconds`        | Histogram     | seconds | Duration of Redis client operations (Experimental)                                                                                   |
+| Application         | `db.client.operation.duration`  | `db_client_operation_duration_seconds` | Histogram     | seconds | Duration of database client operations (SQL, Redis, MongoDB)                                                                         |
 | Application         | `messaging.publish.duration`    | `messaging_publish_duration`           | Histogram     | seconds | Duration of Messaging (Kafka) publish operations (Experimental)                                                                      |
 | Application         | `messaging.process.duration`    | `messaging_process_duration`           | Histogram     | seconds | Duration of Messaging (Kafka) process operations (Experimental)                                                                      |
 | Application process | `process.cpu.time`              | `process_cpu_time_seconds_total`       | Counter       | seconds | Total CPU seconds broken down by different states (system/user/wait)                                                                 |
@@ -47,6 +46,14 @@ Beyla can also export [Span metrics](/docs/tempo/latest/metrics-generator/span_m
 For the sake of brevity, the metrics and attributes in this list use the OTEL `dot.notation`. When using the Prometheus exporter, the metrics use `underscore_notation`.
 
 In order to configure which attributes to show or which attributes to hide, check the `attributes`->`select` section in the [configuration documentation](../configure/options/).
+
+For more information about the OpenTelemetry semantic conventions for each metric type, refer to:
+- [HTTP metrics conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/)
+- [RPC metrics conventions](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/)
+- [Database metrics conventions](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/)
+- [Messaging metrics conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/)
+- [Process metrics conventions](https://opentelemetry.io/docs/specs/semconv/system/process-metrics/)
+- [Kubernetes resource conventions](https://opentelemetry.io/docs/specs/semconv/resource/k8s/)
 
 | Metrics                        | Name                         | Default                                           |
 |--------------------------------|------------------------------|---------------------------------------------------|
@@ -83,13 +90,17 @@ In order to configure which attributes to show or which attributes to hide, chec
 | Application `rpc.*`            | `rpc.method`                 | shown                                             |
 | Application `rpc.*`            | `rpc.system`                 | shown                                             |
 | Application (server)           | `client.address`             | hidden                                            |
-| `beyla.network.flow.bytes`     | `beyla.ip`                   | hidden                                            |
 | `db.client.operation.duration` | `db.operation.name`          | shown                                             |
 | `db.client.operation.duration` | `db.collection.name`         | hidden                                            |
+| `db.client.operation.duration` | `db.system.name`             | shown                                             |
+| `db.client.operation.duration` | `db.query.text`              | hidden                                            |
+| `db.client.operation.duration` | `server.address`             | shown                                             |
+| `db.client.operation.duration` | `error.type`                 | shown                                             |
 | `messaging.publish.duration`   | `messaging.system`           | shown                                             |
 | `messaging.publish.duration`   | `messaging.destination.name` | shown                                             |
 | `messaging.process.duration`   | `messaging.system`           | shown                                             |
 | `messaging.process.duration`   | `messaging.destination.name` | shown                                             |
+| `beyla.network.flow.bytes`     | `beyla.ip`                   | hidden                                            |
 | `beyla.network.flow.bytes`     | `client.port`                | hidden                                            |
 | `beyla.network.flow.bytes`     | `direction`                  | hidden                                            |
 | `beyla.network.flow.bytes`     | `dst.address`                | hidden                                            |
@@ -119,7 +130,6 @@ In order to configure which attributes to show or which attributes to hide, chec
 | `beyla.network.flow.bytes`     | `src.port`                   | hidden                                            |
 | `beyla.network.flow.bytes`     | `src.zone` (only Kubernetes) | hidden                                            |
 | `beyla.network.flow.bytes`     | `transport`                  | hidden                                            |
-| Traces (SQL, Redis)            | `db.query.text`              | hidden                                            |
 
 {{< admonition type="note" >}}
 The `beyla.network.inter.zone.bytes` metric supports the same set of attributes as `beyla.network.flow.bytes`,


### PR DESCRIPTION
- Removed instaces of `sql.client.duration` and `redis.client.duration`
- Link to semantic conventions for metric attributes.
- Example of filtering per `db.system.name`

fixes #1190