### PR TITLE
Fix OTEL Process unit tests

### DIFF
--- a/pkg/export/otel/metrics_proc_test.go
+++ b/pkg/export/otel/metrics_proc_test.go
@@ -169,7 +169,7 @@ func TestGetFilteredProcessResourceAttrs(t *testing.T) {
 
 	attrMap := make(map[string]string)
 	for _, attr := range result {
-		attrMap[string(attr.Key)] = attr.Value.AsString()
+		attrMap[string(attr.Key)] = attr.Value.Emit()
 	}
 
 	expectedBaseAttrs := []string{
@@ -210,7 +210,7 @@ func TestGetFilteredProcessResourceAttrs(t *testing.T) {
 
 	attrMap = make(map[string]string)
 	for _, attr := range result {
-		attrMap[string(attr.Key)] = attr.Value.AsString()
+		attrMap[string(attr.Key)] = attr.Value.Emit()
 	}
 
 	for _, attrName := range expectedBaseAttrs {


### PR DESCRIPTION
An OTEL Process metrics exporter unit test suddenly started to fail. I suspect the reason was a breaking change in any otel dependency.