### PR TITLE
build: pin envtest version for Go 1.25.8 compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ prereqs: install-hooks bpf2go
 	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses/v2,v2.0.1)
 	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,v0.20.0)
 	$(call go-install-tool,$(DASHBOARD_LINTER),github.com/grafana/dashboard-linter,latest)
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,v0.0.0-20260305142021-f9589b9f2b9d) # pin for Go 1.25.8 compatibility
 	$(call go-install-tool,$(GOTESTSUM),gotest.tools/gotestsum,v1.13.0)
 
 .PHONY: fmt


### PR DESCRIPTION
Looks like envtest `latest` now requires Go 1.26, which we don't have yet

```
Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331131016-598e330bda55
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260331131016-598e330bda55 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
make: *** [Makefile:137: prereqs] Error 1
Error: Process completed with exit code 2.
```