### PR TITLE
Fix: claude-code-action tool permissions in agent_fix-obi workflow

### DIFF
--- a/.github/workflows/agent_fix-obi.yml
+++ b/.github/workflows/agent_fix-obi.yml
@@ -65,10 +65,28 @@ jobs:
           # Enable commit signing so Claude can push fixes to the PR branch
           # directly via the GitHub API (no persist-credentials needed).
           use_commit_signing: "true"
+          # Tool permissions via settings (not claude_args --allowedTools)
+          # because the SDK's allowedTools parameter does not support
+          # Bash(X) pattern matching, causing all Bash calls to be denied.
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(cat)", "Bash(date)", "Bash(echo)", "Bash(gh)",
+                  "Bash(git diff)", "Bash(git log)", "Bash(git show)",
+                  "Bash(git status)", "Bash(git submodule)", "Bash(git rev-parse)",
+                  "Bash(go)", "Bash(grep)", "Bash(head)", "Bash(ls)",
+                  "Bash(make)", "Bash(pwd)", "Bash(sort)", "Bash(tail)",
+                  "Bash(uniq)", "Bash(wc)",
+                  "Edit", "MultiEdit", "Glob", "Grep", "LS",
+                  "Read", "Write", "Task", "TodoWrite",
+                  "mcp__github_file_ops__commit_changes",
+                  "mcp__github_file_ops__create_or_update_file"
+                ]
+              }
+            }
           claude_args: >-
             --max-turns 30
-            --allowedTools
-            "Bash(cat),Bash(date),Bash(echo),Bash(gh),Bash(git diff),Bash(git log),Bash(git show),Bash(git status),Bash(git submodule),Bash(git rev-parse),Bash(go),Bash(grep),Bash(head),Bash(ls),Bash(make),Bash(pwd),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),Edit,MultiEdit,Glob,Grep,LS,Read,Write,Task,TodoWrite"
           prompt: |
             # Fix OBI submodule CI
 


### PR DESCRIPTION
## Problem
The agent_fix-obi workflow (used to auto-fix OBI submodule CI failures) was failing on PR #2548 because all Bash tool calls were being denied. The agent hit the 30-turn limit (error_max_turns) without making any progress.

## Root Cause
Tool permissions were configured via `--allowedTools` in claude_args, but the Claude Code SDK's allowedTools parameter does not support Bash(X) pattern matching (e.g., `Bash(gh)`, `Bash(go)`). The patterns were parsed into the SDK array but failed at runtime, causing all Bash calls to be rejected.

## Solution
Moved tool permissions to the `settings` input where Claude Code's own permission system properly supports Bash(X) pattern matching. Also added mcp__github_file_ops MCP server permissions required for commit signing.

## Testing
This fix enables the workflow to properly grant Bash tool access when triggered on future OBI submodule update PRs.