### PR TITLE
fix: add packages write permission to inject-sdk-image workflow

### DIFF
--- a/.github/workflows/publish_inject_sdk_image_manual.yml
+++ b/.github/workflows/publish_inject_sdk_image_manual.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 concurrency:
   group: publish-inject-sdk-image-${{ github.event.inputs.version || 'auto' }}


### PR DESCRIPTION
The workflow was failing with "permission_denied: write_package" error because the workflow-level permissions only granted packages:read. While individual jobs specified packages:write, the more restrictive workflow-level permissions took precedence.
