### PR TITLE
agent/fix-obi: sync tests to OBI upstream before patching assertions

### DIFF
--- a/.github/workflows/agent_fix-obi.yml
+++ b/.github/workflows/agent_fix-obi.yml
@@ -204,6 +204,12 @@ jobs:
 
             ## Diagnostic patterns
 
+            **Test failures — sync before patch:**
+            When a Beyla test fails on an assertion, **do not** simply adjust the assertion to make it pass. First, locate the corresponding test in OBI (`.obi-src/`) and compare the failing test block with its upstream version:
+            - If the test block (or the specific sub-case / table entry within it) has been **removed** in OBI, the correct fix is to **remove the same block** from Beyla's copy of the test (applying the OBI→Beyla translation rules from `scripts/generate-obi-tests.sh`). Do not patch the assertion.
+            - If the test block still exists in OBI but the assertion is now wrong (e.g., a changed return value or behaviour), **then** adjust the assertion to match the new OBI behaviour.
+            The general principle is: Beyla's generated tests shadow OBI's tests. When OBI changes a test, Beyla's version should be updated to match — not worked around with a minimal assertion fix that hides the upstream intent.
+
             **Config struct parity (most common cause of timeouts):**
             Beyla mirrors OBI config structs and uses `pkg/helpers/config/convert.go` (`Convert()`) to copy between them. This converter **panics if the destination struct has an exported field the source does not have** (and vice versa). When OBI adds new config fields, Beyla's mirror must be updated with matching fields (`BEYLA_`-prefixed env tags, matching defaults). A startup panic in k8s-cache manifests as **test timeouts** — the cache process is dead and Beyla never receives K8s metadata, so tests hang rather than showing a panic.
 


### PR DESCRIPTION
## Summary

- Adds a "sync before patch" rule to the plan step of the `fix-obi` agent workflow
- Prevents the agent from silently patching a failing test assertion when the correct fix is to remove the test block entirely (because OBI removed it upstream)

## Context

When an OBI commit removes a feature/option, its test block is also removed upstream. Previously, the plan agent could see a failing Beyla assertion and produce a plan to adjust it (e.g. `assert.False(...)`) — technically making it green, but diverging from upstream intent.

The new rule instructs the agent to first locate the same test in `.obi-src/`, compare the failing block against the OBI version, and:
- **Remove the block** if OBI removed it (applying the normal OBI→Beyla translation rules)
- **Adjust the assertion** only if the block still exists in OBI but the expected value changed

## Example that motivated this change

`TestWillUseTC` in Beyla's `config_test.go` — OBI removed the `"ip"` sub-case in
`open-telemetry/opentelemetry-ebpf-instrumentation@56db2407`, but the agent patched
the assertion instead of removing the block.
