### PR TITLE
feat(release): align deps with alloy

### DIFF
--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -35,6 +35,16 @@ on:
         required: false
         type: boolean
         default: false
+      align_with_alloy:
+        description: "Pin OTel + Prometheus deps in release branches to grafana/alloy"
+        required: false
+        type: boolean
+        default: true
+      alloy_ref:
+        description: "Branch, tag, or SHA in grafana/alloy to align against (default: main)"
+        required: false
+        type: string
+        default: main
 
 concurrency:
   group: release-train-prepare
@@ -53,6 +63,9 @@ jobs:
       obi_version: ${{ steps.prepare.outputs.obi_version }}
       beyla_release_branch: ${{ steps.prepare.outputs.beyla_release_branch }}
       obi_release_branch: ${{ steps.prepare.outputs.obi_release_branch }}
+      alloy_aligned: ${{ steps.prepare.outputs.alloy_aligned }}
+      alloy_sha: ${{ steps.prepare.outputs.alloy_sha }}
+      alloy_align_total: ${{ steps.prepare.outputs.alloy_align_total }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,6 +104,8 @@ jobs:
           DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
           SKIP_CI_CHECK_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_ci_check || 'false' }}
           SKIP_UPSTREAM_SYNC_CHECK_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_upstream_sync_check || 'false' }}
+          ALIGN_WITH_ALLOY_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.align_with_alloy || 'true' }}
+          ALLOY_REF_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.alloy_ref || 'main' }}
         run: |
           set -euo pipefail
 
@@ -120,6 +135,16 @@ jobs:
             cmd+=(--skip-upstream-sync-check)
           fi
 
+          if [[ "${ALIGN_WITH_ALLOY_INPUT:-true}" == "true" ]]; then
+            cmd+=(--align-with-alloy)
+          else
+            cmd+=(--no-align-with-alloy)
+          fi
+
+          if [[ -n "${ALLOY_REF_INPUT}" ]]; then
+            cmd+=(--alloy-ref "${ALLOY_REF_INPUT}")
+          fi
+
           echo "Running: ${cmd[*]}"
           RELEASE_TRAIN_OUTPUT_FILE="$GITHUB_OUTPUT" "${cmd[@]}"
 
@@ -133,6 +158,9 @@ jobs:
             echo "- Beyla release branch: \`${{ steps.prepare.outputs.beyla_release_branch || 'n/a' }}\`"
             echo "- OBI version: \`${{ steps.prepare.outputs.obi_version || 'n/a' }}\`"
             echo "- OBI release branch: \`${{ steps.prepare.outputs.obi_release_branch || 'n/a' }}\`"
+            echo "- Alloy alignment: \`${{ steps.prepare.outputs.alloy_aligned || 'n/a' }}\`"
+            echo "- Alloy SHA: \`${{ steps.prepare.outputs.alloy_sha || 'n/a' }}\`"
+            echo "- Modules downgraded (OBI + Beyla combined): \`${{ steps.prepare.outputs.alloy_align_total || '0' }}\`"
             echo ""
             echo "### Next"
             echo "- Wait for CI to become green on both release branches."

--- a/devdocs/new-release.md
+++ b/devdocs/new-release.md
@@ -37,6 +37,55 @@ Example used in this document:
   - Supports separate Beyla and OBI versions.
 - [`promote-patch-to-stable.yml`](../.github/workflows/promote-patch-to-stable.yml): marks a prerelease as stable/latest and promotes Docker tags.
 
