### PR TITLE
ci: dump github api response on failure

### DIFF
--- a/.github/workflows/bot_sync-obi-fork.yml
+++ b/.github/workflows/bot_sync-obi-fork.yml
@@ -30,9 +30,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
         run: |
-          curl -sSf -X POST \
+          HTTP=$(curl -sS -w '%{http_code}' -o /tmp/merge-upstream.json -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/grafana/opentelemetry-ebpf-instrumentation/merge-upstream \
-            -d '{"branch":"main"}'
+            -d '{"branch":"main"}')
+          if [ "$HTTP" = "200" ]; then
+            echo "Fork synced successfully"
+            exit 0
+          fi
+          echo "Merge-upstream failed: HTTP $HTTP"
+          cat /tmp/merge-upstream.json
+          exit 1


### PR DESCRIPTION
Trying to debug run failure:

```
curl: (22) The requested URL returned error: 422
```