### PR TITLE
Draft: move traces_host_info from OBI to Beyla

### DIFF
--- a/pkg/export/otel/expirer.go
+++ b/pkg/export/otel/expirer.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel // import "go.opentelemetry.io/obi/pkg/export/otel"
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/expire"
+	"go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+)
+
+var timeNow = time.Now
+
+func plog() *slog.Logger {
+	return slog.With("component", "otel.Expirer")
+}
+
+type removableMetric[VT any] interface {
+	Remove(context.Context, ...metric.RemoveOption)
+}
+
+// Expirer drops metrics from labels that haven't been updated during a given timeout.
+// It has multiple generic types to allow it working with different dataPoints (FloatVal, IntCounter...)
+// and different types of data (int, float...).
+// Record: type of the record that holds the metric data request.Span, ebpf.Record, process.Status...
+// Metric: type of the dataPoint kind: IntCounter, FloatVal...
+// VT: type of the value inside the datapoint: int, float64...
+type Expirer[Record any, Metric removableMetric[ValType], ValType any] struct {
+	ctx     context.Context
+	attrs   []attributes.Field[Record, attribute.KeyValue]
+	metric  Metric
+	entries *expire.ExpiryMap[attribute.Set]
+	log     *slog.Logger
+
+	clock          expire.Clock
+	lastExpiration time.Time
+	ttl            time.Duration
+}
+
+// NewExpirer creates an expirer that wraps data points of a given type. Its labeled instances are dropped
+// if they haven't been updated during the last timeout period.
+// Arguments:
+// - instancer: the constructor of each datapoint object (e.g. NewIntCounter, NewFloatVal...)
+// - attrs: attributes for that given data point
+// - clock: function that provides the current time
+// - ttl: time to live of the datapoints whose attribute sets haven't been updated
+func NewExpirer[Record any, Metric removableMetric[ValType], ValType any](
+	ctx context.Context,
+	metric Metric,
+	attrs []attributes.Field[Record, attribute.KeyValue],
+	clock expire.Clock,
+	ttl time.Duration,
+) *Expirer[Record, Metric, ValType] {
+	exp := Expirer[Record, Metric, ValType]{
+		ctx:            ctx,
+		metric:         metric,
+		attrs:          attrs,
+		entries:        expire.NewExpiryMap[attribute.Set](clock, ttl),
+		log:            plog().With("type", fmt.Sprintf("%T", metric)),
+		clock:          clock,
+		lastExpiration: clock(),
+		ttl:            ttl,
+	}
+	return &exp
+}
+
+// ForRecord returns the data point for the given eBPF record. If that record
+// is accessed for the first time, a new data point is created.
+// If not, a cached copy is returned and the "last access" cache time is updated.
+// Extra attributes can be explicitly added (e.g. cpu_mode="wait")
+func (ex *Expirer[Record, Metric, ValType]) ForRecord(r Record, extraAttrs ...attribute.KeyValue) (Metric, attribute.Set) {
+	// to save resources, metrics expiration is triggered each TTL. This means that an expired
+	// metric might stay visible after 2*TTL time after not being updated
+	now := ex.clock()
+	if now.Sub(ex.lastExpiration) >= ex.ttl {
+		ex.removeOutdated(ex.ctx)
+		ex.lastExpiration = now
+	}
+	recordAttrs, attrValues := ex.recordAttributes(r, extraAttrs...)
+	return ex.metric, ex.entries.GetOrCreate(attrValues, func() attribute.Set {
+		ex.log.Debug("storing new metric label set", "labelValues", attrValues)
+		return recordAttrs
+	})
+}
+
+func (ex *Expirer[Record, Metric, ValType]) recordAttributes(m Record, extraAttrs ...attribute.KeyValue) (attribute.Set, []string) {
+	keyVals := make([]attribute.KeyValue, 0, len(ex.attrs)+len(extraAttrs))
+	vals := make([]string, 0, len(ex.attrs)+len(extraAttrs))
+
+	for _, attr := range ex.attrs {
+		kv := attr.Get(m)
+		keyVals = append(keyVals, kv)
+		vals = append(vals, kv.Value.Emit())
+	}
+	keyVals = append(keyVals, extraAttrs...)
+	for i := range extraAttrs {
+		vals = append(vals, extraAttrs[i].Value.Emit())
+	}
+
+	return attribute.NewSet(keyVals...), vals
+}
+
+func (ex *Expirer[Record, Metric, ValType]) removeOutdated(ctx context.Context) {
+	for _, attrs := range ex.entries.DeleteExpired() {
+		ex.deleteMetricInstance(ctx, attrs)
+	}
+}
+
+func (ex *Expirer[Record, Metric, ValType]) deleteMetricInstance(ctx context.Context, attrs attribute.Set) {
+	if ex.log.Enabled(ex.ctx, slog.LevelDebug) {
+		ex.logger(attrs).Debug("deleting old OTEL metric")
+	}
+	ex.metric.Remove(ctx, metric.WithAttributeSet(attrs))
+}
+
+func (ex *Expirer[Record, Metric, ValType]) logger(attrs attribute.Set) *slog.Logger {
+	fmtAttrs := make([]any, 0, attrs.Len()*2)
+	for it := attrs.Iter(); it.Next(); {
+		a := it.Attribute()
+		fmtAttrs = append(fmtAttrs, string(a.Key), a.Value.Emit())
+	}
+	return ex.log.With(fmtAttrs...)
+}
+
+// RemoveAllMetrics is explicitly invoked when the metrics reporter of a given service
+// instance needs to be shut down
+func (ex *Expirer[Record, Metric, ValType]) RemoveAllMetrics(ctx context.Context) {
+	for _, attrs := range ex.entries.DeleteAll() {
+		ex.deleteMetricInstance(ctx, attrs)
+	}
+}

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -1,0 +1,439 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/collector"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+const timeout = 20 * time.Second
+
+var mpConfig = perapp.MetricsConfig{Features: export.FeatureAll}
+
+func TestNetMetricsExpiration(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:        50 * time.Millisecond,
+		CommonEndpoint:  otlp.ServerEndpoint,
+		MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
+		TTL:             3 * time.Minute,
+		Instrumentations: []instrumentations.Instrumentation{
+			instrumentations.InstrumentationALL,
+		},
+	}
+	otelExporter, err := NetMetricsExporterProvider(
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{
+			Cfg: cfg,
+		}}, &NetMetricsConfig{
+			AppO11yMetrics: cfg, SelectorCfg: &attributes.SelectorConfig{
+				SelectionCfg: attributes.Selection{
+					attributes.NetworkFlow.Section: attributes.InclusionLists{
+						Include: []string{"src.name", "dst.name"},
+					},
+				},
+			},
+			CommonCfg: &perapp.MetricsConfig{Features: export.FeatureNetwork},
+		}, metrics)(ctx)
+	require.NoError(t, err)
+
+	go otelExporter(ctx)
+
+	// WHEN it receives metrics
+	metrics.Send([]*ebpf.Record{
+		{
+			Attrs:          ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{AppO11yMetrics: ebpf.NetFlowMetrics{Bytes: 123}},
+		},
+		{
+			Attrs:          ebpf.RecordAttrs{SrcName: "baz", DstName: "bae"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{AppO11yMetrics: ebpf.NetFlowMetrics{Bytes: 456}},
+		},
+	})
+
+	// THEN the metrics are exported
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, map[string]string{"src.name": "foo", "dst.name": "bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 123, metric.IntVal, 0.001)
+	}, timeout, 100*time.Millisecond)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, map[string]string{"src.name": "baz", "dst.name": "bae"}, metric.Attributes)
+		assert.InEpsilon(ct, 456, metric.IntVal, 0.001)
+	}, timeout, 100*time.Millisecond)
+	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
+	now.Advance(2 * time.Minute)
+	metrics.Send([]*ebpf.Record{
+		{
+			Attrs:          ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{AppO11yMetrics: ebpf.NetFlowMetrics{Bytes: 123}},
+		},
+	})
+
+	// THEN THE metrics that have been received during the TTL period are still visible
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, map[string]string{"src.name": "foo", "dst.name": "bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 246, metric.IntVal, 0.001)
+	}, timeout, 100*time.Millisecond)
+
+	now.Advance(2 * time.Minute)
+	metrics.Send([]*ebpf.Record{
+		{
+			Attrs:          ebpf.RecordAttrs{SrcName: "foo", DstName: "bar"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{AppO11yMetrics: ebpf.NetFlowMetrics{Bytes: 123}},
+		},
+	})
+
+	// makes sure that the records channel is emptied and any remaining
+	// old metric is sent and then the channel is re-emptied
+	otlp.ResetRecords()
+	readChan(t, otlp.Records())
+	otlp.ResetRecords()
+
+	// BUT not the metrics that haven't been received during that time.
+	// We just know it because OTEL will only sends foo/bar metric.
+	// If this test is flaky: it means it is actually failing
+	// repeating 10 times to make sure that only this metric is forwarded
+	for range 10 {
+		metric := readChan(t, otlp.Records())
+		require.Equal(t, map[string]string{"src.name": "foo", "dst.name": "bar"}, metric.Attributes)
+		require.InEpsilon(t, 369, metric.IntVal, 0.001)
+	}
+
+	// AND WHEN the metrics labels that disappeared are received again
+	now.Advance(2 * time.Minute)
+	metrics.Send([]*ebpf.Record{
+		{
+			Attrs:          ebpf.RecordAttrs{SrcName: "baz", DstName: "bae"},
+			NetFlowRecordT: ebpf.NetFlowRecordT{AppO11yMetrics: ebpf.NetFlowMetrics{Bytes: 456}},
+		},
+	})
+
+	// THEN they are reported again, starting from zero in the case of counters
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, map[string]string{"src.name": "baz", "dst.name": "bae"}, metric.Attributes)
+		assert.InEpsilon(ct, 456, metric.IntVal, 0.001)
+	}, timeout, 100*time.Millisecond)
+}
+
+// the expiration logic is held at two levels:
+// (1) by group of attributes within the same service Attrs,
+// (2) by metric set of a given service Attrs
+// this test verifies case 1
+func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	var g attributes.AttrGroups
+	g.Add(attributes.GroupKubernetes)
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		TTL:               3 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations: []instrumentations.Instrumentation{
+			instrumentations.InstrumentationALL,
+		},
+	}
+	otelExporter, err := ReportMetrics(
+		&global.ContextInfo{
+			MetricAttributeGroups: g,
+			OTELMetricsExporter:   &otelcfg.MetricsExporterInstancer{Cfg: cfg},
+		}, cfg, &mpConfig, &attributes.SelectorConfig{
+			SelectionCfg: attributes.Selection{
+				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
+					Include: []string{"url.path", "k8s.app.version"},
+				},
+			},
+			ExtraGroupAttributesCfg: map[string][]attr.Name{
+				"k8s_app_meta": {"k8s.app.version"},
+			},
+		}, request.UnresolvedNames{}, metrics, processEvents)(ctx)
+	require.NoError(t, err)
+
+	go otelExporter(ctx)
+
+	// WHEN it receives metrics
+	metrics.Send([]request.Span{
+		{
+			Service: svc.Attrs{
+				Features: export.FeatureAll,
+				UID:      svc.UID{Instance: "foo"},
+				Metadata: map[attr.Name]string{
+					"k8s.app.version": "v0.0.1",
+				},
+			},
+			Type:         request.EventTypeHTTP,
+			Path:         "/foo",
+			RequestStart: 100,
+			End:          200,
+		},
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 150, End: 175},
+	})
+
+	// THEN the metrics are exported
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, "http.server.request.duration", metric.Name)
+		// k8s.app.version attribute is missing because the otel exporter
+		// does not read values from span metadata
+		assert.Equal(ct, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.InEpsilon(ct, 100/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 25/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 250, End: 280},
+	})
+
+	// THEN THE metrics that have been received during the TTL period are still visible
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.InEpsilon(ct, 130/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 2, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 300, End: 310},
+	})
+
+	// makes sure that the records channel is emptied and any remaining
+	// old metric is sent and then the channel is re-emptied
+	otlp.ResetRecords()
+	readChan(t, otlp.Records())
+	otlp.ResetRecords()
+
+	// BUT not the metrics that haven't been received during that time.
+	// We just know it because OTEL will only sends foo/bar metric.
+	// If this test is flaky: it means it is actually failing
+	// repeating 10 times to make sure that only this metric is forwarded
+	for i := 0; i < 10; i++ {
+		metric := readChan(t, otlp.Records())
+		if metric.Name != "http.server.request.duration" {
+			// ignore other HTTP metrics (e.g. request size)
+			i--
+			continue
+		}
+		require.Equal(t, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		require.InEpsilon(t, 140/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(t, 3, metric.Count)
+	}
+
+	// AND WHEN the metrics labels that disappeared are received again
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 450, End: 520},
+	})
+
+	// THEN they are reported again, starting from zero in the case of counters
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 70/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+}
+
+// the expiration logic is held at two levels:
+// (1) by group of attributes within the same service Attrs,
+// (2) by metric set of a given service Attrs
+// this test verifies case 2
+func TestAppMetricsExpiration_BySvcID(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		TTL:               3 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations: []instrumentations.Instrumentation{
+			instrumentations.InstrumentationALL,
+		},
+	}
+	otelExporter, err := ReportMetrics(
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: cfg}},
+		cfg, &mpConfig,
+		&attributes.SelectorConfig{
+			SelectionCfg: attributes.Selection{
+				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
+					Include: []string{"url.path"},
+				},
+			},
+		}, request.UnresolvedNames{}, metrics, processEvents)(ctx)
+	require.NoError(t, err)
+
+	go otelExporter(ctx)
+
+	// WHEN it receives metrics
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 100, End: 200},
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "bar"}}, Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 150, End: 175},
+	})
+
+	// THEN the metrics are exported
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		assert.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.InEpsilon(ct, 100/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 25/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	// AND WHEN it keeps receiving a subset of the initial metrics during the TTL
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 250, End: 280},
+	})
+
+	// THEN THE metrics that have been received during the TTL period are still visible
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		require.Equal(ct, map[string]string{"url.path": "/foo"}, metric.Attributes)
+		assert.InEpsilon(ct, 130/float64(time.Second), metric.FloatVal, 0.001)
+		assert.Equal(ct, 2, metric.Count)
+	}, timeout, 100*time.Millisecond)
+
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 300, End: 310},
+	})
+
+	// BUT not the metrics that haven't been received during that time.
+	// We just know it because OTEL will only sends foo/bar metric.
+	// If this test is flaky: it means it is actually failing
+	// repeating 10 times to make sure that only this metric is forwarded
+	// need to wait until expireCache internal goroutine removes all the expired entries
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// makes sure that the records channel is emptied and any remaining
+		// old metric is sent and then the channel is re-emptied
+		otlp.ResetRecords()
+		readChan(ct, otlp.Records())
+		otlp.ResetRecords()
+		for i := 0; i < 10; i++ {
+			metric := readChan(ct, otlp.Records())
+			if metric.Name != "http.server.request.duration" {
+				// ignore other HTTP metrics (e.g. request size)
+				i--
+				continue
+			}
+			require.Equal(ct, map[string]string{"url.path": "/foo"}, metric.Attributes)
+			require.InEpsilon(ct, 140/float64(time.Second), metric.FloatVal, 0.001)
+			assert.Equal(ct, 3, metric.Count)
+		}
+	}, timeout, 100*time.Millisecond)
+	// AND WHEN the metrics labels that disappeared are received again
+	now.Advance(2 * time.Minute)
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{Features: export.FeatureAll, UID: svc.UID{Instance: "bar"}}, Type: request.EventTypeHTTP, Path: "/bar", RequestStart: 450, End: 520},
+	})
+
+	// THEN they are reported again, starting from zero in the case of counters
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		metric := readChan(ct, otlp.Records())
+		require.Equal(ct, "http.server.request.duration", metric.Name)
+		assert.Equal(ct, map[string]string{"url.path": "/bar"}, metric.Attributes)
+		assert.InEpsilon(ct, 70/float64(time.Second), metric.FloatVal, 0.0001)
+		assert.Equal(ct, 1, metric.Count)
+	}, timeout, 100*time.Millisecond)
+}
+
+type syncedClock struct {
+	mt  sync.Mutex
+	now time.Time
+}
+
+func (c *syncedClock) Now() time.Time {
+	c.mt.Lock()
+	defer c.mt.Unlock()
+	return c.now
+}
+
+func (c *syncedClock) Advance(t time.Duration) {
+	c.mt.Lock()
+	defer c.mt.Unlock()
+	c.now = c.now.Add(t)
+}
+
+func readChan(t require.TestingT, inCh <-chan collector.MetricRecord) collector.MetricRecord {
+	select {
+	case item := <-inCh:
+		return item
+	case <-time.After(timeout):
+		require.Failf(t, "timeout while waiting for event in input channel", "timeout: %s", timeout)
+	}
+	return collector.MetricRecord{}
+}

