### PR TITLE
feat: use release-MAJOR.MINOR branch naming for patch reuse

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@8cc658b604c6e05c275af30163a1c7728dfe19b2 # publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
         with:
           release_tag_regexp: '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?$'
-          release_branch_with_patch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          release_branch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          release_branch_with_patch_regexp: '^release-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           website_directory: content/docs/beyla

--- a/devdocs/new-release.md
+++ b/devdocs/new-release.md
@@ -254,8 +254,9 @@ If the fix is in Beyla only (no OBI changes):
 2. **Prepare**: Run
    [`release-train-prepare.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-prepare.yml)
    with `beyla_version=v3.0.1` and `obi_version=v1.0.0`. The script detects
-   that `PATCH != 0`, reuses the existing `release-3.0` branch, and reads
-   the OBI submodule pointer from the release branch instead of `main`.
+   that `PATCH != 0`, reuses the existing `release-3.0` branch, reads the
+   OBI submodule pointer from the release branch instead of `main`, and
+   regenerates release artifacts (`make vendor-obi`, `make java-build`).
 
 3. **Tag**: After release branch CI is green, run
    [`release-train-tag.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-tag.yml)
@@ -269,17 +270,26 @@ If the fix is in Beyla only (no OBI changes):
 
 If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
 
-1. **Cherry-pick the fix** onto the OBI release branch:
+1. **Cherry-pick the fix** onto the OBI release branch and regenerate
+   artifacts:
    ```bash
    cd /path/to/opentelemetry-ebpf-instrumentation
    git fetch --prune origin
    git checkout -B release-1.0 origin/release-1.0
    git cherry-pick <upstream-fix-sha>
+
+   make docker-generate
+   make java-build
+
+   git add -A
+   if ! git diff --cached --quiet; then
+     git commit -m "Regenerate artifacts for v1.0.1"
+   fi
    git push origin release-1.0
    ```
 
 2. **Update Beyla's `.obi-src`** on the Beyla release branch to point to the
-   new OBI release branch tip:
+   new OBI release branch tip, and regenerate Beyla artifacts:
    ```bash
    cd /path/to/beyla
    git fetch --prune origin
@@ -290,12 +300,24 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
    git -C .obi-src checkout origin/release-1.0
    git add .obi-src
    git commit -m "Update obi submodule for v3.0.1"
+
+   make vendor-obi
+   make java-build
+
+   git add -A
+   if ! git diff --cached --quiet; then
+     git commit -m "Regenerate artifacts for v3.0.1"
+   fi
    git push origin release-3.0
    ```
 
+   Alternatively, skip the manual `make` steps above and use the `prepare`
+   workflow in step 3 to regenerate artifacts automatically.
+
 3. **Prepare**: Run `release-train-prepare.yml` with `beyla_version=v3.0.1`
    and `obi_version=v1.0.1`. The script reuses both existing release
-   branches and regenerates artifacts.
+   branches and regenerates artifacts (OBI: `make docker-generate`,
+   `make java-build`; Beyla: `make vendor-obi`, `make java-build`).
 
 4. **Tag**: Run `release-train-tag.yml` with the same versions after CI is
    green. Tags `v3.0.1` and `v1.0.1` are created on their respective

--- a/devdocs/new-release.md
+++ b/devdocs/new-release.md
@@ -53,7 +53,7 @@ with separate Beyla and OBI versions, or do the same work manually.
 
 Step outcome:
 
-This creates `release-v1.0.0` in OBI and `release-v3.0.0` in Beyla. Both are
+This creates `release-1.0` in OBI and `release-3.0` in Beyla. Both are
 based on the OBI SHA pinned by Beyla `main`, and both get their release
 artifacts committed before CI runs.
 
@@ -74,7 +74,7 @@ generate the OBI artifacts that belong on the release branch.
 cd /path/to/opentelemetry-ebpf-instrumentation
 git fetch --prune origin
 git checkout 8634fc94ab21b86dd829fa92c87d8120790de337
