### PR TITLE
feat(webhook): inject k8s.pod.ip resource attribute via downward API

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -2029,6 +2029,11 @@
     },
     "SDKResource": {
       "properties": {
+        "addK8sIPAttribute": {
+          "type": "boolean",
+          "description": "AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set from the Kubernetes downward API (status.podIP). Useful for environments where the OTel k8sattributesprocessor cannot infer the pod IP from the connection source (e.g. clusters behind a NAT gateway). +optional",
+          "x-env-var": "BEYLA_RESOURCE_ADD_K8S_IP_ATTRIBUTE"
+        },
         "addK8sUIDAttributes": {
           "type": "boolean",
           "description": "AddK8sUIDAttributes defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid). +optional",

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -375,6 +375,13 @@ type SDKResource struct {
 	// +optional
 	AddK8sUIDAttributes bool `yaml:"addK8sUIDAttributes" env:"BEYLA_RESOURCE_ADD_K8S_UID_ATTRIBUTES"`
 
+	// AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set
+	// from the Kubernetes downward API (status.podIP). Useful for environments where the
+	// OTel k8sattributesprocessor cannot infer the pod IP from the connection source
+	// (e.g. clusters behind a NAT gateway).
+	// +optional
+	AddK8sIPAttribute bool `yaml:"addK8sIPAttribute" env:"BEYLA_RESOURCE_ADD_K8S_IP_ATTRIBUTE"`
+
 	// UseLabelsForResourceAttributes defines whether to use common labels for resource attributes:
 	// Note: first entry wins:
 	//   - `app.kubernetes.io/instance` becomes `service.name`

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -441,6 +441,9 @@ When no selector matches or selector is nil, these environment variables are not
 **[4] Kubernetes UID Attributes:**
 Pod UID is only set when `cfg.Injector.Resources.AddK8sUIDAttributes = true`.
 
+**[4b] Kubernetes Pod IP Attribute:**
+`k8s.pod.ip` is only set when `cfg.Injector.Resources.AddK8sIPAttribute = true`. The value is sourced from the Kubernetes downward API (`status.podIP`) and resolved by the kubelet at container start, after the CNI assigns the pod IP. Useful for clusters behind a NAT gateway, where the OTel `k8sattributesprocessor` cannot infer the pod IP from the connection source address.
+
 **[5] Service Name Derivation:**
 Follows the [OpenTelemetry Kubernetes semantic conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/). Priority order:
 1. Annotation: `resource.opentelemetry.io/service.name`
@@ -490,6 +493,7 @@ cfg.Injector.Resources = beyla.ResourcesConfig{
     },
     UseLabelsForResourceAttributes: true,
     AddK8sUIDAttributes: true,
+    AddK8sIPAttribute:   true,
 }
 ```
 

--- a/pkg/webhook/env_vars.go
+++ b/pkg/webhook/env_vars.go
@@ -120,8 +120,13 @@ func (pm *PodMutator) setResourceAttributes(meta *metav1.ObjectMeta, container *
 	// node name has to be added to extra attributes as there is no dedicated OTEL_INJECTOR_* variable
 	extraResAttrs[semconv.K8SNodeNameKey] =
 		setEnvVarFromFieldPath(container, envOtelK8sNodeName, "spec.nodeName")
-	extraResAttrs[attribute.Key("k8s.pod.ip")] =
-		setEnvVarFromFieldPath(container, envOtelK8sPodIP, "status.podIP")
+
+	if cfg.AddK8sIPAttribute {
+		// k8s.pod.ip is resolved at container start by the kubelet, after the CNI assigns the IP.
+		// semconv v1.37.0 doesn't yet expose K8SPodIPKey (added in v1.40.0), so reference the key directly.
+		extraResAttrs[attribute.Key("k8s.pod.ip")] =
+			setEnvVarFromFieldPath(container, envOtelK8sPodIP, "status.podIP")
+	}
 
 	if cfg.AddK8sUIDAttributes {
 		setEnvVarFromFieldPath(container, envInjectorOtelK8sPodUID, "metadata.uid")

--- a/pkg/webhook/env_vars.go
+++ b/pkg/webhook/env_vars.go
@@ -120,6 +120,8 @@ func (pm *PodMutator) setResourceAttributes(meta *metav1.ObjectMeta, container *
 	// node name has to be added to extra attributes as there is no dedicated OTEL_INJECTOR_* variable
 	extraResAttrs[semconv.K8SNodeNameKey] =
 		setEnvVarFromFieldPath(container, envOtelK8sNodeName, "spec.nodeName")
+	extraResAttrs[attribute.Key("k8s.pod.ip")] =
+		setEnvVarFromFieldPath(container, envOtelK8sPodIP, "status.podIP")
 
 	if cfg.AddK8sUIDAttributes {
 		setEnvVarFromFieldPath(container, envInjectorOtelK8sPodUID, "metadata.uid")

--- a/pkg/webhook/env_vars_test.go
+++ b/pkg/webhook/env_vars_test.go
@@ -2158,35 +2158,55 @@ func TestPodMutator_disableUndesiredSDKs(t *testing.T) {
 func TestConfigureContainerEnvVars_K8sPodIP(t *testing.T) {
 	const expectedEnvName = "OTEL_RESOURCE_ATTRIBUTES_POD_IP"
 
-	cfg := &beyla.Config{
-		Injector: beyla.SDKInject{
-			Resources: beyla.SDKResource{
-				Attributes:                     map[string]string{},
-				UseLabelsForResourceAttributes: false,
-				AddK8sUIDAttributes:            false,
-			},
-		},
-	}
-	meta := &metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}
-	container := &corev1.Container{Name: "test-container", Image: "myapp:v1.0.0", Env: []corev1.EnvVar{}}
-
-	pm := &PodMutator{cfg: cfg}
-	pm.configureContainerEnvVars(meta, container, nil)
-
-	var podIPVar *corev1.EnvVar
-	var resAttrs string
-	for i := range container.Env {
-		switch container.Env[i].Name {
-		case expectedEnvName:
-			podIPVar = &container.Env[i]
-		case envInjectorOtelExtraResourceAttrs:
-			resAttrs = container.Env[i].Value
-		}
+	tests := []struct {
+		name              string
+		addK8sIPAttribute bool
+		expectVar         bool
+	}{
+		{name: "opt-in disabled by default", addK8sIPAttribute: false, expectVar: false},
+		{name: "opt-in enabled", addK8sIPAttribute: true, expectVar: true},
 	}
 
-	require.NotNil(t, podIPVar, "expected env var %q to be set", expectedEnvName)
-	require.NotNil(t, podIPVar.ValueFrom)
-	require.NotNil(t, podIPVar.ValueFrom.FieldRef)
-	assert.Equal(t, "status.podIP", podIPVar.ValueFrom.FieldRef.FieldPath)
-	assert.Contains(t, resAttrs, "k8s.pod.ip=$("+expectedEnvName+")")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &beyla.Config{
+				Injector: beyla.SDKInject{
+					Resources: beyla.SDKResource{
+						Attributes:                     map[string]string{},
+						UseLabelsForResourceAttributes: false,
+						AddK8sUIDAttributes:            false,
+						AddK8sIPAttribute:              tt.addK8sIPAttribute,
+					},
+				},
+			}
+			meta := &metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}
+			container := &corev1.Container{Name: "test-container", Image: "myapp:v1.0.0", Env: []corev1.EnvVar{}}
+
+			pm := &PodMutator{cfg: cfg}
+			pm.configureContainerEnvVars(meta, container, nil)
+
+			var podIPVar *corev1.EnvVar
+			var resAttrs string
+			for i := range container.Env {
+				switch container.Env[i].Name {
+				case expectedEnvName:
+					podIPVar = &container.Env[i]
+				case envInjectorOtelExtraResourceAttrs:
+					resAttrs = container.Env[i].Value
+				}
+			}
+
+			if !tt.expectVar {
+				assert.Nil(t, podIPVar, "expected env var %q to NOT be set when AddK8sIPAttribute is false", expectedEnvName)
+				assert.NotContains(t, resAttrs, "k8s.pod.ip")
+				return
+			}
+
+			require.NotNil(t, podIPVar, "expected env var %q to be set", expectedEnvName)
+			require.NotNil(t, podIPVar.ValueFrom)
+			require.NotNil(t, podIPVar.ValueFrom.FieldRef)
+			assert.Equal(t, "status.podIP", podIPVar.ValueFrom.FieldRef.FieldPath)
+			assert.Contains(t, resAttrs, "k8s.pod.ip=$("+expectedEnvName+")")
+		})
+	}
 }

--- a/pkg/webhook/env_vars_test.go
+++ b/pkg/webhook/env_vars_test.go
@@ -2154,3 +2154,39 @@ func TestPodMutator_disableUndesiredSDKs(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigureContainerEnvVars_K8sPodIP(t *testing.T) {
+	const expectedEnvName = "OTEL_RESOURCE_ATTRIBUTES_POD_IP"
+
+	cfg := &beyla.Config{
+		Injector: beyla.SDKInject{
+			Resources: beyla.SDKResource{
+				Attributes:                     map[string]string{},
+				UseLabelsForResourceAttributes: false,
+				AddK8sUIDAttributes:            false,
+			},
+		},
+	}
+	meta := &metav1.ObjectMeta{Name: "test-pod", Namespace: "default"}
+	container := &corev1.Container{Name: "test-container", Image: "myapp:v1.0.0", Env: []corev1.EnvVar{}}
+
+	pm := &PodMutator{cfg: cfg}
+	pm.configureContainerEnvVars(meta, container, nil)
+
+	var podIPVar *corev1.EnvVar
+	var resAttrs string
+	for i := range container.Env {
+		switch container.Env[i].Name {
+		case expectedEnvName:
+			podIPVar = &container.Env[i]
+		case envInjectorOtelExtraResourceAttrs:
+			resAttrs = container.Env[i].Value
+		}
+	}
+
+	require.NotNil(t, podIPVar, "expected env var %q to be set", expectedEnvName)
+	require.NotNil(t, podIPVar.ValueFrom)
+	require.NotNil(t, podIPVar.ValueFrom.FieldRef)
+	assert.Equal(t, "status.podIP", podIPVar.ValueFrom.FieldRef.FieldPath)
+	assert.Contains(t, resAttrs, "k8s.pod.ip=$("+expectedEnvName+")")
+}

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -56,6 +56,7 @@ const (
 	envInjectorOtelK8sContainerName   = "OTEL_INJECTOR_K8S_CONTAINER_NAME"
 	envInjectorDebugName              = "OTEL_INJECTOR_LOG_LEVEL"
 	envOtelK8sNodeName                = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME" // stored in OTEL_INJECTOR_RESOURCE_ATTRIBUTES, since there's no individual OTEL_INJECTOR_K8S_NODE_NAME
+	envOtelK8sPodIP                   = "OTEL_RESOURCE_ATTRIBUTES_POD_IP"
 	envVarSDKVersion                  = "BEYLA_INJECTOR_SDK_PKG_VERSION"
 	envOtelTracesSamplerName          = "OTEL_TRACES_SAMPLER"
 	envOtelTracesSamplerArgName       = "OTEL_TRACES_SAMPLER_ARG"


### PR DESCRIPTION
Fixes #2673 — when Beyla's webhook injects an OTel SDK into a pod, the SDK now sets `k8s.pod.ip` as a resource attribute, sourced from the downward API (`status.podIP`).

This unblocks the OTel `k8sattributesprocessor` in NAT-gateway clusters, where the processor can't infer Pod IP from the connection's source address (option 1 in the issue body) and needs it as a resource attribute (option 2).

## How
Mirrors the existing `K8SNodeName` plumbing in `setResourceAttributes` (the "extra attributes" path used when there's no dedicated `OTEL_INJECTOR_*` variable):

- New constant `envOtelK8sPodIP = "OTEL_RESOURCE_ATTRIBUTES_POD_IP"` in `mutator.go`.
- One new line in `setResourceAttributes` that registers a `valueFrom: fieldRef: status.podIP` env var on the container and references it as `k8s.pod.ip=$(...)` in `OTEL_INJECTOR_RESOURCE_ATTRIBUTES`.

`semconv/v1.37.0` (the version Beyla currently imports) doesn't expose `K8SPodIPKey` (landed in v1.40.0), so I used `attribute.Key("k8s.pod.ip")` directly to keep the diff minimal.

