### PR TITLE
Fix Java agent packaging for multi-arch Beyla images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,20 @@
-# Build the autoinstrumenter binary
 ARG GEN_IMG=ghcr.io/open-telemetry/obi-generator:0.2.11@sha256:c9a11deeda1de354aa334817f693efbf5ccee15dcd18caee6a9b221eed0e5773
 
+# Build the Java OBI agent
+FROM gradle:9.4.1-jdk21-noble@sha256:5a739da3c34646f72da2634b2d4a5e2b467132eaf6abccfb7bc60e1b502d51b5 AS javaagent-builder
+
+WORKDIR /build
+
+RUN apt update
+RUN apt install -y clang llvm
+
+# Copy build files
+COPY .obi-src/pkg/internal/java .
+
+# Build the project
+RUN gradle build --no-daemon
+
+# Build the autoinstrumenter binary
 FROM $GEN_IMG AS builder
 
 # TODO: embed software version in executable
@@ -41,21 +55,11 @@ RUN if [ -z "${DEV_OBI}" ]; then \
     make generate && \
     make copy-obi-vendor \
     ; fi
+
+# The Java agent is embedded at Go compile time, so the platform-specific jar
+# must be copied into vendor before building the Beyla binary.
+COPY --from=javaagent-builder /build/build/obi-java-agent.jar /src/vendor/go.opentelemetry.io/obi/pkg/internal/java/embedded/obi-java-agent.jar
 RUN make compile
-
-# Build the Java OBI agent
-FROM gradle:9.4.1-jdk21-noble@sha256:5a739da3c34646f72da2634b2d4a5e2b467132eaf6abccfb7bc60e1b502d51b5 AS javaagent-builder
-
-WORKDIR /build
-
-RUN apt update
-RUN apt install -y clang llvm
-
-# Copy build files
-COPY .obi-src/pkg/internal/java .
-
-# Build the project
-RUN gradle build --no-daemon
 
 # Create final image from minimal + built binary
 FROM scratch
@@ -64,7 +68,6 @@ LABEL maintainer="Grafana Labs <hello@grafana.com>"
 
 WORKDIR /
 
-COPY --from=javaagent-builder /build/build/obi-java-agent.jar /src/vendor/go.opentelemetry.io/obi/pkg/internal/java/embedded/obi-java-agent.jar
 COPY --from=builder /src/bin/beyla .
 COPY --from=builder /src/LICENSE .
 COPY --from=builder /src/NOTICE .


### PR DESCRIPTION
Our Dockerfile copied the Java agent jar after make compile, so `arm64` images could still embed an `amd64`library and fail at runtime. This PR reorders Docker stages so the platform-specific jar is built and copied into vendor/.../embedded before compile.

Fixes #2740