### PR TITLE
fix: rewrite all go.mod OBI oats references to Beyla module path

### DIFF
--- a/scripts/generate-obi-tests.sh
+++ b/scripts/generate-obi-tests.sh
@@ -569,8 +569,10 @@ adjust_oats_compose_paths() {
 rewrite_oats_go_mod() {
     echo "  Rewriting OATs go.mod files..."
     find "$OATS_DEST" -name "go.mod" -type f | while read -r modfile; do
-        # Rewrite module path: OBI → Beyla convention (no /v3 for standalone test modules)
-        sed_i -e "s|module ${OBI_MODULE}/internal/test/oats|module github.com/grafana/beyla/internal/testgenerated/oats|g" "$modfile"
+        # Rewrite all OBI oats module references (module declarations, require, and replace
+        # directives) to the Beyla module path. Use ${BEYLA_MODULE} (with /v3) to match
+        # the Go import transforms applied to .go files by transform_oats_go_files().
+        sed_i -e "s|${OBI_MODULE}/internal/test/oats|${BEYLA_MODULE}/internal/testgenerated/oats|g" "$modfile"
     done
 }
 


### PR DESCRIPTION
The rewrite_oats_go_mod() function only matched lines starting with "module ", leaving require/replace directives pointing at the OBI module path (go.opentelemetry.io/obi/...) instead of the Beyla path. It also hardcoded "github.com/grafana/beyla" without "/v3", causing a three-way mismatch between harness/go.mod, shard go.mod directives, and oats_test.go imports.

Fix: drop the "module " prefix from the sed pattern so all occurrences in go.mod files are rewritten, and replace the hardcoded path with ${BEYLA_MODULE} (which includes /v3) to match transform_oats_go_files().