### PR TITLE
fix: docs release workflow supports both branch formats

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@8cc658b604c6e05c275af30163a1c7728dfe19b2 # publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
         with:
           release_tag_regexp: '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?$'
           release_branch_with_patch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           website_directory: content/docs/beyla


### PR DESCRIPTION
## Summary
- The `publish-technical-documentation-release` workflow's `release_branch_regexp` only matched `release-X.Y` branches, but `release-train-prepare.yml` creates `release-X.Y.Z` branches. This caused the [v3.8.0 docs publish to fail](https://github.com/grafana/beyla/actions/runs/24416447575).
- Updated the regexp to accept an optional `.PATCH` suffix so it matches both `release-3.8` (manually created) and `release-3.8.0` (release-train created).

## Test plan
- [ ] Re-run the `publish-technical-documentation-release` workflow against the `v3.8.0` tag after merge and verify it succeeds
- [ ] Confirm the workflow still works for branches without a patch version (e.g. `release-3.9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)