### PR TITLE
feat: add geoip to attribute set

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -298,4 +298,7 @@ func attributeGroups(config *beyla.Config, ctxInfo *global.ContextInfo) {
 	if config.NetworkFlows.CIDRs.Enabled() {
 		ctxInfo.MetricAttributeGroups.Add(attributes.GroupNetCIDR)
 	}
+	if config.NetworkFlows.GeoIP.Enabled() {
+		ctxInfo.MetricAttributeGroups.Add(attributes.GroupNetGeoIP)
+	}
 }


### PR DESCRIPTION
This allows beyla (& alloy) to use the geoip lookup functionality present in obi