### PR TITLE
Expose additional fields from beyla to the controller

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -2029,26 +2029,23 @@
       },
       "type": "object"
     },
-    "SDKExport": {
+    "SDKExportedSignals": {
       "properties": {
         "logs": {
           "type": "boolean",
-          "description": "Logs enables log export from injected SDKs via OTLP Defaults to false (disabled) when not explicitly set",
-          "x-env-var": "BEYLA_SDK_EXPORT_LOGS"
+          "description": "Logs enables log export from injected SDKs via OTLP Defaults to false (disabled) when not explicitly set"
         },
         "metrics": {
           "type": "boolean",
-          "description": "Metrics enables metric export from injected SDKs via OTLP Defaults to true (enabled) when not explicitly set Note: SDKs can only export via OTLP, not Prometheus scraping",
-          "x-env-var": "BEYLA_SDK_EXPORT_METRICS"
+          "description": "Metrics enables metric export from injected SDKs via OTLP Defaults to true (enabled) when not explicitly set Note: SDKs can only export via OTLP, not Prometheus scraping"
         },
         "traces": {
           "type": "boolean",
-          "description": "Traces enables trace export from injected SDKs via OTLP Defaults to true (enabled) when not explicitly set",
-          "x-env-var": "BEYLA_SDK_EXPORT_TRACES"
+          "description": "Traces enables trace export from injected SDKs via OTLP Defaults to true (enabled) when not explicitly set"
         }
       },
       "type": "object",
-      "description": "SDKExport defines which telemetry signals should be exported from injected SDKs. These settings are independent from the global export configuration and allow the injector to export metrics/traces/logs even when Beyla uses Prometheus for metrics."
+      "description": "SDKExportedSignals defines which telemetry signals should be exported from injected SDKs. These settings are independent from the global export configuration and allow the injector to export metrics/traces/logs even when Beyla uses Prometheus for metrics."
     },
     "SDKInject": {
       "properties": {
@@ -2063,10 +2060,6 @@
           "type": "array",
           "description": "List of enabled SDK auto-instrumentations. Can be used to disable specific language instrumentations."
         },
-        "export": {
-          "$ref": "#/$defs/SDKExport",
-          "description": "Export configuration for SDK instrumentation Controls which signals (traces, metrics, logs) should be exported from injected SDKs"
-        },
         "image_volume_path": {
           "type": "string",
           "description": "OCI image mount, supported on k8s 1.31+. Must not be empty."
@@ -2075,18 +2068,22 @@
           "$ref": "#/$defs/WebhookInstrument",
           "description": "OTel SDK instrumentation criteria"
         },
-        "propagators": {
+        "otel_exported_signals": {
+          "$ref": "#/$defs/SDKExportedSignals",
+          "description": "Export configuration for SDK instrumentation Controls which signals (traces, metrics, logs) should be exported from injected SDKs"
+        },
+        "resources": {
+          "$ref": "#/$defs/SDKResource",
+          "description": "Resource attributes related settings"
+        },
+        "trace_propagators": {
           "items": {
             "type": "string"
           },
           "type": "array",
           "description": "Propagators configuration for SDK instrumentation Common values: tracecontext, baggage, b3, b3multi, jaeger, xray"
         },
-        "resources": {
-          "$ref": "#/$defs/SDKResource",
-          "description": "Resource attributes related settings"
-        },
-        "sampler": {
+        "trace_sampler": {
           "$ref": "#/$defs/SamplerConfig",
           "description": "Default sampler configuration for SDK instrumentation This is used when no sampler is specified in the selector"
         },
@@ -2100,28 +2097,24 @@
     },
     "SDKResource": {
       "properties": {
-        "addK8sIPAttribute": {
+        "add_k8s_ip_attribute": {
           "type": "boolean",
-          "description": "AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set from the Kubernetes downward API (status.podIP). Useful for environments where the OTel k8sattributesprocessor cannot infer the pod IP from the connection source (e.g. clusters behind a NAT gateway). +optional",
-          "x-env-var": "BEYLA_RESOURCE_ADD_K8S_IP_ATTRIBUTE"
+          "description": "AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set from the Kubernetes downward API (status.podIP). Useful for environments where the OTel k8sattributesprocessor cannot infer the pod IP from the connection source (e.g. clusters behind a NAT gateway). +optional"
         },
-        "addK8sUIDAttributes": {
+        "add_k8s_uid_attributes": {
           "type": "boolean",
-          "description": "AddK8sUIDAttributes defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid). +optional",
-          "x-env-var": "BEYLA_RESOURCE_ADD_K8S_UID_ATTRIBUTES"
+          "description": "AddK8sUIDAttributes defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid). +optional"
         },
-        "resourceAttributes": {
+        "attributes": {
           "additionalProperties": {
             "type": "string"
           },
           "type": "object",
-          "description": "Attributes defines attributes that are added to the resource. For example environment: dev +optional",
-          "x-env-var": "BEYLA_RESOURCE_ATTRIBUTES"
+          "description": "Attributes defines attributes that are added to the resource. For example environment: dev +optional"
         },
-        "useLabelsForResourceAttributes": {
+        "use_k8s_labels_for_resource_attributes": {
           "type": "boolean",
-          "description": "UseLabelsForResourceAttributes defines whether to use common labels for resource attributes: Note: first entry wins:   - `app.kubernetes.io/instance` becomes `service.name`   - `app.kubernetes.io/name` becomes `service.name`   - `app.kubernetes.io/version` becomes `service.version`",
-          "x-env-var": "BEYLA_RESOURCE_USE_LABELS_FOR_RESOURCE_ATTRIBUTES"
+          "description": "UseLabelsForResourceAttributes defines whether to use common labels for resource attributes: Note: first entry wins:   - `app.kubernetes.io/instance` becomes `service.name`   - `app.kubernetes.io/name` becomes `service.name`   - `app.kubernetes.io/version` becomes `service.version`"
         }
       },
       "type": "object",

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -245,15 +245,15 @@ type SDKInject struct {
 	ImageVolumePath string `yaml:"image_volume_path"`
 	// Default sampler configuration for SDK instrumentation
 	// This is used when no sampler is specified in the selector
-	DefaultSampler *services.SamplerConfig `yaml:"sampler"`
+	DefaultSampler *services.SamplerConfig `yaml:"trace_sampler"`
 	// Propagators configuration for SDK instrumentation
 	// Common values: tracecontext, baggage, b3, b3multi, jaeger, xray
-	Propagators []string `yaml:"propagators"`
+	Propagators []string `yaml:"trace_propagators"`
 	// Export configuration for SDK instrumentation
 	// Controls which signals (traces, metrics, logs) should be exported from injected SDKs
-	Export SDKExport `yaml:"export"`
+	ExportedSignals configmap.SDKExportedSignals `yaml:"otel_exported_signals"`
 	// Resource attributes related settings
-	Resources SDKResource `yaml:"resources"`
+	Resources configmap.SDKResource `yaml:"resources"`
 	// List of enabled SDK auto-instrumentations. Can be used to disable specific
 	// language instrumentations.
 	EnabledSDKs []servicesextra.InstrumentableType `yaml:"enabled_sdks"`
@@ -273,76 +273,6 @@ func (s *SDKInject) PackageVersion() string {
 
 func (s *SDKInject) UsesImageVolume() bool {
 	return s.ImageVolumePath != ""
-}
-
-// SDKExport defines which telemetry signals should be exported from injected SDKs.
-// These settings are independent from the global export configuration and allow
-// the injector to export metrics/traces/logs even when Beyla uses Prometheus for metrics.
-type SDKExport struct {
-	// Traces enables trace export from injected SDKs via OTLP
-	// Defaults to true (enabled) when not explicitly set
-	Traces *bool `yaml:"traces" env:"BEYLA_SDK_EXPORT_TRACES"`
-	// Metrics enables metric export from injected SDKs via OTLP
-	// Defaults to true (enabled) when not explicitly set
-	// Note: SDKs can only export via OTLP, not Prometheus scraping
-	Metrics *bool `yaml:"metrics" env:"BEYLA_SDK_EXPORT_METRICS"`
-	// Logs enables log export from injected SDKs via OTLP
-	// Defaults to false (disabled) when not explicitly set
-	Logs *bool `yaml:"logs" env:"BEYLA_SDK_EXPORT_LOGS"`
-}
-
-// TracesEnabled returns whether trace export is enabled for SDK instrumentation
-// Defaults to true when not explicitly set
-func (e SDKExport) TracesEnabled() bool {
-	if e.Traces == nil {
-		return true // default to enabled
-	}
-	return *e.Traces
-}
-
-// MetricsEnabled returns whether metric export is enabled for SDK instrumentation
-// Defaults to true when not explicitly set
-func (e SDKExport) MetricsEnabled() bool {
-	if e.Metrics == nil {
-		return true // default to enabled
-	}
-	return *e.Metrics
-}
-
-// LogsEnabled returns whether log export is enabled for SDK instrumentation
-// Defaults to false when not explicitly set
-func (e SDKExport) LogsEnabled() bool {
-	if e.Logs == nil {
-		return false // default to disabled
-	}
-	return *e.Logs
-}
-
-// Resource defines the configuration for the resource attributes, as defined by the OpenTelemetry specification.
-// See also: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#resources
-type SDKResource struct {
-	// Attributes defines attributes that are added to the resource.
-	// For example environment: dev
-	// +optional
-	Attributes map[string]string `yaml:"resourceAttributes" env:"BEYLA_RESOURCE_ATTRIBUTES"`
-
-	// AddK8sUIDAttributes defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid).
-	// +optional
-	AddK8sUIDAttributes bool `yaml:"addK8sUIDAttributes" env:"BEYLA_RESOURCE_ADD_K8S_UID_ATTRIBUTES"`
-
-	// AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set
-	// from the Kubernetes downward API (status.podIP). Useful for environments where the
-	// OTel k8sattributesprocessor cannot infer the pod IP from the connection source
-	// (e.g. clusters behind a NAT gateway).
-	// +optional
-	AddK8sIPAttribute bool `yaml:"addK8sIPAttribute" env:"BEYLA_RESOURCE_ADD_K8S_IP_ATTRIBUTE"`
-
-	// UseLabelsForResourceAttributes defines whether to use common labels for resource attributes:
-	// Note: first entry wins:
-	//   - `app.kubernetes.io/instance` becomes `service.name`
-	//   - `app.kubernetes.io/name` becomes `service.name`
-	//   - `app.kubernetes.io/version` becomes `service.version`
-	UseLabelsForResourceAttributes bool `yaml:"useLabelsForResourceAttributes,omitempty" env:"BEYLA_RESOURCE_USE_LABELS_FOR_RESOURCE_ATTRIBUTES"`
 }
 
 // WebhookConfig contains the configuration for the mutating webhook

--- a/pkg/beyla/sdk_export_test.go
+++ b/pkg/beyla/sdk_export_test.go
@@ -3,8 +3,9 @@ package beyla
 import (
 	"testing"
 
-	"github.com/grafana/beyla/v3/pkg/webhook/configmap"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/beyla/v3/pkg/webhook/configmap"
 )
 
 func TestSDKExport_TracesEnabled(t *testing.T) {

--- a/pkg/beyla/sdk_export_test.go
+++ b/pkg/beyla/sdk_export_test.go
@@ -3,6 +3,7 @@ package beyla
 import (
 	"testing"
 
+	"github.com/grafana/beyla/v3/pkg/webhook/configmap"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,22 +13,22 @@ func TestSDKExport_TracesEnabled(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		export   SDKExport
+		export   configmap.SDKExportedSignals
 		expected bool
 	}{
 		{
 			name:     "nil traces defaults to enabled",
-			export:   SDKExport{Traces: nil},
+			export:   configmap.SDKExportedSignals{Traces: nil},
 			expected: true,
 		},
 		{
 			name:     "explicitly enabled",
-			export:   SDKExport{Traces: &trueVal},
+			export:   configmap.SDKExportedSignals{Traces: &trueVal},
 			expected: true,
 		},
 		{
 			name:     "explicitly disabled",
-			export:   SDKExport{Traces: &falseVal},
+			export:   configmap.SDKExportedSignals{Traces: &falseVal},
 			expected: false,
 		},
 	}
@@ -45,22 +46,22 @@ func TestSDKExport_MetricsEnabled(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		export   SDKExport
+		export   configmap.SDKExportedSignals
 		expected bool
 	}{
 		{
 			name:     "nil metrics defaults to enabled",
-			export:   SDKExport{Metrics: nil},
+			export:   configmap.SDKExportedSignals{Metrics: nil},
 			expected: true,
 		},
 		{
 			name:     "explicitly enabled",
-			export:   SDKExport{Metrics: &trueVal},
+			export:   configmap.SDKExportedSignals{Metrics: &trueVal},
 			expected: true,
 		},
 		{
 			name:     "explicitly disabled",
-			export:   SDKExport{Metrics: &falseVal},
+			export:   configmap.SDKExportedSignals{Metrics: &falseVal},
 			expected: false,
 		},
 	}
@@ -78,22 +79,22 @@ func TestSDKExport_LogsEnabled(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		export   SDKExport
+		export   configmap.SDKExportedSignals
 		expected bool
 	}{
 		{
 			name:     "nil logs defaults to disabled",
-			export:   SDKExport{Logs: nil},
+			export:   configmap.SDKExportedSignals{Logs: nil},
 			expected: false,
 		},
 		{
 			name:     "explicitly enabled",
-			export:   SDKExport{Logs: &trueVal},
+			export:   configmap.SDKExportedSignals{Logs: &trueVal},
 			expected: true,
 		},
 		{
 			name:     "explicitly disabled",
-			export:   SDKExport{Logs: &falseVal},
+			export:   configmap.SDKExportedSignals{Logs: &falseVal},
 			expected: false,
 		},
 	}

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -63,6 +63,24 @@ type InjectConfig struct {
 	// protocol to set on instrumented containers. Empty fields are pruned
 	// by Marshal so the document stays minimal.
 	OtelExport OtelExport `yaml:"otel_export,omitempty"`
+
+	// ExportedSignals configuration for SDK instrumentation
+	// Controls which signals (traces, metrics, logs) should be exported from injected SDKs
+	ExportedSignals SDKExportedSignals `yaml:"otel_exported_signals,omitempty"`
+
+	// OCI image mount, supported on k8s 1.31+. Must not be empty.
+	ImageVolumePath string `yaml:"image_volume_path,omitempty"`
+
+	// Default sampler configuration for SDK instrumentation
+	// This is used when no sampler is specified in the selector
+	DefaultSampler *services.SamplerConfig `yaml:"trace_sampler,omitempty"`
+
+	// Propagators configuration for SDK instrumentation
+	// Common values: tracecontext, baggage, b3, b3multi, jaeger, xray
+	Propagators []string `yaml:"trace_propagators,omitempty"`
+
+	// Resource attributes related settings
+	Resources SDKResource `yaml:"resources,omitempty"`
 }
 
 // OtelExport is the per-ConfigMap OTLP destination applied to matched pods.
@@ -79,4 +97,74 @@ type EligibleDeployment struct {
 	Kind      string `yaml:"kind,omitempty"`
 	Name      string `yaml:"name"`
 	Language  string `yaml:"language,omitempty"`
+}
+
+// SDKExportedSignals defines which telemetry signals should be exported from injected SDKs.
+// These settings are independent from the global export configuration and allow
+// the injector to export metrics/traces/logs even when Beyla uses Prometheus for metrics.
+type SDKExportedSignals struct {
+	// Traces enables trace export from injected SDKs via OTLP
+	// Defaults to true (enabled) when not explicitly set
+	Traces *bool `yaml:"traces,omitempty" env:"BEYLA_SDK_EXPORT_TRACES"`
+	// Metrics enables metric export from injected SDKs via OTLP
+	// Defaults to true (enabled) when not explicitly set
+	// Note: SDKs can only export via OTLP, not Prometheus scraping
+	Metrics *bool `yaml:"metrics,omitempty" env:"BEYLA_SDK_EXPORT_METRICS"`
+	// Logs enables log export from injected SDKs via OTLP
+	// Defaults to false (disabled) when not explicitly set
+	Logs *bool `yaml:"logs,omitempty" env:"BEYLA_SDK_EXPORT_LOGS"`
+}
+
+// TracesEnabled returns whether trace export is enabled for SDK instrumentation
+// Defaults to true when not explicitly set
+func (e SDKExportedSignals) TracesEnabled() bool {
+	if e.Traces == nil {
+		return true // default to enabled
+	}
+	return *e.Traces
+}
+
+// MetricsEnabled returns whether metric export is enabled for SDK instrumentation
+// Defaults to true when not explicitly set
+func (e SDKExportedSignals) MetricsEnabled() bool {
+	if e.Metrics == nil {
+		return true // default to enabled
+	}
+	return *e.Metrics
+}
+
+// LogsEnabled returns whether log export is enabled for SDK instrumentation
+// Defaults to false when not explicitly set
+func (e SDKExportedSignals) LogsEnabled() bool {
+	if e.Logs == nil {
+		return false // default to disabled
+	}
+	return *e.Logs
+}
+
+// Resource defines the configuration for the resource attributes, as defined by the OpenTelemetry specification.
+// See also: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#resources
+type SDKResource struct {
+	// Attributes defines attributes that are added to the resource.
+	// For example environment: dev
+	// +optional
+	Attributes map[string]string `yaml:"attributes,omitempty" env:"BEYLA_RESOURCE_ATTRIBUTES"`
+
+	// AddK8sUIDAttributes defines whether K8s UID attributes should be collected (e.g. k8s.deployment.uid).
+	// +optional
+	AddK8sUIDAttributes bool `yaml:"add_k8s_uid_attributes,omitempty" env:"BEYLA_RESOURCE_ADD_K8S_UID_ATTRIBUTES"`
+
+	// AddK8sIPAttribute defines whether the k8s.pod.ip resource attribute should be set
+	// from the Kubernetes downward API (status.podIP). Useful for environments where the
+	// OTel k8sattributesprocessor cannot infer the pod IP from the connection source
+	// (e.g. clusters behind a NAT gateway).
+	// +optional
+	AddK8sIPAttribute bool `yaml:"add_k8s_ip_attribute,omitempty" env:"BEYLA_RESOURCE_ADD_K8S_IP_ATTRIBUTE"`
+
+	// UseLabelsForResourceAttributes defines whether to use common labels for resource attributes:
+	// Note: first entry wins:
+	//   - `app.kubernetes.io/instance` becomes `service.name`
+	//   - `app.kubernetes.io/name` becomes `service.name`
+	//   - `app.kubernetes.io/version` becomes `service.version`
+	UseLabelsForResourceAttributes bool `yaml:"use_k8s_labels_for_resource_attributes,omitempty" env:"BEYLA_RESOURCE_USE_LABELS_FOR_RESOURCE_ATTRIBUTES"`
 }

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -52,6 +52,8 @@ type WebhookKubeOnlySelector struct {
 // service-selection globs and the OTLP destination to stamp onto matched
 // pods.
 type InjectConfig struct {
+	NodeName string `yaml:"node_name"`
+
 	// Discovery is a list of service-selection criteria reused verbatim from
 	// Beyla's own configuration shape. The injection controller picks the
 	// kubernetes metadata fields (k8s_namespace, k8s_pod_name, ...) out of

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -315,6 +315,7 @@ func (s *Server) writeStateConfigMap(ctx context.Context) error {
 	sortEligible(eligible)
 
 	config := configmap.InjectConfig{
+		NodeName:  s.nodeName,
 		Discovery: s.cfg.Injector.Instrument,
 		OtelExport: configmap.OtelExport{
 			Endpoint: s.mutator.Endpoint(),

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -320,6 +320,11 @@ func (s *Server) writeStateConfigMap(ctx context.Context) error {
 			Endpoint: s.mutator.Endpoint(),
 			Protocol: s.mutator.Protocol(),
 		},
+		ExportedSignals: s.cfg.Injector.ExportedSignals,
+		ImageVolumePath: s.cfg.Injector.ImageVolumePath,
+		DefaultSampler:  s.cfg.Injector.DefaultSampler,
+		Propagators:     s.cfg.Injector.Propagators,
+		Resources:       s.cfg.Injector.Resources,
 	}
 
 	return s.stateWriter.Write(ctx, &config, eligible)

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -99,7 +99,7 @@ func (w *StateConfigMapWriter) Write(
 	config *configmap.InjectConfig,
 	eligible []*configmap.EligibleDeployment,
 ) error {
-	criteriaYAML, err := yaml.Marshal(config)
+	configYAML, err := yaml.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("marshal criteria: %w", err)
 	}
@@ -127,7 +127,7 @@ func (w *StateConfigMapWriter) Write(
 			},
 		},
 		Data: map[string]string{
-			configmap.KeyInstrumentation:    string(criteriaYAML),
+			configmap.KeyInstrumentation:    string(configYAML),
 			configmap.KeyEligibleForRestart: string(eligibleYAML),
 		},
 	}


### PR DESCRIPTION
This adds the missing fields that will need to get pushed from Beyla to the k8s controller via the config map. It also normalises the naming of these fields based on YAML standards.