### PR TITLE
Pin requests >=2.32.4 in webhook python requirements (CVE-2018-18074)

### DIFF
--- a/pkg/webhook/image/python/requirements.txt
+++ b/pkg/webhook/image/python/requirements.txt
@@ -4,6 +4,7 @@
 opentelemetry-distro==0.62b1
 
 urllib3 <2.7.1
+requests >=2.32.4
 # We don't use the distro[otlp] option which automatically includes exporters since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.41.1


### PR DESCRIPTION
## Summary
- Add a floor pin `requests >=2.32.4` to `pkg/webhook/image/python/requirements.txt` so resolution can't land on releases affected by CVE-2018-18074 (fixed in 2.20.0) or later CVEs in the 2.32.x line.
- `requests` is pulled in transitively by `opentelemetry-exporter-otlp-proto-http`, whose own constraint is only `requests~=2.7`, so a direct pin in our requirements is the only way to enforce a fixed version.

## Test plan
- [x] Rebuild `pkg/webhook/image/Dockerfile` and confirm the python build stages still resolve cleanly.
- [ ] Re-run the vulnerability scanner and confirm CVE-2018-18074 no longer appears.