### PR TITLE
Add checksum override for beyla config

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.11.0
+version: 1.12.0
 appVersion: 2.8.4
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -25,6 +25,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | used for scheduling of pods based on affinity rules |
+| config.checksum | string | `""` | Use `tpl` so parent charts can pass templated checksums. |
 | config.create | bool | `true` | set to true, to use the below default configurations |
 | config.data | object | `{"attributes":{"kubernetes":{"enable":true}},"filter":{"network":{"k8s_dst_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"},"k8s_src_owner_name":{"not_match":"{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}"}}},"prometheus_export":{"path":"/metrics","port":9090}}` | default value of beyla configuration |
 | config.name | string | `""` |  |

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -25,7 +25,11 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.config.checksum }}
+        checksum/config: {{ tpl .Values.config.checksum $ }}
+        {{- else }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/beyla/tests/unit/daemon-set.yaml
+++ b/charts/beyla/tests/unit/daemon-set.yaml
@@ -34,3 +34,27 @@ tests:
           of: DaemonSet
       - notExists:
           path: spec.minReadySeconds
+
+  - it: should use checksum override when provided
+    template: daemon-set.yaml
+    set:
+      config:
+        checksum: "custom-sum"
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: spec.template.metadata.annotations.checksum/config
+          value: custom-sum
+
+  - it: should default checksum to configmap hash when override empty
+    template: daemon-set.yaml
+    set:
+      config:
+        checksum: ""
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - matchRegex:
+          path: spec.template.metadata.annotations.checksum/config
+          pattern: "^[a-f0-9]{64}$"

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -202,6 +202,9 @@ config:
   ## `kubectl create cm --from-file=beyla-config.yaml=<name-of-config-file> -n <namespace>`
   ## If empty, default configuration below is used.
   name: ""
+  # -- Optional checksum override for external configmap usage.
+  # -- Use `tpl` so parent charts can pass templated checksums.
+  checksum: ""
   # -- default value of beyla configuration
   data:
     # profile_port: 6060


### PR DESCRIPTION
Adds a config checksum override for the Beyla DaemonSet so parent charts can drive rollouts when using external configmaps. Updates values/README to document the new option and adds unit tests for override and fallback hashing. Bumps the chart version to 1.12.0.

Tested on a local kind cluster:

```shell
# deploy beyla helm chart with default values to default namespace
helm install beyla ./charts/beyla

# flip one default value with default checksum behaviour, confirm restart OK
helm upgrade beyla ./charts/beyla --set "config.data.attributes.kubernetes.enabled=false"

# set custom checksum, confirm restart OK
helm upgrade beyla ./charts/beyla --set "config.checksum=one"

# set same custom checksum, confirm no restart OK
helm upgrade beyla ./charts/beyla --set "config.checksum=one"

# set new custom checksum, confirm restart OK
helm upgrade beyla ./charts/beyla --set "config.checksum=two"
```

Fixes #2128