### PR TITLE
ci: increase concurrency group uniqueness

### DIFF
--- a/.github/workflows/agent_fix-obi.yml
+++ b/.github/workflows/agent_fix-obi.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  group: "fix-obi-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bot_sync-obi-fork.yml
+++ b/.github/workflows/bot_sync-obi-fork.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sync-obi-fork-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/bot_sync-obi-submodule.yml
+++ b/.github/workflows/bot_sync-obi-submodule.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sync-obi-submodule-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main", "release-*"]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: pull-request-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request_beyla_integration_tests.yml
+++ b/.github/workflows/pull_request_beyla_integration_tests.yml
@@ -19,7 +19,7 @@ on:
       - ".github/workflows/pull_request_beyla_integration_tests.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: beyla-integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -21,7 +21,7 @@ on:
       - ".obi-src/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -21,7 +21,7 @@ on:
       - ".obi-src/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: integration-tests-arm-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -21,7 +21,7 @@ on:
       - ".obi-src/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: k8s-integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Set restrictive permissions at workflow level

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -21,7 +21,7 @@ on:
       - ".obi-src/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: oats-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_test_docker_build.yml
+++ b/.github/workflows/pull_request_test_docker_build.yml
@@ -4,7 +4,7 @@ on:
     branches: ["main", "release-*"]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: docker-build-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -14,7 +14,7 @@ on:
       - ".obi-src/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: vm-integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Porting the same from OBI that hardcodes the concurrency group prefixes to prevent release workflows from being interrupted by parallel PR workflows.