### PR TITLE
ci: increase timeout minutes to 45

### DIFF
--- a/.github/workflows/agent_fix-obi.yml
+++ b/.github/workflows/agent_fix-obi.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -130,7 +130,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -260,7 +260,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
   generate:
     name: Generate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     # Grant specific permissions needed for DockerHub login via Vault OIDC
@@ -75,7 +75,7 @@ jobs:
     name: Lint
     needs: generate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -108,7 +108,7 @@ jobs:
     name: "Unit test ${{ matrix.description }}"
     needs: generate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Grant specific permissions needed only for this job
     permissions:
       contents: read

--- a/.github/workflows/pull_request_beyla_integration_tests.yml
+++ b/.github/workflows/pull_request_beyla_integration_tests.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -32,7 +32,7 @@ jobs:
   test-matrix:
     name: "Build integration matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.description }}
     needs: test-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Grant specific permissions needed only for this job
     permissions:
       contents: read

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -32,7 +32,7 @@ jobs:
   test-matrix:
     name: "Build ARM integration matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     name: ${{ matrix.description }}
     needs: test-matrix
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Grant specific permissions needed only for this job
     permissions:
       contents: read

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -32,7 +32,7 @@ jobs:
   test-matrix:
     name: "Build integration k8s matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -54,7 +54,7 @@ jobs:
     name: ${{ matrix.basename }}
     needs: test-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Grant specific permissions needed only for this job
     permissions:
       contents: read

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -31,7 +31,7 @@ jobs:
   test-matrix:
     name: "Build oats matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -53,7 +53,7 @@ jobs:
     name: ${{ matrix.basename }}
     needs: test-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -24,7 +24,7 @@ jobs:
   vm-test-matrix:
     name: "Build VM integration matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -54,7 +54,7 @@ jobs:
   test:
     name: kernel ${{ matrix.kernel.kernel-version }} ${{ matrix.kernel.arch }} ${{ matrix.test.description }}
     needs: vm-test-matrix
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Some runners are slower than others, apply the same change as was done in OBI.