### PR TITLE
ci: use updater-for-ci GitHub App for deploy-dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -50,7 +50,7 @@ jobs:
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          github_app: updater-app
+          github_app: updater-for-ci
 
       - name: Update deployment_tools dev wave
         env:


### PR DESCRIPTION
## Summary
- Corrects the GitHub App name from `updater-app` to `updater-for-ci` in the deploy-dev workflow so the token broker step can authenticate.

## Test plan
- [ ] Trigger the deploy-dev workflow and confirm the `Get GitHub App token for deployment_tools` step succeeds.