### PR TITLE
ci: use renovate gomodMassage option

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:best-practices", "helpers:pinGitHubActionDigestsToSemver"],
+  postUpdateOptions: ["gomodMassage"],
   ignorePaths: [
     // OBI submodule - managed by submodule updates, not Renovate
     ".obi-src/**",


### PR DESCRIPTION
This [comment](https://github.com/grafana/beyla/pull/2561#issuecomment-3981502355) on the renovate PR indicates that the bot run `go get -t ./...` to update dependencies as it does not checkout the OBI submodule:

```
Command failed: go get -t ./...
go: go.opentelemetry.io/obi@v0.5.0 (replaced by ./.obi-src): reading .obi-src/go.mod: open /tmp/renovate/repos/github/grafana/beyla/.obi-src/go.mod: no such file or directory
```

This PR adds [postUpdateOptions](https://docs.renovatebot.com/modules/manager/gomod/#post-update-options) `gomodMassage` which allows renovate to temporarily ignore the OBI submodule during dependency updates.