-git checkout -B release-v1.0.0
+git checkout -B release-1.0
 
 make docker-generate
 make java-build
@@ -83,7 +83,7 @@ git add -A
 if ! git diff --cached --quiet; then
   git commit -m "Release v1.0.0 artifacts"
 fi
-git push -u origin release-v1.0.0
+git push -u origin release-1.0
 ```
 
 Then create the Beyla release branch for `v3.0.0`, keep `.obi-src` pinned to
@@ -92,7 +92,7 @@ the same OBI SHA, and generate the Beyla release artifacts.
 ```bash
 cd /path/to/beyla
 git fetch --prune origin
-git checkout -B release-v3.0.0 origin/main
+git checkout -B release-3.0 origin/main
 
 git submodule sync --recursive
 git submodule update --init --recursive
@@ -107,15 +107,15 @@ make java-build
 
 git add -A
 git commit -m "Release v3.0.0 artifacts"
-git push -u origin release-v3.0.0
+git push -u origin release-3.0
 ```
 
 ### 3. Wait for release branch CI
 
 Ensure both release branches are green:
 
-- `grafana/opentelemetry-ebpf-instrumentation:release-v1.0.0`
-- `grafana/beyla:release-v3.0.0`
+- `grafana/opentelemetry-ebpf-instrumentation:release-1.0`
+- `grafana/beyla:release-3.0`
 
 ### 4. Create prereleases and tags
 
@@ -133,7 +133,7 @@ First, tag the OBI release branch and create the OBI prerelease.
 ```bash
 cd /path/to/opentelemetry-ebpf-instrumentation
 git fetch --prune --tags origin
-git checkout -B release-v1.0.0 origin/release-v1.0.0
+git checkout -B release-1.0 origin/release-1.0
 
 git tag v1.0.0 "$(git rev-parse HEAD)"
 git push origin refs/tags/v1.0.0