+## Alloy dependency alignment
+
+Grafana Alloy refuses OpenTelemetry dependency bumps on minor/patch releases of
+Beyla that ship embedded inside it. To avoid blocking the Alloy integration on
+every Beyla release, `release-train-prepare.yml` downgrades OTel and Prometheus
+modules in the release branches to match Alloy's `main` branch `go.mod`
+automatically.
+
+Key guarantees:
+
+- Alignment only happens on `release-MAJOR.MINOR` branches. `main` in
+  `grafana/beyla`, `grafana/opentelemetry-ebpf-instrumentation`, and the
+  upstream `open-telemetry/opentelemetry-ebpf-instrumentation` fork are never
+  touched.
+- Scope is limited to `go.opentelemetry.io/*` and `github.com/prometheus/*`.
+  Other dependencies are free to drift.
+- The Alloy ref (default `main`) is resolved once per prepare run to a concrete
+  SHA, so the OBI and Beyla release branches are aligned against the exact
+  same Alloy snapshot.
+- Each alignment commit records the resolved Alloy SHA and the list of
+  module downgrades in its commit message, and the `prepare` workflow
+  surfaces the SHA in the run summary.
+
+Workflow inputs on [release-train-prepare.yml](../.github/workflows/release-train-prepare.yml):
+
+- `align_with_alloy` (boolean, default `true`). Uncheck to skip alignment for
+  a single run (for example, when you want to release Beyla without coupling
+  it to Alloy's OTel pins).
+- `alloy_ref` (string, default `main`). A branch, tag, or SHA in
+  `grafana/alloy`. Use a tag or SHA for a fully reproducible alignment.
+
+Kill switch (turn off globally without removing code):
+
+- Set the env var `RELEASE_TRAIN_ALIGN_WITH_ALLOY=false` in the workflow
+  environment, or flip the default in [`scripts/release-train.sh`](../scripts/release-train.sh)
+  from `true` to `false`. Once Beyla ships as an embedded binary inside Alloy
+  and the two repos no longer share a Go module graph, this knob makes the
+  alignment step a no-op without needing to delete the wiring.
+
+Local testing:
+
+```bash
+# See which modules would be downgraded, without touching the worktree.
+./scripts/align-with-alloy.sh --repo-dir . --dry-run
+
+# Align against a specific Alloy commit instead of main@HEAD.
+./scripts/align-with-alloy.sh --repo-dir . --alloy-ref 1a2b3c4d
+```
+
 ## End-to-End Flow
 
 ### 1. Preconditions

--- a/scripts/align-with-alloy.sh
+++ b/scripts/align-with-alloy.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+#
+# Downgrade in-scope modules in a release branch's go.mod to match the versions
+# pinned in grafana/alloy's go.mod, so that Beyla/OBI release branches produce
+# artifacts that can be embedded in Alloy without forcing OTel (or similar)
+# upgrades.
+#
+# Scope (default):
+#   - go.opentelemetry.io/*
+#   - github.com/prometheus/*
+#
+# Rules, per in-scope module:
+#   - If local version > Alloy version:  go get module@<alloy_version>
+#   - If local version <= Alloy version: leave alone (MVS picks Alloy's version)
+#   - If Alloy does not require the module: leave alone
+#
+# This script only mutates <repo-dir>.  It never pushes, never tags, and never
+# touches mains of beyla, grafana/opentelemetry-ebpf-instrumentation, or
+# open-telemetry/opentelemetry-ebpf-instrumentation.
+#
+# Invoked by scripts/release-train.sh after a release branch has been checked
+# out.  Can also be run standalone for local dry-runs.
+
+set -euo pipefail
+
+REPO_DIR=""
+ALLOY_REPO="grafana/alloy"
+ALLOY_REF="main"
+SCOPE_CSV="go.opentelemetry.io/*,github.com/prometheus/*"
+SKIP_MODULES=("go.opentelemetry.io/obi")
+DRY_RUN=false
+
+OUTPUT_FILE="${ALIGN_OUTPUT_FILE:-}"
+
+# Global scratch dir so the EXIT trap can clean up even after main() returns.
+TMP_DIR=""
+cleanup() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+log_info() {
+    echo "[align] $*" >&2
+}
+
+log_warn() {
+    echo "[align][warn] $*" >&2
+}
+
+log_error() {
+    echo "[align][error] $*" >&2
+}
+
+die() {
+    log_error "$*"
+    exit 1
+}
+
+show_help() {
+    cat << 'EOF'
+Align a release branch's go.mod with grafana/alloy's go.mod.
+
+Usage:
+  ./scripts/align-with-alloy.sh --repo-dir <path> [options]
+
+Required:
+  --repo-dir <path>          Repo clone whose go.mod should be aligned.
+                             Must already be checked out to the release branch.
+
+Options:
+  --alloy-repo <owner/repo>  Default: grafana/alloy
+  --alloy-ref  <ref>         Branch, tag, or SHA. Default: main.
+                             Resolved to a concrete SHA before download.
+  --scope <csv>              Comma-separated module path globs to align.
+                             Default: go.opentelemetry.io/*,github.com/prometheus/*
+  --skip-module <module>     Repeatable. Always skipped:
+                             go.opentelemetry.io/obi
+  --dry-run                  Print the planned go get invocations without
+                             modifying go.mod / go.sum / vendor.
+  --help, -h                 Show this help.
+
+Environment:
+  ALIGN_OUTPUT_FILE          If set, writes:
+                               alloy_sha=<resolved sha>
+                               aligned_count=<n>
+                               aligned_modules=<csv of module@old=>new>
+
+Exit codes:
+  0  success (even if no changes were needed)
+  1  usage error or unrecoverable failure (network, parse, go get, etc.)
+EOF
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-dir=*)
+            REPO_DIR="${1#*=}"
+            shift
+            ;;
+        --repo-dir)
+            [[ $# -ge 2 ]] || die "Option --repo-dir requires a value."
+            REPO_DIR="$2"
+            shift 2
+            ;;
+        --alloy-repo=*)
+            ALLOY_REPO="${1#*=}"
+            shift
+            ;;
+        --alloy-repo)
+            [[ $# -ge 2 ]] || die "Option --alloy-repo requires a value."
+            ALLOY_REPO="$2"
+            shift 2
+            ;;
+        --alloy-ref=*)
+            ALLOY_REF="${1#*=}"
+            shift
+            ;;
+        --alloy-ref)
+            [[ $# -ge 2 ]] || die "Option --alloy-ref requires a value."
+            ALLOY_REF="$2"
+            shift 2
+            ;;
+        --scope=*)
+            SCOPE_CSV="${1#*=}"
+            shift
+            ;;
+        --scope)
+            [[ $# -ge 2 ]] || die "Option --scope requires a value."
+            SCOPE_CSV="$2"
+            shift 2
+            ;;
+        --skip-module=*)
+            SKIP_MODULES+=("${1#*=}")
+            shift
+            ;;
+        --skip-module)
+            [[ $# -ge 2 ]] || die "Option --skip-module requires a value."
+            SKIP_MODULES+=("$2")
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+    esac
+done
+
+[[ -n "$REPO_DIR" ]] || { show_help; die "--repo-dir is required."; }
+[[ -d "$REPO_DIR" ]] || die "--repo-dir does not exist: $REPO_DIR"
+[[ -f "$REPO_DIR/go.mod" ]] || die "No go.mod in --repo-dir: $REPO_DIR"
+
+require_cmd git
+require_cmd curl
+require_cmd awk
+require_cmd go
+
+# Prefer gh for SHA resolution if available; fall back to unauthenticated API.
+resolve_alloy_sha() {
+    local ref="$1"
+    local sha=""
+
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        sha="$(gh api "repos/${ALLOY_REPO}/commits/${ref}" --jq '.sha' 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$sha" ]]; then
+        # Unauthenticated fallback; fine for public repos but rate-limited.
+        local resp
+        resp="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${ALLOY_REPO}/commits/${ref}" 2>/dev/null || true)"
+        if [[ -n "$resp" ]]; then
+            sha="$(printf '%s' "$resp" | awk -F'"' '/"sha":[ ]*"/ { print $4; exit }')"
+        fi
+    fi
+
+    [[ -n "$sha" ]] || die "Failed to resolve ${ALLOY_REPO}@${ref} to a SHA."
+    printf '%s' "$sha"
+}
+
+download_alloy_go_mod() {
+    local sha="$1"
+    local dest="$2"
+    local url="https://raw.githubusercontent.com/${ALLOY_REPO}/${sha}/go.mod"
+    log_info "Downloading ${url}"
+    curl -fsSL "$url" -o "$dest" || die "Failed to download Alloy go.mod at ${sha}"
+    [[ -s "$dest" ]] || die "Downloaded Alloy go.mod is empty: ${url}"
+}
+
+# Print "module version" pairs from a go.mod's require blocks / require lines.
+# Handles both:
+#   require (
+#       module v1.2.3
+#       module v1.2.3 // indirect
+#   )
+#   require module v1.2.3
+# Ignores replace/exclude/retract blocks entirely.
+extract_requires() {
+    local gomod="$1"
+    awk '
+        BEGIN { in_block = 0; block_kind = "" }
+        /^[[:space:]]*\/\// { next }
+        /^[[:space:]]*$/ { next }
+        /^replace[[:space:]]*\(/    { in_block = 1; block_kind = "replace"; next }
+        /^exclude[[:space:]]*\(/    { in_block = 1; block_kind = "exclude"; next }
+        /^retract[[:space:]]*\(/    { in_block = 1; block_kind = "retract"; next }
+        /^require[[:space:]]*\(/    { in_block = 1; block_kind = "require"; next }
+        in_block && /^[[:space:]]*\)/ { in_block = 0; block_kind = ""; next }
+        in_block && block_kind == "require" {
+            line = $0
+            sub(/\/\/.*$/, "", line)
+            n = split(line, f, /[[:space:]]+/)
+            mod = ""; ver = ""
+            for (i = 1; i <= n; i++) {
+                if (f[i] == "") continue
+                if (mod == "") { mod = f[i]; continue }
+                if (ver == "") { ver = f[i]; break }
+            }
+            if (mod != "" && ver != "") print mod, ver
+            next
+        }
+        /^require[[:space:]]+[^(]/ {
+            line = $0
+            sub(/^require[[:space:]]+/, "", line)
+            sub(/\/\/.*$/, "", line)
+            n = split(line, f, /[[:space:]]+/)
+            mod = ""; ver = ""
+            for (i = 1; i <= n; i++) {
+                if (f[i] == "") continue
+                if (mod == "") { mod = f[i]; continue }
+                if (ver == "") { ver = f[i]; break }
+            }
+            if (mod != "" && ver != "") print mod, ver
+            next
+        }
+    ' "$gomod"
+}
+
+matches_scope() {
+    local mod="$1"
+    local csv="$2"
+    local IFS=','
+    local pattern
+    # shellcheck disable=SC2206
+    local patterns=($csv)
+    for pattern in "${patterns[@]}"; do
+        [[ -z "$pattern" ]] && continue
+        # Glob match: go.opentelemetry.io/* etc.
+        # shellcheck disable=SC2053
+        [[ "$mod" == $pattern ]] && return 0
+    done
+    return 1
+}
+
+is_skipped() {
+    local mod="$1"
+    local skip
+    for skip in "${SKIP_MODULES[@]}"; do
+        [[ "$mod" == "$skip" ]] && return 0
+    done
+    return 1
+}
+
+# Compare two semver-ish Go module versions.
+# Prints: ">" if a > b, "<" if a < b, "=" if equal.
+# Uses sort -V which handles pseudo-versions well enough for our purposes.
+compare_versions() {
+    local a="$1"
+    local b="$2"
+    if [[ "$a" == "$b" ]]; then
+        printf '='
+        return
+    fi
+    local higher
+    higher="$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n 1)"
+    if [[ "$higher" == "$a" ]]; then
+        printf '>'
+    else
+        printf '<'
+    fi
+}
+
+write_output() {
+    local key="$1"
+    local value="$2"
+    if [[ -n "$OUTPUT_FILE" ]]; then
+        printf '%s=%s\n' "$key" "$value" >> "$OUTPUT_FILE"
+    fi
+}
+
+main() {
+    local alloy_sha
+    alloy_sha="$(resolve_alloy_sha "$ALLOY_REF")"
+    log_info "Resolved ${ALLOY_REPO}@${ALLOY_REF} -> ${alloy_sha}"
+
+    TMP_DIR="$(mktemp -d -t align-with-alloy.XXXXXX)"
+
+    local alloy_gomod="${TMP_DIR}/alloy.go.mod"
+    download_alloy_go_mod "$alloy_sha" "$alloy_gomod"
+
+    local alloy_reqs="${TMP_DIR}/alloy.requires"
+    local local_reqs="${TMP_DIR}/local.requires"
+    extract_requires "$alloy_gomod" | LC_ALL=C sort -u > "$alloy_reqs"
+    extract_requires "${REPO_DIR}/go.mod" | LC_ALL=C sort -u > "$local_reqs"
+
+    local alloy_count local_count
+    alloy_count="$(wc -l < "$alloy_reqs" | tr -d ' ')"
+    local_count="$(wc -l < "$local_reqs" | tr -d ' ')"
+    log_info "Alloy requires ${alloy_count} modules; local requires ${local_count}."
+
+    # Build an associative array: alloy[module] = version.
+    declare -A alloy_ver
+    while read -r mod ver; do
+        [[ -z "$mod" ]] && continue
+        alloy_ver["$mod"]="$ver"
+    done < "$alloy_reqs"
+
+    local -a plan_mods=()
+    local -a plan_old=()
+    local -a plan_new=()
+    local in_scope_total=0
+    local already_ok=0
+
+    while read -r mod local_version; do
+        [[ -z "$mod" ]] && continue
+        matches_scope "$mod" "$SCOPE_CSV" || continue
+        is_skipped "$mod" && { log_info "Skipping (skip-list): ${mod}"; continue; }
+
+        in_scope_total=$((in_scope_total + 1))
+
+        local alloy_version="${alloy_ver[$mod]:-}"
+        if [[ -z "$alloy_version" ]]; then
+            log_info "In scope but not required by Alloy, leaving alone: ${mod}@${local_version}"
+            continue
+        fi
+
+        local cmp
+        cmp="$(compare_versions "$local_version" "$alloy_version")"
+        case "$cmp" in
+            '=')
+                already_ok=$((already_ok + 1))
+                ;;
+            '<')
+                log_info "Local already <= Alloy (MVS will pick Alloy's): ${mod} local=${local_version} alloy=${alloy_version}"
+                already_ok=$((already_ok + 1))
+                ;;
+            '>')
+                plan_mods+=("$mod")
+                plan_old+=("$local_version")
+                plan_new+=("$alloy_version")
+                ;;
+        esac
+    done < "$local_reqs"
+
+    log_info "In-scope local modules: ${in_scope_total}; already aligned or lower: ${already_ok}; to downgrade: ${#plan_mods[@]}"
+
+    local aligned_csv=""
+    local aligned_count=0
+
+    if [[ "${#plan_mods[@]}" -eq 0 ]]; then
+        log_info "No downgrades needed. Release branch is already aligned with grafana/alloy@${alloy_sha:0:12}."
+    else
+        printf '[align] plan:\n' >&2
+        local i
+        for ((i = 0; i < ${#plan_mods[@]}; i++)); do
+            printf '[align]   %s  %s -> %s\n' "${plan_mods[$i]}" "${plan_old[$i]}" "${plan_new[$i]}" >&2
+        done
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_warn "Dry-run: not invoking 'go get' or 'go mod tidy'."
+        else
+            # One go get invocation per module keeps the logs readable and lets us
+            # surface which specific pin broke if a downgrade fails.
+            local idx
+            for ((idx = 0; idx < ${#plan_mods[@]}; idx++)); do
+                local mod="${plan_mods[$idx]}"
+                local ver="${plan_new[$idx]}"
+                log_info "go get ${mod}@${ver}"
+                ( cd "$REPO_DIR" && GOFLAGS='' go get "${mod}@${ver}" ) \
+                    || die "go get ${mod}@${ver} failed in ${REPO_DIR}"
+            done
+
+            log_info "go mod tidy"
+            ( cd "$REPO_DIR" && GOFLAGS='' go mod tidy ) || die "go mod tidy failed in ${REPO_DIR}"
+
+            if [[ -d "${REPO_DIR}/vendor" ]]; then
+                log_info "go mod vendor"
+                ( cd "$REPO_DIR" && GOFLAGS='' go mod vendor ) || die "go mod vendor failed in ${REPO_DIR}"
+            fi
+        fi
+
+        aligned_count="${#plan_mods[@]}"
+        local sep=""
+        for ((i = 0; i < ${#plan_mods[@]}; i++)); do
+            aligned_csv+="${sep}${plan_mods[$i]}@${plan_old[$i]}=>${plan_new[$i]}"
+            sep=","
+        done
+    fi
+
+    write_output "alloy_sha" "$alloy_sha"
+    write_output "aligned_count" "$aligned_count"
+    write_output "aligned_modules" "$aligned_csv"
+
+    log_info "Done. alloy_sha=${alloy_sha} aligned_count=${aligned_count}"
+}
+
+main "$@"

--- a/scripts/release-train.sh
+++ b/scripts/release-train.sh
@@ -29,6 +29,16 @@ SKIP_UPSTREAM_SYNC_CHECK=false
 EXCLUDE_CHECK_NAME=""
 WORKDIR=""
 
+# Alloy alignment: on by default, can be flipped off globally via env var,
+# per-run via --align-with-alloy / --no-align-with-alloy, or via workflow input.
+# Long-term, when Beyla ships as an embedded binary in Alloy, set the env var
+# default to "false" (or delete the wiring) and the alignment becomes a no-op.
+ALIGN_WITH_ALLOY="${RELEASE_TRAIN_ALIGN_WITH_ALLOY:-true}"
+ALLOY_REPO="${RELEASE_TRAIN_ALLOY_REPO:-grafana/alloy}"
+ALLOY_REF="${RELEASE_TRAIN_ALLOY_REF:-main}"
+ALLOY_RESOLVED_SHA=""
+ALLOY_ALIGN_TOTAL=0
+
 RELEASE_TRAIN_TOKEN="${RELEASE_TRAIN_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
 OUTPUT_FILE="${RELEASE_TRAIN_OUTPUT_FILE:-}"
 
@@ -85,6 +95,19 @@ Prepare-only options:
                           patch -> force PATCH bump
   --skip-upstream-sync-check
                           Skip verification that grafana OBI main includes upstream OBI main
+  --align-with-alloy      Pin OTel + Prometheus deps in release branches to grafana/alloy (default)
+  --no-align-with-alloy   Skip the Alloy alignment step entirely
+  --alloy-repo <owner/repo>
+                          Alloy repository to read go.mod from. Default: grafana/alloy
+  --alloy-ref <ref>       Branch, tag, or SHA in --alloy-repo. Default: main.
+                          Resolved to a concrete SHA once per prepare run so
+                          OBI and Beyla release branches are aligned against
+                          the same snapshot.
+
+Environment:
+  RELEASE_TRAIN_ALIGN_WITH_ALLOY  true|false - default for --align-with-alloy (kill switch)
+  RELEASE_TRAIN_ALLOY_REPO        default for --alloy-repo
+  RELEASE_TRAIN_ALLOY_REF         default for --alloy-ref
 
 Examples:
   # Auto compute the next release versions and cut release branches
@@ -520,6 +543,93 @@ uncomment_bpfel_in_gitignore() {
     rm -f "${gitignore}.bak"
 }
 
+align_with_alloy() {
+    local repo_dir="$1"
+    local repo_label="$2"
+
+    if [[ "$ALIGN_WITH_ALLOY" != "true" ]]; then
+        log_info "Alloy alignment disabled for ${repo_label}; skipping."
+        return 0
+    fi
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local aligner="${script_dir}/align-with-alloy.sh"
+    if [[ ! -x "$aligner" ]]; then
+        die "align-with-alloy.sh not found or not executable at ${aligner}"
+    fi
+
+    # First call: pin to the caller-provided ref and capture the resolved SHA.
+    # Subsequent calls: pass the resolved SHA so both repos align to the same snapshot.
+    local effective_ref="$ALLOY_REF"
+    if [[ -n "$ALLOY_RESOLVED_SHA" ]]; then
+        effective_ref="$ALLOY_RESOLVED_SHA"
+    fi
+
+    local out_file
+    out_file="$(mktemp -t align-output.XXXXXX)"
+
+    local -a cmd
+    cmd=("$aligner"
+        --repo-dir "$repo_dir"
+        --alloy-repo "$ALLOY_REPO"
+        --alloy-ref "$effective_ref")
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        cmd+=(--dry-run)
+    fi
+
+    log_info "Aligning ${repo_label} with ${ALLOY_REPO}@${effective_ref}"
+    ALIGN_OUTPUT_FILE="$out_file" run_cmd "${cmd[@]}"
+
+    local alloy_sha aligned_count aligned_modules
+    alloy_sha="$(awk -F= '/^alloy_sha=/ { print $2; exit }' "$out_file")"
+    aligned_count="$(awk -F= '/^aligned_count=/ { print $2; exit }' "$out_file")"
+    aligned_modules="$(awk -F= '/^aligned_modules=/ { sub(/^aligned_modules=/, ""); print; exit }' "$out_file")"
+    rm -f "$out_file"
+
+    [[ -n "$alloy_sha" ]] || die "align-with-alloy.sh did not emit an alloy_sha"
+
+    if [[ -z "$ALLOY_RESOLVED_SHA" ]]; then
+        ALLOY_RESOLVED_SHA="$alloy_sha"
+    elif [[ "$ALLOY_RESOLVED_SHA" != "$alloy_sha" ]]; then
+        die "Alloy SHA drifted between repos: ${ALLOY_RESOLVED_SHA} vs ${alloy_sha}"
+    fi
+
+    aligned_count="${aligned_count:-0}"
+    ALLOY_ALIGN_TOTAL=$((ALLOY_ALIGN_TOTAL + aligned_count))
+
+    if [[ "$aligned_count" == "0" ]]; then
+        log_info "${repo_label} already aligned with grafana/alloy@${alloy_sha:0:12}; nothing to commit."
+        return 0
+    fi
+
+    local short_sha="${alloy_sha:0:12}"
+    local commit_subject="Align ${repo_label} with ${ALLOY_REPO}@${short_sha}"
+    local commit_body_file
+    commit_body_file="$(mktemp -t align-commit.XXXXXX)"
+    {
+        printf '%s\n\n' "$commit_subject"
+        printf 'Alloy ref:  %s\n' "$effective_ref"
+        printf 'Alloy SHA:  %s\n' "$alloy_sha"
+        printf 'Aligned:    %s module(s)\n' "$aligned_count"
+        printf '\n'
+        printf 'Downgrades:\n'
+        # aligned_modules is a CSV of <module>@<old>=><new>
+        printf '%s' "$aligned_modules" | awk -v RS=',' 'NF { print "  " $0 }'
+    } > "$commit_body_file"
+
+    run_write_cmd git -C "$repo_dir" add -A
+    if git -C "$repo_dir" diff --cached --quiet; then
+        log_warn "${repo_label}: aligner reported ${aligned_count} change(s) but git sees no staged diff."
+        rm -f "$commit_body_file"
+        return 0
+    fi
+
+    run_write_cmd git -C "$repo_dir" commit -F "$commit_body_file"
+    rm -f "$commit_body_file"
+}
+
 prepare_obi_branch() {
     local version="$1"
     local release_branch="$2"
@@ -543,6 +653,8 @@ prepare_obi_branch() {
     fi
 
     uncomment_bpfel_in_gitignore "$OBI_DIR"
+
+    align_with_alloy "$OBI_DIR" "OBI ${release_branch}"
 
     run_write_cmd make -C "$OBI_DIR" docker-generate
     run_write_cmd make -C "$OBI_DIR" java-build
@@ -576,6 +688,8 @@ prepare_beyla_branch() {
     else
         log_info "No Beyla submodule pointer change to commit."
     fi
+
+    align_with_alloy "$BEYLA_DIR" "Beyla ${release_branch}"
 
     uncomment_bpfel_in_gitignore "$BEYLA_DIR"
 
@@ -734,6 +848,11 @@ prepare_command() {
     set_output "obi_sha" "$obi_sha"
     set_output "beyla_repo" "$BEYLA_REPO"
     set_output "obi_repo" "$OBI_REPO"
+    set_output "alloy_aligned" "$ALIGN_WITH_ALLOY"
+    set_output "alloy_repo" "$ALLOY_REPO"
+    set_output "alloy_ref" "$ALLOY_REF"
+    set_output "alloy_sha" "$ALLOY_RESOLVED_SHA"
+    set_output "alloy_align_total" "$ALLOY_ALIGN_TOTAL"
 }
 
 tag_command() {
@@ -895,6 +1014,40 @@ parse_args() {
             --skip-upstream-sync-check)
                 SKIP_UPSTREAM_SYNC_CHECK=true
                 shift
+                ;;
+            --align-with-alloy)
+                ALIGN_WITH_ALLOY=true
+                shift
+                ;;
+            --no-align-with-alloy)
+                ALIGN_WITH_ALLOY=false
+                shift
+                ;;
+            --align-with-alloy=*)
+                case "${1#*=}" in
+                    true|1) ALIGN_WITH_ALLOY=true ;;
+                    false|0) ALIGN_WITH_ALLOY=false ;;
+                    *) die "Invalid value for --align-with-alloy: ${1#*=} (expected true/false)" ;;
+                esac
+                shift
+                ;;
+            --alloy-repo=*)
+                ALLOY_REPO="${1#*=}"
+                shift
+                ;;
+            --alloy-repo)
+                require_option_value "$1" "${2:-}"
+                ALLOY_REPO="${2:-}"
+                shift 2
+                ;;
+            --alloy-ref=*)
+                ALLOY_REF="${1#*=}"
+                shift
+                ;;
+            --alloy-ref)
+                require_option_value "$1" "${2:-}"
+                ALLOY_REF="${2:-}"
+                shift 2
                 ;;
             --help|-h)
                 show_help


### PR DESCRIPTION
Pins OTel and Prometheus dependencies in the OBI and Beyla release branches to Alloy's `go.mod`. Does not affect OBI or Beyla `main`.

This is set to `default: true` but can be flipped to `false` at any time if this is no longer required.