### PR TITLE
ci(supervisor): use REST API to request Copilot review

### DIFF
--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -247,7 +247,10 @@ jobs:
             NON_GREEN=$(echo "$CHECKS_JSON" | jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")] | length')
             if [ "$NON_GREEN" -eq 0 ]; then
               echo "All checks green — requesting Copilot review"
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "copilot"
+              gh api --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+                -f "reviewers[]=Copilot"
             fi
           else
             echo "${PENDING} of ${TOTAL} checks still pending — handle-ci-completion job will promote when CI completes"
@@ -379,4 +382,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           echo "All CI checks green on automated PR #${PR_NUMBER}. Requesting Copilot review."
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "copilot"
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=Copilot"


### PR DESCRIPTION
## Summary

The supervisor's `Request Copilot review` step was failing with `GraphQL: Could not resolve user with login 'copilot'` (see [run on PR #2750](https://github.com/grafana/beyla/actions/runs/24988457796)). The gate (`should_request_review`) was set correctly — the failure was at the `gh pr edit --add-reviewer "copilot"` API call.

GitHub records the Copilot reviewer as `Copilot` (capital C) when added via the UI. Switching both call sites in `supervisor_rerun-flaky.yml` to call `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` directly with `reviewers[]=Copilot` bypasses `gh`'s user-resolution step.

## Test plan

- [ ] Next automated PR (e.g. an OBI submodule bump) reaches all-green and gets Copilot requested automatically by the supervisor