@@ -151,7 +151,7 @@ Then tag the Beyla release branch and create the Beyla prerelease.
 ```bash
 cd /path/to/beyla
 git fetch --prune --tags origin
-git checkout -B release-v3.0.0 origin/release-v3.0.0
+git checkout -B release-3.0 origin/release-3.0
 
 git tag v3.0.0 "$(git rev-parse HEAD)"
 git push origin refs/tags/v3.0.0
@@ -230,6 +230,79 @@ If a release fails in CI or in `dev/ops/prod`:
 - Continue with the next SemVer version in the next run.
 
 Skipping versions is expected behavior.
+
+## Patch Releases
+
+When a critical fix must ship on an already-released minor version (e.g., a
+security hotfix for `v3.0.0`), use the patch release flow instead of the
+normal weekly train. Patch releases reuse the existing `release-MAJOR.MINOR`
+branch.
+
+### Beyla-only patch release
+
+If the fix is in Beyla only (no OBI changes):
+
+1. **Cherry-pick the fix** onto the existing Beyla release branch:
+   ```bash
+   cd /path/to/beyla
+   git fetch --prune origin
+   git checkout -B release-3.0 origin/release-3.0
+   git cherry-pick <fix-commit-sha>
+   git push origin release-3.0
+   ```
+
+2. **Prepare**: Run
+   [`release-train-prepare.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-prepare.yml)
+   with `beyla_version=v3.0.1` and `obi_version=v1.0.0`. The script detects
+   that `PATCH != 0`, reuses the existing `release-3.0` branch, and reads
+   the OBI submodule pointer from the release branch instead of `main`.
+
+3. **Tag**: After release branch CI is green, run
+   [`release-train-tag.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-tag.yml)
+   with the same versions. The tag `v3.0.1` is created on `release-3.0`.
+
+4. **Promote**: After validation in `ops`, run
+   [`promote-patch-to-stable.yml`](https://github.com/grafana/beyla/actions/workflows/promote-patch-to-stable.yml)
+   with `version_tag=v3.0.1`.
+
+### OBI patch release
+
+If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
+
+1. **Cherry-pick the fix** onto the OBI release branch:
+   ```bash
+   cd /path/to/opentelemetry-ebpf-instrumentation
+   git fetch --prune origin
+   git checkout -B release-1.0 origin/release-1.0
+   git cherry-pick <upstream-fix-sha>
+   git push origin release-1.0
+   ```
+
+2. **Update Beyla's `.obi-src`** on the Beyla release branch to point to the
+   new OBI release branch tip:
+   ```bash
+   cd /path/to/beyla
+   git fetch --prune origin
+   git checkout -B release-3.0 origin/release-3.0
+   git submodule sync --recursive
+   git submodule update --init --recursive
+   git -C .obi-src fetch --prune origin
+   git -C .obi-src checkout origin/release-1.0
+   git add .obi-src
+   git commit -m "Update obi submodule for v3.0.1"
+   git push origin release-3.0
+   ```
+
+3. **Prepare**: Run `release-train-prepare.yml` with `beyla_version=v3.0.1`
+   and `obi_version=v1.0.1`. The script reuses both existing release
+   branches and regenerates artifacts.
+
+4. **Tag**: Run `release-train-tag.yml` with the same versions after CI is
+   green. Tags `v3.0.1` and `v1.0.1` are created on their respective
+   release branches.
+
+5. **Promote**: Run `promote-patch-to-stable.yml` with
+   `version_tag=v3.0.1` after validation in `ops`.
 
 ## Manual CLI Notes
 

--- a/devdocs/new-release.md
+++ b/devdocs/new-release.md
@@ -257,6 +257,8 @@ If the fix is in Beyla only (no OBI changes):
    that `PATCH != 0`, reuses the existing `release-3.0` branch, reads the
    OBI submodule pointer from the release branch instead of `main`, and
    regenerates release artifacts (`make vendor-obi`, `make java-build`).
+   The OBI artifact regeneration steps (`make docker-generate`,
+   `make java-build`) also run but should be a no-op when OBI is unchanged.
 
 3. **Tag**: After release branch CI is green, run
    [`release-train-tag.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-tag.yml)

