### PR TITLE
build: maintain original copyright headers

### DIFF
--- a/scripts/generate-obi-tests.sh
+++ b/scripts/generate-obi-tests.sh
@@ -532,9 +532,7 @@ apply_behavioral_transforms() {
 
 cleanup_and_inject_build_tags() {
     local jobs="$1"
-    echo "  Cleaning up headers and adding build tags..."
-    find "$OBI_DEST" -name "*.go" -type f | run_parallel "$jobs" strip_headers
-
+    echo "  Adding build tags..."
     find "$OBI_DEST" -name "*_test.go" -type f | while read -r file; do
         if ! grep -q "^//go:build" "$file"; then
             { echo "//go:build integration"; echo ""; cat "$file"; } > "$file.tmp"
@@ -605,8 +603,6 @@ transform_oats_go_files() {
     find "$OATS_DEST" -name "*.go" -type f 2>/dev/null | while read -r file; do
         sed_i -e "s|${OBI_MODULE}/internal/test|${BEYLA_MODULE}/internal/testgenerated|g" "$file"
     done
-    # Strip copyright headers
-    find "$OATS_DEST" -name "*.go" -type f | run_parallel "$jobs" strip_headers
 }
 
 apply_oats_behavioral_transforms() {
@@ -694,14 +690,6 @@ apply_component_path_transform() {
     local file="$1"
     sed_i -e 's|path\.Join(pathRoot, "internal", "test", "integration", "components",|path.Join(pathObiSrc, "internal", "test", "integration", "components",|g' \
         -e 's|pathRoot + "/internal/test/|pathObiSrc + "/internal/test/|g' \
-        "$file"
-}
-
-strip_headers() {
-    local file="$1"
-    sed_i \
-        -e '/^\/\/ Copyright The OpenTelemetry Authors/d' \
-        -e '/^\/\/ SPDX-License-Identifier:/d' \
         "$file"
 }
 


### PR DESCRIPTION
Code used to go from Beyla --> OBI, now it's the other way around.