### PR TITLE
Helm chart: mount host machine-id files in Beyla container

### DIFF
--- a/charts/beyla/Chart.yaml
+++ b/charts/beyla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: beyla
-version: 1.16.5
+version: 1.16.6
 appVersion: 3.9.5
 description: eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 home: https://grafana.com/oss/beyla-ebpf/

--- a/charts/beyla/README.md
+++ b/charts/beyla/README.md
@@ -1,6 +1,6 @@
 # beyla
 
-![Version: 1.16.5](https://img.shields.io/badge/Version-1.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.5](https://img.shields.io/badge/AppVersion-3.9.5-informational?style=flat-square)
+![Version: 1.16.6](https://img.shields.io/badge/Version-1.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.5](https://img.shields.io/badge/AppVersion-3.9.5-informational?style=flat-square)
 
 eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network metrics.
 
@@ -67,6 +67,7 @@ eBPF-based autoinstrumentation HTTP, HTTP2 and gRPC services, as well as network
 | k8sCache.service.name | string | `"beyla-k8s-cache"` | Name of both the Service and Deployment |
 | k8sCache.service.port | int | `50055` | Port of the Kubernetes metadata cache service. |
 | k8sCache.tolerations | list | `[]` | Tolerations allow cache pods to be scheduled on nodes with specific taints |
+| machineIDFiles | list | `["/etc/machine-id"]` | Read-only host files to mount into the Beyla DaemonSet at the same absolute path. Each entry is mounted as a hostPath volume with `type: File`, so the file must exist on the node. |
 | minReadySeconds | int | `0` | Minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its containers crashing, for it to be considered available. ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#min-ready-seconds |
 | nameOverride | string | `""` | Overrides the chart's name |
 | namespaceOverride | string | `""` | Override the deployment namespace |

--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -123,6 +123,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/beyla/config
               name: beyla-config
+          {{- range $index, $path := .Values.machineIDFiles }}
+            - mountPath: {{ $path | quote }}
+              name: machine-id-file-{{ $index }}
+              readOnly: true
+          {{- end }}
           {{- if .Values.contextPropagation.enabled }}
             - mountPath: /sys/fs/cgroup
               name: cgroup
@@ -154,6 +159,12 @@ spec:
         - name: beyla-config
           configMap:
             name: {{ default (include "beyla.fullname" .) .Values.config.name }}
+      {{- range $index, $path := .Values.machineIDFiles }}
+        - name: machine-id-file-{{ $index }}
+          hostPath:
+            path: {{ $path | quote }}
+            type: File
+      {{- end }}
       {{- if .Values.contextPropagation.enabled }}
         - name: cgroup
           hostPath:

--- a/charts/beyla/tests/unit/daemon-set.yaml
+++ b/charts/beyla/tests/unit/daemon-set.yaml
@@ -70,3 +70,59 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/version"]
           value: "custom"
+
+  - it: should mount default host machine-id files as read-only
+    template: daemon-set.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/machine-id
+            name: machine-id-file-0
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: machine-id-file-0
+            hostPath:
+              path: /etc/machine-id
+              type: File
+
+  - it: should allow disabling machine-id host file mounts
+    template: daemon-set.yaml
+    set:
+      machineIDFiles: []
+      contextPropagation:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /etc/beyla/config
+              name: beyla-config
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: beyla-config
+              configMap:
+                name: RELEASE-NAME-beyla
+
+  - it: should allow replacing machine-id host file mounts
+    template: daemon-set.yaml
+    set:
+      machineIDFiles:
+        - /run/custom-machine-id
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /run/custom-machine-id
+            name: machine-id-file-0
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: machine-id-file-0
+            hostPath:
+              path: /run/custom-machine-id
+              type: File

--- a/charts/beyla/values.yaml
+++ b/charts/beyla/values.yaml
@@ -152,6 +152,14 @@ updateStrategy:
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#min-ready-seconds
 minReadySeconds: 0
 
+# -- Read-only host files to mount into the Beyla DaemonSet at the same absolute path.
+# Each entry is mounted as a hostPath volume with `type: File`, so the file must exist on the node.
+machineIDFiles:
+  - /etc/machine-id
+  # disabling entry below af it is ignored if /etc/machine-id exists,
+  # to prevent that the deployment fails in a node not containing this file
+  # - /var/lib/dbus/machine-id
+
 # -- Additional volumes on the output daemonset definition.
 volumes: []
 # - name: foo


### PR DESCRIPTION
Beyla node can't identify the host.id when running in kubernetes, as it requires to access the `/etc/machine-id` file.