### PR TITLE
ci: migrate deploy-dev updater-app auth to Token Broker

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,21 +46,11 @@ jobs:
       - name: Log in to Google Artifact Registry
         uses: grafana/shared-workflows/actions/login-to-gar@00646b30431b955ec3c00982b23b1eeb7b66445b # v1.0.0
 
-      - name: Get updater-app secrets from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
-        with:
-          common_secrets: |
-            APP_ID=updater-app:app-id
-            APP_PRIVATE_KEY=updater-app:private-key
-
       - name: Get GitHub App token for deployment_tools
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.APP_PRIVATE_KEY }}
-          owner: grafana
-          repositories: deployment_tools
+          github_app: updater-app
 
       - name: Update deployment_tools dev wave
         env:


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/deploy-dev.yml` to obtain the `updater-app` GitHub App token via the Token Broker (`grafana/shared-workflows/actions/create-github-app-token`) instead of fetching the app private key from Vault and minting the token with `actions/create-github-app-token`. The workflow no longer touches the App's private key. Mirrors grafana/grafana-k8s-plugin#3066.

Depends on a `deployment_tools` change adding `terraform/repositories/beyla/github-app-configs/config.yaml` for `updater-app`, which must be merged and applied before this workflow runs.

## Test plan

- [ ] Trigger `Deploy Beyla to dev wave` via `workflow_dispatch` with a known version and confirm the token step succeeds and the deployment_tools PR is opened as before.