### PR TITLE
docs: port new beyla.network.flow.bytes attributes from the OBI docs

### DIFF
--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -147,6 +147,12 @@ For more information about the OpenTelemetry semantic conventions for each metri
 | `beyla.network.flow.bytes`     | `src.port`                   | hidden                                            |
 | `beyla.network.flow.bytes`     | `src.zone` (only Kubernetes) | hidden                                            |
 | `beyla.network.flow.bytes`     | `transport`                  | hidden                                            |
+| `beyla.network.flow.bytes`     | `network.type`               | hidden                                            |
+| `beyla.network.flow.bytes`     | `network.protocol.name`      | hidden                                            |
+| `beyla.network.flow.bytes`     | `src.country`                | shown if the `geoip` configuration section exists |
+| `beyla.network.flow.bytes`     | `src.asn`                    | shown if the `geoip` configuration section exists |
+| `beyla.network.flow.bytes`     | `dst.country`                | shown if the `geoip` configuration section exists |
+| `beyla.network.flow.bytes`     | `dst.asn`                    | shown if the `geoip` configuration section exists |
 
 {{< admonition type="note" >}}
 The `beyla.network.inter.zone.bytes` metric supports the same set of attributes as `beyla.network.flow.bytes`,


### PR DESCRIPTION
Closes #2422.

Ports the six attributes added to the upstream OBI metrics page in [open-telemetry/opentelemetry.io#8914](https://github.com/open-telemetry/opentelemetry.io/pull/8914) onto the Beyla equivalent (\`docs/sources/metrics.md\`). The OBI PR is already merged.

Added rows to the \`beyla.network.flow.bytes\` attribute table:

| Attribute | Visibility |
|---|---|
| \`network.type\` | hidden |
| \`network.protocol.name\` | hidden |
| \`src.country\` | shown if the \`geoip\` configuration section exists |
| \`src.asn\` | shown if the \`geoip\` configuration section exists |
| \`dst.country\` | shown if the \`geoip\` configuration section exists |
| \`dst.asn\` | shown if the \`geoip\` configuration section exists |

The existing trailing admonition about \`beyla.network.inter.zone.bytes\` inheriting the same attribute set remains accurate, so no further changes were needed.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>