--- a/pkg/export/otel/metrics_appo11y.go
+++ b/pkg/export/otel/metrics_appo11y.go
@@ -1,0 +1,277 @@
+package otel
+
+import (
+	"context"
+	"debug/pe"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/metric"
+	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func mlog() *slog.Logger {
+	return slog.With("component", "otel.AppO11yHostInfoMetricsReporter")
+}
+
+const (
+	TracesHostInfo = "traces_host_info"
+)
+
+// GrafanaHostIDKey is the same attribute Key as HostIDKey, but used for
+// traces_target_info
+const GrafanaHostIDKey = attribute.Key("grafana.host.id")
+
+// MetricsReporter implements the graph node that receives request.Span
+// instances and forwards them as OTEL metrics.
+type MetricsReporter struct {
+	ctx              context.Context
+	cfg              *otelcfg.MetricsConfig
+	jointMetricsCfg  *perapp.MetricsConfig
+	hostID           string
+	attributes       *attributes.AttrSelector
+	exporter         sdkmetric.Exporter
+	hostInfo         *Expirer[*request.Span, instrument.Int64Gauge, int64]
+	targetInfo       instrument.Int64UpDownCounter
+	tracesTargetInfo instrument.Int64UpDownCounter
+	pidTracker       otel.PidServiceTracker
+	is               instrumentations.InstrumentationSelection
+	attrGetters      attributes.NamedGetters[*request.Span, attribute.KeyValue]
+	spanExtraAttrs   []attr.Name
+
+	input         <-chan []request.Span
+	processEvents <-chan exec.ProcessEvent
+
+	log *slog.Logger
+}
+
+func ReportAppO11yHostMetrics(
+	ctxInfo *global.ContextInfo,
+	cfg *otelcfg.MetricsConfig,
+	jointMetricsCfg *perapp.MetricsConfig,
+	selectorCfg *attributes.SelectorConfig,
+	unresolved request.UnresolvedNames,
+	input *msg.Queue[[]request.Span],
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
+		if !(cfg.EndpointEnabled() && jointMetricsCfg.Features.AppHost()) {
+			return swarm.EmptyRunFunc()
+		}
+		otelcfg.SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
+
+		mr, err := newMetricsReporter(
+			ctx,
+			ctxInfo,
+			cfg,
+			jointMetricsCfg,
+			selectorCfg,
+			unresolved,
+			input,
+			processEventCh,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
+		}
+
+		return mr.reportMetrics, nil
+	}
+}
+
+func newMetricsReporter(
+	ctx context.Context,
+	ctxInfo *global.ContextInfo,
+	cfg *otelcfg.MetricsConfig,
+	jointMetricsCfg *perapp.MetricsConfig,
+	selectorCfg *attributes.SelectorConfig,
+	unresolved request.UnresolvedNames,
+	input *msg.Queue[[]request.Span],
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) (*MetricsReporter, error) {
+	log := mlog()
+
+	attribProvider, err := attributes.NewAttrSelector(ctxInfo.MetricAttributeGroups, selectorCfg)
+	if err != nil {
+		return nil, fmt.Errorf("attributes select: %w", err)
+	}
+
+	is := instrumentations.NewInstrumentationSelection(cfg.Instrumentations)
+
+	mr := MetricsReporter{
+		ctx:             ctx,
+		cfg:             cfg,
+		jointMetricsCfg: jointMetricsCfg,
+		is:              is,
+		attributes:      attribProvider,
+		hostID:          ctxInfo.HostID,
+		input:           input.Subscribe(msg.SubscriberName("otelMetrics.InputSpans")),
+		processEvents:   processEventCh.Subscribe(msg.SubscriberName("otelMetrics.ProcessEvents")),
+		log:             mlog(),
+		attrGetters:     request.SpanOTELGetters(unresolved),
+	}
+
+	mr.spanExtraAttrs = []attr.Name{}
+	for _, label := range cfg.ExtraSpanResourceLabels {
+		mr.spanExtraAttrs = append(mr.spanExtraAttrs, attr.Name(label))
+	}
+
+	// Instantiate the OTLP HTTP or GRPC metrics exporter
+	exporter, err := ctxInfo.OTELMetricsExporter.Instantiate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	mr.exporter = exporter
+
+	mr.pidTracker = otel.NewPidServiceTracker()
+
+	systemMetrics := mr.newMetricsInstance(nil)
+	systemMeter := systemMetrics.provider.Meter(ReporterName)
+
+	if err := mr.setupHostInfoMeter(systemMeter); err != nil {
+		return nil, fmt.Errorf("setting up host metrics: %w", err)
+	}
+
+	return &mr, nil
+}
+
+func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
+	tracesHostInfo, err := meter.Int64Gauge(TracesHostInfo)
+	if err != nil {
+		return fmt.Errorf("creating span metric traces host info: %w", err)
+	}
+	attr := attributes.Field[*request.Span, attribute.KeyValue]{
+		ExposedName: string(GrafanaHostIDKey),
+		Get: func(_ *request.Span) attribute.KeyValue {
+			return semconv.HostID(mr.hostID)
+		},
+	}
+
+	mr.hostInfo = NewExpirer[*request.Span, instrument.Int64Gauge, int64](
+		mr.ctx, tracesHostInfo, []attributes.Field[*request.Span, attribute.KeyValue]{attr}, timeNow, mr.cfg.TTL)
+
+	return nil
+}
+
+func (mr *MetricsReporter) close() {
+	if err := mr.exporter.Shutdown(mr.ctx); err != nil {
+		slog.With("component", "MetricsReporter").Error("closing metrics provider", "error", err)
+	}
+}
+
+func (mr *MetricsReporter) setupPIDToServiceRelationship(pid app.PID, uid svc.UID) {
+	mr.pidTracker.AddPID(pid, uid)
+}
+
+func (mr *MetricsReporter) disassociatePIDFromService(pid app.PID) (bool, svc.UID) {
+	return mr.pidTracker.RemovePID(pid)
+}
+
+func (mr *MetricsReporter) reportMetrics(ctx context.Context) {
+	defer mr.close()
+	for {
+		select {
+		case <-ctx.Done():
+			mr.log.Debug("context done, stopping metrics reporting")
+			return
+		case pe, ok := <-mr.processEvents:
+			if !ok {
+				mr.log.Debug("process events channel closed, stopping metrics reporting")
+				return
+			}
+			mr.onProcessEvent(&pe)
+		case spans, ok := <-mr.input:
+			if !ok {
+				mr.log.Debug("input channel closed, stopping metrics reporting")
+				return
+			}
+			mr.onSpan(spans)
+		}
+	}
+}
+
+func (mr *MetricsReporter) onProcessEvent(pe *exec.ProcessEvent) {
+	mr.log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+
+	if pe.Type == exec.ProcessEventCreated {
+		uid := pe.File.Service.UID
+
+		// Handle the case when the PID changed its feathers, e.g. got new metadata impacting the service name.
+		// There's no new PID, just an update to the metadata.
+		if staleUID, exists := mr.pidTracker.TracksPID(pe.File.Pid); exists && !staleUID.Equals(&uid) {
+			mr.log.Debug("updating older service definition", "from", staleUID, "new", uid)
+			mr.pidTracker.ReplaceUID(staleUID, uid)
+			// we don't setup the pid again, we just replaced the metrics it's associated with
+			return
+		}
+		mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
+	} else {
+		if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
+			// We only need the UID to look up in the pool, no need to cache
+			// the whole of the attrs in the pidTracker
+			mr.log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", origUID)
+			if mr.hostInfo != nil && mr.pidTracker.Count() == 0 {
+				mlog().Debug("No more PIDs tracked, expiring host info metric")
+				mr.hostInfo.RemoveAllMetrics(mr.ctx)
+			}
+		}
+	}
+}
+
+func (mr *MetricsReporter) onSpan(spans []request.Span) {
+	for i := range spans {
+		s := &spans[i]
+		if s.InternalSignal() {
+			continue
+		}
+		if !s.Service.ExportModes.CanExportMetrics() {
+			continue
+		}
+		hostInfo, attrs := mr.hostInfo.ForRecord(s)
+		hostInfo.Record(mr.ctx, 1, instrument.WithAttributeSet(attrs))
+	}
+}
+
+func (mr *MetricsReporter) newMeterProvider(service *svc.Attrs) *metric.MeterProvider {
+	mlog := mlog()
+	var resourceAttributes []attribute.KeyValue
+	if service != nil {
+		mlog = mlog.With("service", service)
+		resourceAttributes = append(otelcfg.GetAppResourceAttrs(mr.hostID, service), otelcfg.ResourceAttrsFromEnv(service)...)
+	}
+	mlog.Debug("creating new Metrics reporter")
+	resources := resource.NewWithAttributes(semconv.SchemaURL, resourceAttributes...)
+
+	opts := []metric.Option{
+		metric.WithResource(resources),
+		metric.WithReader(metric.NewPeriodicReader(mr.exporter,
+			metric.WithInterval(mr.cfg.Interval))),
+	}
+
+	return Metrics{
+		ctx:     mr.ctx,
+		service: service,
+		provider: metric.NewMeterProvider(
+			opts...,
+		),
+	}
+}

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -228,7 +228,7 @@ func getFilteredProcessResourceAttrs(hostID string, procID *process.ID, attrSele
 
 func (me *procMetricsExporter) newMetricSet(procID *process.ID) (*procMetrics, error) {
 	log := me.log.With("service", procID.Service, "processID", procID.UID)
-	log.Debug("creating new Metrics exporter")
+	log.Debug("creating new AppO11yMetrics exporter")
 	resources := resource.NewWithAttributes(semconv.SchemaURL, getFilteredProcessResourceAttrs(me.hostID, procID, me.cfg.SelectorCfg.SelectionCfg)...)
 	opts := []metric.Option{
 		metric.WithResource(resources),

--- a/pkg/export/otel/metrics_proc_test.go
+++ b/pkg/export/otel/metrics_proc_test.go
@@ -32,7 +32,7 @@ func TestProcMetrics_Disaggregated(t *testing.T) {
 	otlp, err := collector.Start(ctx)
 	require.NoError(t, err)
 
-	// GIVEN an OTEL Metrics Exporter whose process CPU metrics consider the cpu.mode
+	// GIVEN an OTEL AppO11yMetrics Exporter whose process CPU metrics consider the cpu.mode
 	includedAttributes := attributes.InclusionLists{
 		Include: []string{"process_command", "cpu_mode", "disk_io_direction", "network_io_direction"},
 	}

--- a/pkg/export/otel/metrics_survey.go
+++ b/pkg/export/otel/metrics_survey.go
@@ -77,7 +77,7 @@ func newSurveyMetricsReporter(
 		processEvents: processEventsQueue.Subscribe(msg.SubscriberName("processEvents")),
 		pidTracker:    otel.NewPidServiceTracker(),
 	}
-	log.Debug("creating new Survey Metrics reporter")
+	log.Debug("creating new Survey AppO11yMetrics reporter")
 
 	var err error
 	smr.exporter, err = ctxInfo.OTELMetricsExporter.Instantiate(ctx)

--- a/pkg/export/prom/expirer.go
+++ b/pkg/export/prom/expirer.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prom // import "go.opentelemetry.io/obi/pkg/export/prom"
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"go.opentelemetry.io/obi/pkg/export/expire"
+)
+
+func plog() *slog.Logger {
+	return slog.With("component", "prom.Expirer")
+}
+
+// Expirer drops metrics from labels that haven't been updated during a given timeout
+type Expirer[T prometheus.Metric] struct {
+	entries *expire.ExpiryMap[*MetricEntry[T]]
+	wrapped *prometheus.MetricVec
+}
+
+type MetricEntry[T prometheus.Metric] struct {
+	Metric    T
+	LabelVals []string
+}
+
+// NewExpirer creates a metric that wraps a given CounterVec. Its labeled instances are dropped
+// if they haven't been updated during the last timeout period
+func NewExpirer[T prometheus.Metric](wrapped *prometheus.MetricVec, clock func() time.Time, expireTime time.Duration) *Expirer[T] {
+	return &Expirer[T]{
+		wrapped: wrapped,
+		entries: expire.NewExpiryMap[*MetricEntry[T]](clock, expireTime),
+	}
+}
+
+// WithLabelValues returns the Counter for the given slice of label
+// values (same order as the variable labels in Desc). If that combination of
+// label values is accessed for the first time, a new Counter is created.
+// If not, a cached copy is returned and the "last access" cache time is updated.
+func (ex *Expirer[T]) WithLabelValues(lbls ...string) *MetricEntry[T] {
+	return ex.entries.GetOrCreate(lbls, func() *MetricEntry[T] {
+		plog().With("labelValues", lbls).Debug("storing new metric label set")
+		c, err := ex.wrapped.GetMetricWithLabelValues(lbls...)
+		// same behavior as specific WithLabelValues implementations
+		// no need to return the error
+		if err != nil {
+			panic(err)
+		}
+		return &MetricEntry[T]{
+			Metric:    c.(T),
+			LabelVals: lbls,
+		}
+	})
+}
+
+// Describe wraps prometheus.Collector Describe method
+func (ex *Expirer[T]) Describe(descs chan<- *prometheus.Desc) {
+	ex.wrapped.Describe(descs)
+}
+
+// Collect wraps prometheus.Collector Wrap method
+func (ex *Expirer[T]) Collect(metrics chan<- prometheus.Metric) {
+	log := plog()
+	for _, old := range ex.entries.DeleteExpired() {
+		ex.wrapped.DeleteLabelValues(old.LabelVals...)
+		log.With("labelValues", old).Debug("deleting old Prometheus metric")
+	}
+	for _, m := range ex.entries.All() {
+		metrics <- m.Metric
+	}
+}

--- a/pkg/export/prom/prom_appo11y.go
+++ b/pkg/export/prom/prom_appo11y.go
@@ -1,0 +1,219 @@
+package prom
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/connector"
+	"go.opentelemetry.io/obi/pkg/export/expire"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/export/prom"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+)
+
+// using labels and names that are equivalent names to the OTEL attributes
+// but following the different naming conventions
+const (
+	TracesHostInfo   = "traces_host_info"
+	grafanaHostIDKey = "grafana_host_id"
+)
+
+var (
+	hostInfoLabelNames = []string{grafanaHostIDKey}
+)
+
+func ahilog() *slog.Logger {
+	return slog.With("component", "prom.AppO11yHostInfoMetricsReporter")
+}
+
+type appO11yHostInfoReporter struct {
+	log                     *slog.Logger
+	cfg                     *prom.PrometheusConfig
+	extraMetadataLabels     []attr.Name
+	extraSpanMetadataLabels []attr.Name
+
+	input         <-chan []request.Span
+	processEvents <-chan exec.ProcessEvent
+
+	// trace span metrics
+	tracesHostInfo *Expirer[prometheus.Gauge]
+
+	promConnect *connector.PrometheusManager
+
+	clock   *expire.CachedClock
+	ctxInfo *global.ContextInfo
+
+	is instrumentations.InstrumentationSelection
+
+	kubeEnabled   bool
+	dockerEnabled bool
+	hostID        string
+
+	pidsTracker otel.PidServiceTracker
+}
+
+func AppO11yHostInfoMetricsReporter(
+	ctxInfo *global.ContextInfo,
+	cfg *prom.PrometheusConfig,
+	jointMetricsConfig *perapp.MetricsConfig,
+	selectorCfg *attributes.SelectorConfig,
+	unresolved request.UnresolvedNames,
+	input *msg.Queue[[]request.Span],
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) swarm.InstanceFunc {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
+		if !cfg.EndpointEnabled() || !jointMetricsConfig.Features.AppHost() {
+			return swarm.EmptyRunFunc()
+		}
+		reporter, err := newReporter(ctx, ctxInfo, cfg, jointMetricsConfig, selectorCfg, unresolved, input, processEventCh)
+		if err != nil {
+			return nil, fmt.Errorf("instantiating Prometheus endpoint: %w", err)
+		}
+		if cfg.Registry != nil {
+			return reporter.collectMetrics, nil
+		}
+		return reporter.reportMetrics, nil
+	}
+}
+
+//nolint:cyclop
+func newReporter(
+	ctx context.Context,
+	ctxInfo *global.ContextInfo,
+	cfg *prom.PrometheusConfig,
+	jointMetricsConfig *perapp.MetricsConfig,
+	selectorCfg *attributes.SelectorConfig,
+	unresolved request.UnresolvedNames,
+	input *msg.Queue[[]request.Span],
+	processEventCh *msg.Queue[exec.ProcessEvent],
+) (*appO11yHostInfoReporter, error) {
+	groups := ctxInfo.MetricAttributeGroups
+	groups.Add(attributes.GroupPrometheus)
+
+	is := instrumentations.NewInstrumentationSelection(cfg.Instrumentations)
+
+	kubeEnabled := ctxInfo.K8sInformer.IsKubeEnabled()
+	dockerEnabled := ctxInfo.DockerMetadata.IsEnabled(ctx)
+
+	clock := expire.NewCachedClock(timeNow)
+
+	extraMetadataLabels := parseExtraMetadata(cfg.ExtraResourceLabels)
+	extraSpanMetadataLabels := parseExtraMetadata(cfg.ExtraSpanResourceLabels)
+	mr := &appO11yHostInfoReporter{
+		log:                     ahilog(),
+		input:                   input.Subscribe(msg.SubscriberName("prom.InputSpans")),
+		processEvents:           processEventCh.Subscribe(msg.SubscriberName("prom.ProcessEvents")),
+		pidsTracker:             otel.NewPidServiceTracker(),
+		ctxInfo:                 ctxInfo,
+		cfg:                     cfg,
+		kubeEnabled:             kubeEnabled,
+		dockerEnabled:           dockerEnabled,
+		extraMetadataLabels:     extraMetadataLabels,
+		extraSpanMetadataLabels: extraSpanMetadataLabels,
+		hostID:                  ctxInfo.HostID,
+		clock:                   clock,
+		is:                      is,
+		promConnect:             ctxInfo.Prometheus,
+		tracesHostInfo: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: TracesHostInfo,
+			Help: "A metric with a constant '1' value labeled by the host id ",
+		}, hostInfoLabelNames).MetricVec, clock.Time, cfg.TTL),
+	}
+
+	if mr.cfg.Registry != nil {
+		mr.cfg.Registry.MustRegister(mr.tracesHostInfo)
+	} else {
+		mr.promConnect.Register(cfg.Port, cfg.Path, mr.tracesHostInfo)
+	}
+
+	return mr, nil
+}
+
+func optionalGaugeProvider(enable bool, provider func() *Expirer[prometheus.Gauge]) *Expirer[prometheus.Gauge] {
+	if !enable {
+		return nil
+	}
+
+	return provider()
+}
+
+func (r *appO11yHostInfoReporter) reportMetrics(ctx context.Context) {
+	go r.promConnect.StartHTTP(ctx)
+	r.collectMetrics(ctx)
+}
+
+func (r *appO11yHostInfoReporter) collectMetrics(ctx context.Context) {
+	go r.watchForProcessEvents(ctx)
+	swarms.ForEachInput(ctx, r.input, r.log.Debug, func(spans []request.Span) {
+		// clock needs to be updated to let the expirer
+		// remove the old metrics
+		r.clock.Update()
+		for i := range spans {
+			r.observe(&spans[i])
+		}
+	})
+}
+
+func (r *appO11yHostInfoReporter) otelSpanFiltered(span *request.Span) bool {
+	return span.InternalSignal() || request.IgnoreMetrics(span)
+}
+
+//nolint:cyclop
+func (r *appO11yHostInfoReporter) observe(span *request.Span) {
+	if r.otelSpanFiltered(span) {
+		return
+	}
+	if !span.Service.ExportModes.CanExportMetrics() {
+		return
+	}
+	if span.Service.Features.AppHost() {
+		r.tracesHostInfo.WithLabelValues(r.hostID).Metric.Set(1.0)
+	}
+}
+
+func (r *appO11yHostInfoReporter) watchForProcessEvents(ctx context.Context) {
+	log := r.log.With("function", "watchForProcessEvents")
+	swarms.ForEachInput(ctx, r.processEvents, log.Debug, func(pe exec.ProcessEvent) {
+		r.handleProcessEvent(pe, log)
+	})
+}
+
+func (r *appO11yHostInfoReporter) disassociatePIDFromService(pid app.PID) (bool, svc.UID) {
+	return r.pidsTracker.RemovePID(pid)
+}
+
+func (r *appO11yHostInfoReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Logger) {
+	log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+	uid := pe.File.Service.UID
+
+	if pe.Type == exec.ProcessEventCreated {
+		// Handle the case when the PID changed its feathers, e.g. got new metadata impacting the service name.
+		// There's no new PID, just an update to the metadata.
+		if staleUID, exists := r.pidsTracker.TracksPID(pe.File.Pid); exists && !staleUID.Equals(&uid) {
+			log.Debug("updating older service definition", "from", staleUID, "new", uid)
+			r.pidsTracker.ReplaceUID(staleUID, uid)
+			return
+		}
+	} else {
+		if deleted, _ := r.disassociatePIDFromService(pe.File.Pid); deleted {
+			r.log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+			if r.pidsTracker.Count() == 0 {
+				r.log.Debug("No more PIDs tracked, expiring host info metric")
+				r.tracesHostInfo.entries.DeleteAll()
+			}
+		}
+	}
+}


### PR DESCRIPTION
Traces_host_info is a metric reported in OBI but it's specific to Grafana App O11y.

This PR will be required when the metric is removed from OBI.