### PR TITLE
feat(webhook): use semconv K8SPodIPKey from v1.40.0 spec

### DIFF
--- a/pkg/webhook/env_vars.go
+++ b/pkg/webhook/env_vars.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/distribution/reference"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -122,9 +122,7 @@ func (pm *PodMutator) setResourceAttributes(meta *metav1.ObjectMeta, container *
 		setEnvVarFromFieldPath(container, envOtelK8sNodeName, "spec.nodeName")
 
 	if cfg.AddK8sIPAttribute {
-		// k8s.pod.ip is resolved at container start by the kubelet, after the CNI assigns the IP.
-		// semconv v1.37.0 doesn't yet expose K8SPodIPKey (added in v1.40.0), so reference the key directly.
-		extraResAttrs[attribute.Key("k8s.pod.ip")] =
+		extraResAttrs[semconv.K8SPodIPKey] =
 			setEnvVarFromFieldPath(container, envOtelK8sPodIP, "status.podIP")
 	}
 

--- a/pkg/webhook/env_vars_test.go
+++ b/pkg/webhook/env_vars_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
Follow-up to #2762, addressing https://github.com/grafana/beyla/pull/2762#issuecomment-4372043544.

Bumps the OpenTelemetry semconv import in `pkg/webhook` from `v1.37.0` to `v1.40.0` so the `k8s.pod.ip` resource attribute can reference the spec-defined `semconv.K8SPodIPKey` constant instead of a hardcoded `attribute.Key("k8s.pod.ip")` literal. `K8SPodIPKey` was added to the OTel semconv spec in v1.40.0.

## Changes
- `pkg/webhook/env_vars.go`: import `semconv/v1.40.0`; replace `attribute.Key("k8s.pod.ip")` with `semconv.K8SPodIPKey`; drop the now-stale comment explaining why the key was hardcoded.
- `pkg/webhook/env_vars_test.go`: bump import to `v1.40.0` for consistency. All semconv keys referenced in tests (`ServiceNameKey`, `ServiceNamespaceKey`, `ServiceVersionKey`, `ServiceInstanceIDKey`, `K8SDeploymentNameKey`, `K8SReplicaSetNameKey`, `K8SStatefulSetNameKey`, `K8SDaemonSetNameKey`, `K8SCronJobNameKey`, `K8SJobNameKey`) are present in v1.40.0.

No behavior change — `K8SPodIPKey` is `attribute.Key("k8s.pod.ip")`, identical to the literal it replaces.

## Test plan
- [ ] CI build passes
- [ ] CI unit tests pass (`pkg/webhook/env_vars_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)