### PR TITLE
Bump versions/ fix CVEs

### DIFF
--- a/configs/offsets/kafkago/go.mod
+++ b/configs/offsets/kafkago/go.mod
@@ -1,6 +1,6 @@
 module kafkago_off
 
-go 1.25.6
+go 1.25.8
 
 require github.com/segmentio/kafka-go v0.4.50
 

--- a/configs/offsets/redis/go.mod
+++ b/configs/offsets/redis/go.mod
@@ -1,6 +1,6 @@
 module grafana.com/goredis
 
-go 1.25.6
+go 1.25.8
 
 require github.com/redis/go-redis/v9 v9.18.0
 

--- a/configs/offsets/sarama/go.mod
+++ b/configs/offsets/sarama/go.mod
@@ -1,6 +1,6 @@
 module sarama_off
 
-go 1.25.6
+go 1.25.8
 
 require github.com/IBM/sarama v1.47.0
 

--- a/configs/offsets/shopify/go.mod
+++ b/configs/offsets/shopify/go.mod
@@ -1,6 +1,6 @@
 module shopify_sarama_off
 
-go 1.25.6
+go 1.25.8
 
 require github.com/Shopify/sarama v1.37.1
 

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5 as builder
+FROM golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 as builder
 
 ARG TARGETARCH
 

--- a/internal/test/beyla_extensions/components/beyla-k8s-cache/Dockerfile
+++ b/internal/test/beyla_extensions/components/beyla-k8s-cache/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/beyla_extensions/components/beyla/Dockerfile
+++ b/internal/test/beyla_extensions/components/beyla/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/beyla_extensions/components/beyla/Dockerfile-with-javaagent
+++ b/internal/test/beyla_extensions/components/beyla/Dockerfile-with-javaagent
@@ -15,7 +15,7 @@ RUN gradle build --no-daemon
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/beyla_extensions/components/beyla/Dockerfile_dbg
+++ b/internal/test/beyla_extensions/components/beyla/Dockerfile_dbg
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/beyla/Dockerfile
+++ b/internal/test/integration/components/beyla/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/beyla/Dockerfile_dbg
+++ b/internal/test/integration/components/beyla/Dockerfile_dbg
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 

--- a/k8scache.Dockerfile
+++ b/k8scache.Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary for the k8s-cache service
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.1@sha256:c42e4d75186af6a44eb4159dcfac758ef1c05a7011a0052fe8a8df016d8e8fb9 AS builder
 
 ARG TARGETARCH
 ENV GOARCH=$TARGETARCH


### PR DESCRIPTION
Bumps Go from 1.25.x to 1.25.8 (and 1.26.0 to 1.26.1) across all
go.mod files and Dockerfiles.

Fixes:
- CVE-2026-25679 (net/url host validation bypass, CVSS 7.5 HIGH)
- CVE-2026-27137 (crypto/x509 email constraint bypass, CVSS 7.5 HIGH) — affects 1.26.0 only
- CVE-2026-27142 (html/template XSS via meta content attribute, CVSS 6.1 MEDIUM)
- CVE-2026-27139 (os.Root sandbox metadata leak, CVSS 2.5 LOW)

Companion fix in opentelemetry-ebpf-instrumentation: open-telemetry/opentelemetry-ebpf-instrumentation#1599