### PR TITLE
Fix OBI version to Beyla version

### DIFF
--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       obi_version:
-        description: "Optional explicit OBI version (vMAJOR.MINOR.PATCH)"
+        description: "Optional explicit OBI version (vMAJOR.MINOR.PATCH). Defaults to beyla_version when omitted."
         required: false
         type: string
       bump:

--- a/.github/workflows/release-train-tag.yml
+++ b/.github/workflows/release-train-tag.yml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
       obi_version:
-        description: "OBI version to prerelease/tag (vMAJOR.MINOR.PATCH)"
-        required: true
+        description: "Optional OBI version to prerelease/tag (vMAJOR.MINOR.PATCH). Defaults to beyla_version when omitted."
+        required: false
         type: string
       dry_run:
         description: "Dry run mode (validate only)"
@@ -65,10 +65,13 @@ jobs:
 
           cmd=(./scripts/release-train.sh tag
             --beyla-version "${BEYLA_VERSION_INPUT}"
-            --obi-version "${OBI_VERSION_INPUT}"
             --beyla-repo "${{ github.repository }}"
             --obi-repo "grafana/opentelemetry-ebpf-instrumentation"
             --exclude-check "${{ github.job }}")
+
+          if [[ -n "${OBI_VERSION_INPUT}" ]]; then
+            cmd+=(--obi-version "${OBI_VERSION_INPUT}")
+          fi
 
           if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
             cmd+=(--dry-run)

--- a/devdocs/new-release.md
+++ b/devdocs/new-release.md
@@ -3,8 +3,13 @@
 ## Overview
 
 Beyla embeds OBI as the `.obi-src` git submodule.
-Beyla and `grafana/opentelemetry-ebpf-instrumentation` are versioned
-independently.
+By default, Beyla and `grafana/opentelemetry-ebpf-instrumentation` share
+the same version: when Beyla cuts `v3.14.0`, the OBI fork is tagged
+`v3.14.0` against the SHA pinned by Beyla (and a matching patch tag is
+cut for every Beyla patch, even when `.obi-src` is unchanged). The
+release-train workflows expose an `obi_version` input that can override
+this default for out-of-band OBI-only releases, but the default path
+should be used in every normal release.
 
 The release process follows a weekly release train and Semantic Versioning only:
 
@@ -23,7 +28,7 @@ to `prod`.
 Example used in this document:
 
 - Beyla release: `v3.0.0`
-- OBI release: `v1.0.0`
+- OBI release: `v3.0.0` (defaults to the Beyla version)
 
 ## Automation Workflows
 
@@ -31,10 +36,10 @@ Example used in this document:
 - `bot_sync-obi-submodule.yml`: weekly (Monday) update of Beyla `.obi-src` on `main`.
 - [`release-train-prepare.yml`](../.github/workflows/release-train-prepare.yml): creates or updates OBI and Beyla release branches and regenerates artifacts.
   - Manual dispatch after OBI fork is synced.
-  - Supports separate Beyla and OBI versions.
+  - `obi_version` defaults to `beyla_version`; only set it when an out-of-band OBI version is required.
 - [`release-train-tag.yml`](../.github/workflows/release-train-tag.yml): creates GitHub prereleases and SemVer tags in OBI and Beyla.
   - Manual dispatch after release branch CI is green.
-  - Supports separate Beyla and OBI versions.
+  - `obi_version` defaults to `beyla_version`; only set it when an out-of-band OBI version is required.
 - [`promote-patch-to-stable.yml`](../.github/workflows/promote-patch-to-stable.yml): marks a prerelease as stable/latest and promotes Docker tags.
 
 ## End-to-End Flow
@@ -44,18 +49,19 @@ Example used in this document:
 - OBI fork is synced from upstream.
 - Beyla `main` is synced to latest intended OBI state.
 - CI on Beyla `main` is green.
