### PR TITLE
ci: fix bot permissions with id-token write

### DIFF
--- a/.github/workflows/bot_sync-obi-fork.yml
+++ b/.github/workflows/bot_sync-obi-fork.yml
@@ -10,13 +10,15 @@ concurrency:
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   sync-fork:
     name: Sync grafana/opentelemetry-ebpf-instrumentation with upstream
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for create-github-app-token
     steps:
       - name: Get GitHub App token
         id: get-github-app-token

--- a/.github/workflows/bot_sync-obi-submodule.yml
+++ b/.github/workflows/bot_sync-obi-submodule.yml
@@ -10,8 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update-obi:
@@ -20,7 +19,7 @@ jobs:
     permissions:
       contents: write # Needed for creating commits and pushing branch
       pull-requests: write # Needed for creating PRs
-      id-token: write # Required for DockerHub login
+      id-token: write # Required for DockerHub login and create-github-app-token
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Fix [permissions error](https://github.com/grafana/beyla/actions/runs/22188267159/job/64168223166):

```
Error: Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```