### PR TITLE
Helm chart: derive version label from image.tag when set

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.16.1
+version: 1.16.2
 appVersion: 3.8.0
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.16.1](https://img.shields.io/badge/Version-1.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
+![Version: 1.16.2](https://img.shields.io/badge/Version-1.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 

--- a/charts/beyla/templates/_helpers.tpl
+++ b/charts/beyla/templates/_helpers.tpl
@@ -42,14 +42,26 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Effective version for beyla (prefers image.tag over Chart appVersion).
+*/}}
+{{- define "beyla.version" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Effective version for beyla-k8s-cache (prefers k8sCache.image.tag over Chart appVersion).
+*/}}
+{{- define "beyla.k8sCache.version" -}}
+{{- .Values.k8sCache.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "beyla.labels" -}}
 helm.sh/chart: {{ include "beyla.chart" . }}
 {{ include "beyla.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ include "beyla.version" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: beyla
 {{- end }}
@@ -89,7 +101,7 @@ Calculate name of image ID to use for "beyla".
 {{- else if .Values.image.tag }}
 {{- printf ":%s" .Values.image.tag }}
 {{- else }}
-{{- printf ":%s" .Chart.AppVersion }}
+{{- printf ":%s" (include "beyla.version" .) }}
 {{- end }}
 {{- end }}
 
@@ -106,7 +118,7 @@ Calculate name of image ID to use for "beyla-cache".
 {{- else if .Values.k8sCache.image.tag }}
 {{- printf ":%s" .Values.k8sCache.image.tag }}
 {{- else }}
-{{- printf ":%s" .Chart.AppVersion }}
+{{- printf ":%s" (include "beyla.k8sCache.version" .) }}
 {{- end }}
 {{- end }}
 
@@ -116,9 +128,7 @@ Common kube cache labels
 {{- define "beyla.cache.labels" -}}
 helm.sh/chart: {{ include "beyla.chart" . }}
 {{ include "beyla.cache.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ include "beyla.k8sCache.version" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: beyla
 {{- end }}

--- a/charts/beyla/tests/unit/cache-deployment.yaml
+++ b/charts/beyla/tests/unit/cache-deployment.yaml
@@ -99,3 +99,17 @@ tests:
           of: Deployment
       - notExists:
           path: spec.template.spec.affinity
+
+  - it: should use k8sCache.image.tag for version label when set
+    template: cache-deployment.yaml
+    set:
+      k8sCache:
+        replicas: 1
+        image:
+          tag: "custom"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: "custom"

--- a/charts/beyla/tests/unit/daemon-set.yaml
+++ b/charts/beyla/tests/unit/daemon-set.yaml
@@ -58,3 +58,15 @@ tests:
       - matchRegex:
           path: spec.template.metadata.annotations.checksum/config
           pattern: "^[a-f0-9]{64}$"
+
+  - it: should use image.tag for version label when set
+    template: daemon-set.yaml
+    set:
+      image:
+        tag: "custom"
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: "custom"


### PR DESCRIPTION
## Summary
- When `image.tag` or `k8sCache.image.tag` is explicitly set, the `app.kubernetes.io/version` label now reflects the deployed version instead of always using `Chart.AppVersion`
- Adds `beyla.version` and `beyla.k8sCache.version` template helpers, reused in both labels and imageId templates
- Adds unit tests for the version label override behavior
- Bumps chart version to 1.16.2