-- Example below assumes Beyla `v3.0.0` and OBI `v1.0.0`.
+- Example below assumes Beyla `v3.0.0` (OBI defaults to the same `v3.0.0`).
 
 ### 2. Create release branches
 
 Run [`release-train-prepare.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-prepare.yml)
-with separate Beyla and OBI versions, or do the same work manually.
+with the Beyla version (OBI inherits the same version), or do the same
+work manually.
 
 Step outcome:
 
-This creates `release-1.0` in OBI and `release-3.0` in Beyla. Both are
-based on the OBI SHA pinned by Beyla `main`, and both get their release
-artifacts committed before CI runs.
+This creates `release-3.0` in both OBI and Beyla. Both are based on the
+OBI SHA pinned by Beyla `main`, and both get their release artifacts
+committed before CI runs.
 
 First, inspect Beyla `main` and confirm the OBI SHA that it pins. For example, 
 Beyla `main` points to OBI commit `8634fc94ab21b86dd829fa92c87d8120790de337`.
@@ -67,23 +73,23 @@ git checkout origin/main
 git ls-tree origin/main .obi-src
 ```
 
-Next, create the OBI release branch for `v1.0.0` from that pinned SHA and
+Next, create the OBI release branch for `v3.0.0` from that pinned SHA and
 generate the OBI artifacts that belong on the release branch.
 
 ```bash
 cd /path/to/opentelemetry-ebpf-instrumentation
 git fetch --prune origin
 git checkout 8634fc94ab21b86dd829fa92c87d8120790de337
-git checkout -B release-1.0
+git checkout -B release-3.0
 
 make docker-generate
 make java-build
 
 git add -A
 if ! git diff --cached --quiet; then
-  git commit -m "Release v1.0.0 artifacts"
+  git commit -m "Release v3.0.0 artifacts"
 fi
-git push -u origin release-1.0
+git push -u origin release-3.0
 ```
 
 Then create the Beyla release branch for `v3.0.0`, keep `.obi-src` pinned to
@@ -114,36 +120,35 @@ git push -u origin release-3.0
 
 Ensure both release branches are green:
 
-- `grafana/opentelemetry-ebpf-instrumentation:release-1.0`
+- `grafana/opentelemetry-ebpf-instrumentation:release-3.0`
 - `grafana/beyla:release-3.0`
 
 ### 4. Create prereleases and tags
 
 Run [`release-train-tag.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-tag.yml)
-with the Beyla and OBI versions, or do the same work manually after both
-release branches are green.
+with the Beyla version (OBI inherits the same version), or do the same
+work manually after both release branches are green.
 
 Step outcome:
 
-This creates the `v1.0.0` tag and prerelease in OBI and the `v3.0.0` tag and
-prerelease in Beyla.
+This creates the `v3.0.0` tag and prerelease in both OBI and Beyla.
 
 First, tag the OBI release branch and create the OBI prerelease.
 
 ```bash
 cd /path/to/opentelemetry-ebpf-instrumentation
 git fetch --prune --tags origin
-git checkout -B release-1.0 origin/release-1.0
+git checkout -B release-3.0 origin/release-3.0
 
-git tag v1.0.0 "$(git rev-parse HEAD)"
-git push origin refs/tags/v1.0.0
+git tag v3.0.0 "$(git rev-parse HEAD)"
+git push origin refs/tags/v3.0.0
 
-gh release create v1.0.0 \
+gh release create v3.0.0 \
   --repo grafana/opentelemetry-ebpf-instrumentation \
   --target "$(git rev-parse HEAD)" \
-  --title v1.0.0 \
+  --title v3.0.0 \
   --prerelease \
-  --notes "Release v1.0.0"
+  --notes "Release v3.0.0"
 ```
 
 Then tag the Beyla release branch and create the Beyla prerelease.
@@ -238,6 +243,11 @@ security hotfix for `v3.0.0`), use the patch release flow instead of the
 normal weekly train. Patch releases reuse the existing `release-MAJOR.MINOR`
 branch.
 
+Every patch ships matching Beyla and OBI tags. When the fix is in Beyla
+only and `.obi-src` is unchanged, OBI is still tagged at the same patch
+version against the SHA the previous OBI patch already pointed at — so
+that the OBI fork's tag stream stays in lockstep with Beyla's.
+
 ### Beyla-only patch release
 
 If the fix is in Beyla only (no OBI changes):
@@ -253,16 +263,19 @@ If the fix is in Beyla only (no OBI changes):
 
 2. **Prepare**: Run
    [`release-train-prepare.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-prepare.yml)
-   with `beyla_version=v3.0.1` and `obi_version=v1.0.0`. The script detects
-   that `PATCH != 0`, reuses the existing `release-3.0` branch, reads the
-   OBI submodule pointer from the release branch instead of `main`, and
-   regenerates release artifacts (`make vendor-obi`, `make java-build`).
-   The OBI artifact regeneration steps (`make docker-generate`,
-   `make java-build`) also run but should be a no-op when OBI is unchanged.
+   with `beyla_version=v3.0.1` (leave `obi_version` empty). The script
+   detects that `PATCH != 0`, reuses the existing `release-3.0` branch
+   on both repos, reads the OBI submodule pointer from the Beyla release
+   branch, and regenerates release artifacts (`make vendor-obi`,
+   `make java-build`). The OBI artifact regeneration steps
+   (`make docker-generate`, `make java-build`) also run but should be a
+   no-op when OBI is unchanged.
 
 3. **Tag**: After release branch CI is green, run
    [`release-train-tag.yml`](https://github.com/grafana/beyla/actions/workflows/release-train-tag.yml)
-   with the same versions. The tag `v3.0.1` is created on `release-3.0`.
+   with `beyla_version=v3.0.1` (leave `obi_version` empty). Both `v3.0.1`
+   tags are created on `release-3.0`. The OBI `v3.0.1` tag points at the
+   same SHA as the previous OBI patch.
 
 4. **Promote**: After validation in `ops`, run
    [`promote-patch-to-stable.yml`](https://github.com/grafana/beyla/actions/workflows/promote-patch-to-stable.yml)
@@ -277,7 +290,7 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
    ```bash
    cd /path/to/opentelemetry-ebpf-instrumentation
    git fetch --prune origin
-   git checkout -B release-1.0 origin/release-1.0
+   git checkout -B release-3.0 origin/release-3.0
    git cherry-pick <upstream-fix-sha>
 
    make docker-generate
@@ -285,9 +298,9 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
 
    git add -A
    if ! git diff --cached --quiet; then
-     git commit -m "Regenerate artifacts for v1.0.1"
+     git commit -m "Regenerate artifacts for v3.0.1"
    fi
-   git push origin release-1.0
+   git push origin release-3.0
    ```
 
 2. **Update Beyla's `.obi-src`** on the Beyla release branch to point to the
@@ -299,7 +312,7 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
    git submodule sync --recursive
    git submodule update --init --recursive
    git -C .obi-src fetch --prune origin
-   git -C .obi-src checkout origin/release-1.0
+   git -C .obi-src checkout origin/release-3.0
    git add .obi-src
    git commit -m "Update obi submodule for v3.0.1"
 
@@ -317,13 +330,14 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
    workflow in step 3 to regenerate artifacts automatically.
 
 3. **Prepare**: Run `release-train-prepare.yml` with `beyla_version=v3.0.1`
-   and `obi_version=v1.0.1`. The script reuses both existing release
-   branches and regenerates artifacts (OBI: `make docker-generate`,
-   `make java-build`; Beyla: `make vendor-obi`, `make java-build`).
+   (leave `obi_version` empty so OBI inherits the same version). The
+   script reuses both existing `release-3.0` branches and regenerates
+   artifacts (OBI: `make docker-generate`, `make java-build`; Beyla:
+   `make vendor-obi`, `make java-build`).
 
-4. **Tag**: Run `release-train-tag.yml` with the same versions after CI is
-   green. Tags `v3.0.1` and `v1.0.1` are created on their respective
-   release branches.
+4. **Tag**: Run `release-train-tag.yml` with `beyla_version=v3.0.1`
+   (leave `obi_version` empty) after CI is green. Both `v3.0.1` tags are
+   created on the respective `release-3.0` branches.
 
 5. **Promote**: Run `promote-patch-to-stable.yml` with
    `version_tag=v3.0.1` after validation in `ops`.
@@ -332,8 +346,10 @@ If the fix originates in OBI (e.g., a cherry-picked upstream security fix):
 
 The workflows above use `scripts/release-train.sh` under the hood, but the
 commands shown in each step are the manual `git`/`make`/`gh` equivalents.
-Use the manual path when Beyla and OBI are intentionally released with
-different version numbers, or when you want to inspect each step directly.
+Use the manual path (or the `obi_version` workflow override) when Beyla and
+OBI must intentionally be released with different version numbers — for
+example, an out-of-band OBI-only hotfix — or when you want to inspect
+each step directly.
 
 ## Checking if an OBI PR shipped in Beyla
 

--- a/scripts/release-train.sh
+++ b/scripts/release-train.sh
@@ -69,7 +69,7 @@ Commands:
 
 Common options:
   --beyla-version <vX.Y.Z>
-  --obi-version <vX.Y.Z>
+  --obi-version <vX.Y.Z>   Defaults to --beyla-version when omitted
   --beyla-repo <owner/repo>
   --obi-repo <owner/repo>
   --dry-run               Validate and print actions, without pushing/tags/releases
@@ -87,14 +87,17 @@ Prepare-only options:
                           Skip verification that grafana OBI main includes upstream OBI main
 
 Examples:
-  # Auto compute the next release versions and cut release branches
+  # Auto compute the next Beyla version and cut release branches (OBI version defaults to Beyla)
   ./scripts/release-train.sh prepare
 
-  # Force specific versions
-  ./scripts/release-train.sh prepare --beyla-version v4.3.0 --obi-version v1.0.0
+  # Force a specific Beyla version (OBI inherits the same version)
+  ./scripts/release-train.sh prepare --beyla-version v4.3.0
 
-  # After CI is green, create tags and prereleases
-  ./scripts/release-train.sh tag --beyla-version v4.3.0 --obi-version v1.0.0
+  # Override OBI version explicitly (escape hatch for out-of-band OBI releases)
+  ./scripts/release-train.sh prepare --beyla-version v4.3.0 --obi-version v4.3.1
+
+  # After CI is green, create tags and prereleases (OBI defaults to Beyla)
+  ./scripts/release-train.sh tag --beyla-version v4.3.0
 EOF
 }
 
@@ -470,16 +473,19 @@ resolve_prepare_versions() {
         validate_semver_tag "$OBI_VERSION"
         log_info "Using explicit OBI version: ${OBI_VERSION}"
     else
-        OBI_VERSION="$(auto_compute_next_version "$OBI_DIR" "$OBI_REPO")"
-        log_info "Auto-computed OBI version: ${OBI_VERSION}"
+        OBI_VERSION="$BEYLA_VERSION"
+        log_info "OBI version defaulted to Beyla version: ${OBI_VERSION}"
     fi
 }
 
 resolve_tag_versions() {
     [[ -n "$BEYLA_VERSION" ]] || die "--beyla-version is required for the tag command."
-    [[ -n "$OBI_VERSION" ]] || die "--obi-version is required for the tag command."
-
     validate_semver_tag "$BEYLA_VERSION"
+
+    if [[ -z "$OBI_VERSION" ]]; then
+        OBI_VERSION="$BEYLA_VERSION"
+        log_info "OBI version defaulted to Beyla version: ${OBI_VERSION}"
+    fi
     validate_semver_tag "$OBI_VERSION"
 }
 


### PR DESCRIPTION
This changes the release train workflow to tag grafana-obi using the same version of Beyla - this means that from now on, Beyla 3.a.b.c will be linked against OBI 3.a.b.c - this makes it easy for us to know which Grafana OBI version is being used by a given Beyla version. 


---

Dry run:

```
rafael@crux ~/dev/beyla  (fix_obi_ver)$ ./scripts/release-train.sh prepare --dry-run --beyla-repo grafana/beyla --obi-repo grafana/opentelemetry-ebpf-instrumentation --bump minor --skip-ci-check --skip-upstream-sync-check
[info] Workspace: /tmp/release-train.uBKSrO
[info] + git clone https://github.com/grafana/beyla.git /tmp/release-train.uBKSrO/beyla
Cloning into '/tmp/release-train.uBKSrO/beyla'...
remote: Enumerating objects: 81514, done.
remote: Counting objects: 100% (434/434), done.
remote: Compressing objects: 100% (207/207), done.
remote: Total 81514 (delta 342), reused 228 (delta 227), pack-reused 81080 (from 3)
Receiving objects: 100% (81514/81514), 346.15 MiB | 29.14 MiB/s, done.
Resolving deltas: 100% (51206/51206), done.
[info] + git -C /tmp/release-train.uBKSrO/beyla fetch --prune --tags origin
[info] + git clone https://github.com/grafana/opentelemetry-ebpf-instrumentation.git /tmp/release-train.uBKSrO/obi
Cloning into '/tmp/release-train.uBKSrO/obi'...
remote: Enumerating objects: 46806, done.
remote: Counting objects: 100% (999/999), done.
remote: Compressing objects: 100% (608/608), done.
remote: Total 46806 (delta 728), reused 407 (delta 390), pack-reused 45807 (from 3)
Receiving objects: 100% (46806/46806), 155.38 MiB | 30.89 MiB/s, done.
Resolving deltas: 100% (27960/27960), done.
[info] + git -C /tmp/release-train.uBKSrO/obi fetch --prune --tags origin
[info] + git -C /tmp/release-train.uBKSrO/beyla config user.name github-actions[bot]
[info] + git -C /tmp/release-train.uBKSrO/beyla config user.email github-actions[bot]@users.noreply.github.com
[info] + git -C /tmp/release-train.uBKSrO/obi config user.name github-actions[bot]
[info] + git -C /tmp/release-train.uBKSrO/obi config user.email github-actions[bot]@users.noreply.github.com
[info] + git -C /tmp/release-train.uBKSrO/beyla checkout -B main origin/main
branch 'main' set up to track 'origin/main'.
Reset branch 'main'
Your branch is up to date with 'origin/main'.
[info] + git -C /tmp/release-train.uBKSrO/obi checkout -B main origin/main
branch 'main' set up to track 'origin/main'.
Reset branch 'main'
Your branch is up to date with 'origin/main'.
[warn] Skipping CI check for grafana/beyla:main
[warn] Skipping OBI upstream sync check.
[info] Auto-computed Beyla version: v3.15.0
[info] OBI version defaulted to Beyla version: v3.15.0
[info] OBI SHA pinned in grafana/beyla:main: a7c15a39ac5f207eca6852d1995fbc0c5830b0ec
[info] + git -C /tmp/release-train.uBKSrO/obi fetch --prune origin
[info] + git -C /tmp/release-train.uBKSrO/obi checkout a7c15a39ac5f207eca6852d1995fbc0c5830b0ec
Note: switching to 'a7c15a39ac5f207eca6852d1995fbc0c5830b0ec'.

# ...


HEAD is now at a7c15a39 Fix iter_tcp (#1981)
[info] + git -C /tmp/release-train.uBKSrO/obi checkout -B release-3.15
Switched to a new branch 'release-3.15'
[info] Commenting out bpfel exclusions in /tmp/release-train.uBKSrO/obi/.gitignore for release branch
[info] [dry-run] make -C /tmp/release-train.uBKSrO/obi docker-generate
[info] [dry-run] make -C /tmp/release-train.uBKSrO/obi java-build
[info] [dry-run] git -C /tmp/release-train.uBKSrO/obi add -A
[info] No OBI artifact changes to commit.
[info] [dry-run] git -C /tmp/release-train.uBKSrO/obi push -u origin release-3.15
[info] OBI release branch tip SHA: a7c15a39ac5f207eca6852d1995fbc0c5830b0ec
[info] + git -C /tmp/release-train.uBKSrO/beyla fetch --prune origin
[info] + git -C /tmp/release-train.uBKSrO/beyla checkout -B release-3.15 origin/main
branch 'release-3.15' set up to track 'origin/main'.
Switched to a new branch 'release-3.15'
[info] + git -C /tmp/release-train.uBKSrO/beyla submodule sync --recursive
[info] + git -C /tmp/release-train.uBKSrO/beyla submodule update --init --recursive
Submodule 'obi-src' (https://github.com/grafana/opentelemetry-ebpf-instrumentation.git) registered for path '.obi-src'
Cloning into '/tmp/release-train.uBKSrO/beyla/.obi-src'...
Submodule path '.obi-src': checked out 'a7c15a39ac5f207eca6852d1995fbc0c5830b0ec'
[info] + git -C /tmp/release-train.uBKSrO/beyla/.obi-src fetch --prune origin
[info] + git -C /tmp/release-train.uBKSrO/beyla/.obi-src checkout a7c15a39ac5f207eca6852d1995fbc0c5830b0ec
HEAD is now at a7c15a39 Fix iter_tcp (#1981)
[info] [dry-run] git -C /tmp/release-train.uBKSrO/beyla add .obi-src
[info] No Beyla submodule pointer change to commit.
[info] Commenting out bpfel exclusions in /tmp/release-train.uBKSrO/beyla/.gitignore for release branch
[info] [dry-run] make -C /tmp/release-train.uBKSrO/beyla vendor-obi
[info] [dry-run] make -C /tmp/release-train.uBKSrO/beyla java-build
[info] [dry-run] git -C /tmp/release-train.uBKSrO/beyla add -A
[info] No Beyla release artifact changes to commit.
[info] [dry-run] git -C /tmp/release-train.uBKSrO/beyla push -u origin release-3.15
[info] Release branches prepared: beyla_version=v3.15.0, beyla_branch=release-3.15, obi_version=v3.15.0, obi_branch=release-3.15
```