### PR TITLE
ci: fix beyla/alloy auto-trigger

### DIFF
--- a/.github/workflows/promote-patch-to-stable.yml
+++ b/.github/workflows/promote-patch-to-stable.yml
@@ -254,6 +254,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
           github_app: grafana-beyla-bot
+          permission_set: trigger-alloy-bump
 
       - name: Trigger Alloy Beyla component update
         env:


### PR DESCRIPTION
The Beyla workflow was using the default permission set, so failed to trigger the Alloy workflow:

- https://github.com/grafana/beyla/actions/runs/24658930785/job/72099657209

The fix is to explicitly use the `trigger-alloy-bump` permission set [defined in Terraform](https://github.com/grafana/deployment_tools/blob/80d964fc081d8dbba4fad6f2313d1ae919deefe4/terraform/repositories/beyla/github-app-configs/config.yaml#L57-L64).