### PR TITLE
Replace inject-sdk-image version in webhook example

### DIFF
--- a/pkg/webhook/example/beyla.yaml
+++ b/pkg/webhook/example/beyla.yaml
@@ -86,7 +86,7 @@ data:
         key_path: /etc/webhook/certs/tls.key
       instrument:
         - k8s_namespace: "*"
-      sdk_package_version: v0.0.7
+      sdk_package_version: v0.0.8
       host_mount_path: /var/lib/beyla/instrumentation
     discovery:
       services:
@@ -143,10 +143,10 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
         - name: populate-instrumentation
-          image: ghcr.io/grafana/beyla/inject-sdk-image:0.0.7
+          image: ghcr.io/grafana/beyla/inject-sdk-image:0.0.8
           env:
             - name: SDK_PKG_VERSION
-              value: "v0.0.7"
+              value: "v0.0.8"
             - name: MOUNT_PATH
               value: "/var/lib/beyla/instrumentation"
           volumeMounts:


### PR DESCRIPTION
inject-sdk-image:0.0.7 references to a vulnerable OTEL Java SDK. We published version 0.0.8 and this PR references to it in the webhook example.