### PR TITLE
ci(supervisor): fix missed Copilot review request; rerun agent failures

### DIFF
--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -14,6 +14,7 @@ on: # zizmor: ignore[dangerous-triggers] no code checkout; GITHUB_TOKEN used for
       - "Documentation CI"
       - "Pull request integration tests on VM"
       - "Helm Test"
+      - "Fix OBI submodule CI"
     types: [completed]
 
 # Set restrictive permissions at workflow level
@@ -223,8 +224,8 @@ jobs:
                 '{check_runs: [
                   .check_runs[]
                   | select(
-                      .app.slug != "github-actions"
-                      or (.check_suite.id as $id | $pr_suites | index($id))
+                      .app.slug == "github-actions"
+                      and (.check_suite.id as $id | $pr_suites | index($id))
                     )
                   | select(
                       (.name as $n | $excluded | index($n)) | not
@@ -314,8 +315,8 @@ jobs:
                 '{check_runs: [
                   .check_runs[]
                   | select(
-                      .app.slug != "github-actions"
-                      or (.check_suite.id as $id | $pr_suites | index($id))
+                      .app.slug == "github-actions"
+                      and (.check_suite.id as $id | $pr_suites | index($id))
                     )
                   | select(
                       (.name as $n | $excluded | index($n)) | not


### PR DESCRIPTION
## Summary
- `handle-ci-completion` and `add-agent-label` previously included external-app check-runs (e.g. `socket-security`, `github-advanced-security`) in the PENDING/NON-GREEN evaluation. When such an app was the last to finish, supervisor was already done firing for the day (those apps don't trigger `workflow_run`), so the PR sat green forever and `--add-reviewer "copilot"` was never called. Tighten the filter to only count `github-actions` check-runs from PR-triggered workflow suites.
- Subscribe the supervisor to `Fix OBI submodule CI` so transient agent failures get auto-rerun via `gh run rerun --failed`.

## Test plan
- [ ] On the next automated PR, confirm Copilot is auto-requested without manual intervention even when Socket Security finishes last.
- [ ] On a transient `Fix OBI submodule CI` failure, confirm the supervisor reruns the failed jobs (artifacts from earlier successful jobs are reused, so Triage/Plan don't re-burn Anthropic API calls).