### PR TITLE
ci(release-train): install ARM64 cross-compiler for Java agent build

### DIFF
--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -71,6 +71,11 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Install ARM64 cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+
       - name: Login to DockerHub
         uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
 


### PR DESCRIPTION
## Summary

Fixes the `Create release branches with binaries` workflow, which has been failing on `main` since OBI submodule bump #2760 (run [25113401595](https://github.com/grafana/beyla/actions/runs/25113401595/job/73593500509)).

OBI [#1931](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1931) made the Java agent's Gradle build produce native libraries for both amd64 and aarch64. The new `:agent:buildNativeLib-aarch64` task invokes `aarch64-linux-gnu-gcc`, which is not present on `ubuntu-latest`, so `make java-build` fails with `Error 127`. This patch installs the same cross-toolchain (`gcc-aarch64-linux-gnu` + `libc6-dev-arm64-cross`) that OBI's own `.github/workflows/java-agent.yml` uses, so Gradle can cross-compile the aarch64 `.so` baked into the embedded JAR.

## Test plan

- [ ] Re-run `release-train-prepare.yml` against `main` (with `dry_run: true`) and confirm the `Create release branches and artifacts` step passes the `java-build` stage.