--- a/scripts/release-train.sh
+++ b/scripts/release-train.sh
@@ -531,10 +531,8 @@ prepare_obi_branch() {
     if git -C "$OBI_DIR" show-ref --verify --quiet "refs/remotes/origin/${release_branch}"; then
         log_info "OBI branch ${release_branch} already exists; reusing it."
         run_cmd git -C "$OBI_DIR" checkout -B "$release_branch" "origin/${release_branch}"
-        if [[ "$is_patch" != "true" ]]; then
-            if ! git -C "$OBI_DIR" merge-base --is-ancestor "$obi_sha" HEAD; then
-                die "Existing OBI branch ${release_branch} does not contain pinned SHA ${obi_sha}"
-            fi
+        if ! git -C "$OBI_DIR" merge-base --is-ancestor "$obi_sha" HEAD; then
+            die "Existing OBI branch ${release_branch} does not contain pinned SHA ${obi_sha}"
         fi
     else
         if [[ "$is_patch" == "true" ]]; then
@@ -695,11 +693,18 @@ prepare_command() {
     local obi_release_branch
     obi_release_branch="$(release_branch_name "$OBI_VERSION")"
 
-    local obi_sha
-    local patch_flag="false"
+    local beyla_is_patch="false"
     if is_patch_release "$BEYLA_VERSION"; then
-        patch_flag="true"
-        # For patch releases, the release branch already exists.
+        beyla_is_patch="true"
+    fi
+    local obi_is_patch="false"
+    if is_patch_release "$OBI_VERSION"; then
+        obi_is_patch="true"
+    fi
+
+    local obi_sha
+    if [[ "$beyla_is_patch" == "true" ]]; then
+        # For Beyla patch releases, the release branch already exists.
         # Read the OBI SHA from the existing release branch instead of main.
         run_git_remote_cmd -C "$BEYLA_DIR" fetch --prune origin
         if ! git -C "$BEYLA_DIR" show-ref --verify --quiet "refs/remotes/origin/${beyla_release_branch}"; then
@@ -712,7 +717,7 @@ prepare_command() {
         log_info "OBI SHA pinned in ${BEYLA_REPO}:${BEYLA_MAIN_BRANCH}: ${obi_sha}"
     fi
 
-    prepare_obi_branch "$OBI_VERSION" "$obi_release_branch" "$obi_sha" "$patch_flag"
+    prepare_obi_branch "$OBI_VERSION" "$obi_release_branch" "$obi_sha" "$obi_is_patch"
     local obi_release_sha
     obi_release_sha="$(git -C "$OBI_DIR" rev-parse HEAD)"
     log_info "OBI release branch tip SHA: ${obi_release_sha}"

--- a/scripts/release-train.sh
+++ b/scripts/release-train.sh
@@ -8,7 +8,7 @@
 #
 # Notes:
 #   - Versions must be SemVer tags: vMAJOR.MINOR.PATCH
-#   - Release branch naming is: release-MAJOR.MINOR.PATCH (no "v" prefix)
+#   - Release branch naming is: release-MAJOR.MINOR (no "v" prefix, no PATCH)
 #   - Run from any directory (the script uses temporary clones)
 
 set -euo pipefail
@@ -164,6 +164,20 @@ validate_semver_tag() {
 version_without_v() {
     local tag="$1"
     echo "${tag#v}"
+}
+
+release_branch_name() {
+    local tag="$1"
+    local major minor _patch
+    IFS='.' read -r major minor _patch <<< "${tag#v}"
+    echo "release-${major}.${minor}"
+}
+
+is_patch_release() {
+    local tag="$1"
+    local _major _minor patch
+    IFS='.' read -r _major _minor patch <<< "${tag#v}"
+    [[ "$patch" != "0" ]]
 }
 
 parse_semver() {
@@ -364,6 +378,19 @@ resolve_obi_sha_from_beyla_main() {
     echo "$obi_sha"
 }
 
+resolve_obi_sha_from_beyla_branch() {
+    local branch="$1"
+    local tree_line
+    tree_line=$(git -C "$BEYLA_DIR" ls-tree "origin/${branch}" .obi-src) || {
+        die "Failed to inspect .obi-src in ${BEYLA_REPO}:${branch}"
+    }
+
+    local obi_sha
+    obi_sha=$(awk '{print $3}' <<< "$tree_line")
+    [[ -n "$obi_sha" ]] || die "Could not determine .obi-src SHA from ${BEYLA_REPO}:${branch}"
+    echo "$obi_sha"
+}
+
 latest_semver_tag_from_repo() {
     local repo_dir="$1"
     git -C "$repo_dir" tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
@@ -497,16 +524,22 @@ prepare_obi_branch() {
     local version="$1"
     local release_branch="$2"
     local obi_sha="$3"
+    local is_patch="${4:-false}"
 
     run_git_remote_cmd -C "$OBI_DIR" fetch --prune origin
 
     if git -C "$OBI_DIR" show-ref --verify --quiet "refs/remotes/origin/${release_branch}"; then
         log_info "OBI branch ${release_branch} already exists; reusing it."
         run_cmd git -C "$OBI_DIR" checkout -B "$release_branch" "origin/${release_branch}"
-        if ! git -C "$OBI_DIR" merge-base --is-ancestor "$obi_sha" HEAD; then
-            die "Existing OBI branch ${release_branch} does not contain pinned SHA ${obi_sha}"
+        if [[ "$is_patch" != "true" ]]; then
+            if ! git -C "$OBI_DIR" merge-base --is-ancestor "$obi_sha" HEAD; then
+                die "Existing OBI branch ${release_branch} does not contain pinned SHA ${obi_sha}"
+            fi
         fi
     else
+        if [[ "$is_patch" == "true" ]]; then
+            die "Patch release requested but OBI branch ${release_branch} does not exist."
+        fi
         run_cmd git -C "$OBI_DIR" checkout "$obi_sha"
         run_cmd git -C "$OBI_DIR" checkout -B "$release_branch"
     fi
@@ -656,15 +689,30 @@ prepare_command() {
         check_obi_fork_sync
     fi
 
-    local obi_sha
-    obi_sha="$(resolve_obi_sha_from_beyla_main)"
-    log_info "OBI SHA pinned in ${BEYLA_REPO}:${BEYLA_MAIN_BRANCH}: ${obi_sha}"
-
     resolve_prepare_versions
-    local beyla_release_branch="release-$(version_without_v "$BEYLA_VERSION")"
-    local obi_release_branch="release-$(version_without_v "$OBI_VERSION")"
+    local beyla_release_branch
+    beyla_release_branch="$(release_branch_name "$BEYLA_VERSION")"
+    local obi_release_branch
+    obi_release_branch="$(release_branch_name "$OBI_VERSION")"
 
-    prepare_obi_branch "$OBI_VERSION" "$obi_release_branch" "$obi_sha"
+    local obi_sha
+    local patch_flag="false"
+    if is_patch_release "$BEYLA_VERSION"; then
+        patch_flag="true"
+        # For patch releases, the release branch already exists.
+        # Read the OBI SHA from the existing release branch instead of main.
+        run_git_remote_cmd -C "$BEYLA_DIR" fetch --prune origin
+        if ! git -C "$BEYLA_DIR" show-ref --verify --quiet "refs/remotes/origin/${beyla_release_branch}"; then
+            die "Patch release ${BEYLA_VERSION} requested but branch ${beyla_release_branch} does not exist."
+        fi
+        obi_sha="$(resolve_obi_sha_from_beyla_branch "$beyla_release_branch")"
+        log_info "OBI SHA from existing ${beyla_release_branch}: ${obi_sha}"
+    else
+        obi_sha="$(resolve_obi_sha_from_beyla_main)"
+        log_info "OBI SHA pinned in ${BEYLA_REPO}:${BEYLA_MAIN_BRANCH}: ${obi_sha}"
+    fi
+
+    prepare_obi_branch "$OBI_VERSION" "$obi_release_branch" "$obi_sha" "$patch_flag"
     local obi_release_sha
     obi_release_sha="$(git -C "$OBI_DIR" rev-parse HEAD)"
     log_info "OBI release branch tip SHA: ${obi_release_sha}"
@@ -690,8 +738,10 @@ tag_command() {
     ensure_gh_auth
 
     resolve_tag_versions
-    local beyla_release_branch="release-$(version_without_v "$BEYLA_VERSION")"
-    local obi_release_branch="release-$(version_without_v "$OBI_VERSION")"
+    local beyla_release_branch
+    beyla_release_branch="$(release_branch_name "$BEYLA_VERSION")"
+    local obi_release_branch
+    obi_release_branch="$(release_branch_name "$OBI_VERSION")"
 
     setup_workspace
 


### PR DESCRIPTION
## Summary

- Switches release branch naming from `release-MAJOR.MINOR.PATCH` to `release-MAJOR.MINOR` so patch releases reuse the same branch as the initial minor release.
- Adds patch-aware logic to `release-train.sh prepare`: when PATCH != 0, the script reuses the existing release branch and reads the OBI SHA from it instead of from `main`.
- Updates `publish-technical-documentation-release.yml` regexps to match the new branch format.
- Adds documentation for Beyla-only and OBI patch release procedures in `devdocs/new-release.md`.
