### PR TITLE
pin beyla .obi-src to OBI release branch tip, not main SHA

### DIFF
--- a/scripts/release-train.sh
+++ b/scripts/release-train.sh
@@ -665,7 +665,10 @@ prepare_command() {
     local obi_release_branch="release-$(version_without_v "$OBI_VERSION")"
 
     prepare_obi_branch "$OBI_VERSION" "$obi_release_branch" "$obi_sha"
-    prepare_beyla_branch "$BEYLA_VERSION" "$beyla_release_branch" "$obi_sha"
+    local obi_release_sha
+    obi_release_sha="$(git -C "$OBI_DIR" rev-parse HEAD)"
+    log_info "OBI release branch tip SHA: ${obi_release_sha}"
+    prepare_beyla_branch "$BEYLA_VERSION" "$beyla_release_branch" "$obi_release_sha"
 
     log_info "Release branches prepared: beyla_version=${BEYLA_VERSION}, beyla_branch=${beyla_release_branch}, obi_version=${OBI_VERSION}, obi_branch=${obi_release_branch}"
 


### PR DESCRIPTION
After `prepare_obi_branch` runs, the OBI release branch may have additional commits on top of the original `obi_sha` (e.g. generated artifacts). The beyla release branch was being wired to `obi_sha` (the SHA pinned in beyla main) rather than the actual tip of the newly created OBI release branch.

Fix: capture git rev-parse HEAD in the OBI working directory after prepare_obi_branch returns and use that SHA when updating the .obi-src submodule pointer in the beyla release branch.