### PR TITLE
Add instrumented hash to eligible deployments for SDK instrumentation

### DIFF
--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Stage generated test tree
         run: |
-          tar cf compiled-tests/testgenerated.tar internal/testgenerated
+          tar cf compiled-tests/testgenerated.tar internal/testgenerated schemas
 
       - name: Upload prep artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -66,6 +66,9 @@ jobs:
     needs: vm-test-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Free up disk space
         run: |

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -25,9 +25,10 @@ jobs:
   vm-test-matrix:
     name: "Build VM integration matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
+      kernels: ${{ steps.build-kernel-matrix.outputs.kernels }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,7 +38,7 @@ jobs:
       - name: Generate OBI tests
         run: make generate-obi-tests
 
-      - name: build matrix
+      - name: Build test matrix
         id: build-matrix
         env:
           # 5 partitions, one for each of:
@@ -52,28 +53,19 @@ jobs:
           echo -n "matrix=" >> $GITHUB_OUTPUT
           make vm-integration-test-matrix-json >> $GITHUB_OUTPUT
 
-  test:
-    name: kernel ${{ matrix.kernel.kernel-version }} ${{ matrix.kernel.arch }} ${{ matrix.test.description }}
+      - name: Build kernel matrix
+        id: build-kernel-matrix
+        env:
+          OBI_KERNELS_YAML: .obi-src/internal/test/vm/kernels.yaml
+        run: |
+          echo -n "kernels=" >> "$GITHUB_OUTPUT"
+          bash .obi-src/scripts/kernel-matrix-json.sh --kind=integration >> "$GITHUB_OUTPUT"
+
+  prep:
+    name: "Prep VM test artifacts"
     needs: vm-test-matrix
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      pull-requests: write
-      # required for CODECOV token
-      id-token: write
-      checks: write
-      # Required for uploading artifacts
-      actions: write
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        kernel:
-          - kernel-version: "5.15.152"
-            arch: "x86_64"
-          - kernel-version: "6.10.6"
-            arch: "x86_64"
-        test: ${{ fromJson(needs.vm-test-matrix.outputs.matrix).include }}
+    timeout-minutes: 45
     steps:
       - name: Free up disk space
         run: |
@@ -140,17 +132,25 @@ jobs:
       - name: Generate files
         run: make prereqs vendor-obi
 
-      - name: Install QEMU and musl-tools
+      - name: Install qemu-utils and musl-tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 musl-tools
+          sudo apt-get install -y --no-install-recommends qemu-utils musl-tools
 
       - name: Pre-compile Go integration tests
         run: |
           mkdir compiled-tests
           CC=musl-gcc CGO_ENABLED=1 go test -c -tags=integration -mod vendor -ldflags="-s -w" -o compiled-tests/ ./internal/testgenerated/integration
 
+      - name: Cache Docker images
+        id: docker-images-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] keyed on hash of compose+Dockerfile inputs
+        with:
+          path: compiled-tests/docker-images.tar
+          key: vm-docker-images-${{ hashFiles('internal/testgenerated/integration/docker-compose-multiexec*.yml', 'internal/testgenerated/integration/**/Dockerfile*', 'internal/test/beyla_extensions/**/Dockerfile*') }}
+
       - name: Pre-build Docker images for VM tests
+        if: steps.docker-images-cache.outputs.cache-hit != 'true'
         run: |
           # Auto-discover Docker images from compose files and build them on
           # the host at native speed, avoiding slow in-VM builds under QEMU
@@ -197,6 +197,107 @@ jobs:
             docker builder prune -af
           fi
 
+      - name: Cache rootfs.qcow2
+        id: rootfs-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] keyed on hash of VM Dockerfile
+        with:
+          path: compiled-tests/rootfs.qcow2
+          key: vm-rootfs-${{ hashFiles('internal/testgenerated/vm/Dockerfile') }}
+
+      - name: Build rootfs.qcow2
+        if: steps.rootfs-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo make -C internal/testgenerated/vm WORKDIR="$(pwd)" build-rootfs
+          sudo chown "$(id -u):$(id -g)" rootfs.qcow2
+          mv rootfs.qcow2 compiled-tests/rootfs.qcow2
+          ls -lh compiled-tests/rootfs.qcow2
+
+      - name: Upload prep artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vm-prep-${{ github.run_id }}
+          path: compiled-tests
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  test:
+    name: kernel ${{ matrix.kernel.id }} ${{ matrix.test.description }}
+    needs: [vm-test-matrix, prep]
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+      # required for CODECOV token
+      id-token: write
+      checks: write
+      # Required for uploading artifacts
+      actions: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kernel: ${{ fromJson(needs.vm-test-matrix.outputs.kernels).include }}
+        test: ${{ fromJson(needs.vm-test-matrix.outputs.matrix).include }}
+    steps:
+      - name: Free up disk space
+        run: |
+          # Free disk space without pruning docker — we will load cached
+          # images from the prep artifact.
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /opt/microsoft /opt/google
+          sudo rm -rf /opt/az
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Download prep artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: vm-prep-${{ github.run_id }}
+          path: compiled-tests
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86
+
+      - name: Stage rootfs.qcow2
+        run: |
+          mv compiled-tests/rootfs.qcow2 ./rootfs.qcow2
+
+      - name: Cache LVH kernel artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] keyed on pinned LVH tag from kernels.yaml
+        with:
+          path: |
+            .obi-src/internal/test/vm/lvh/out/vmlinuz-${{ matrix.kernel.id }}-amd64
+            .obi-src/internal/test/vm/lvh/out/vmlinuz-${{ matrix.kernel.id }}-amd64.config
+            .obi-src/internal/test/vm/lvh/out/vmlinuz-${{ matrix.kernel.id }}-amd64.buildinfo
+            .obi-src/internal/test/vm/lvh/out/modules-${{ matrix.kernel.id }}-amd64
+          key: lvh-${{ matrix.kernel.lvh_tag }}-amd64
+
+      - name: Resolve kernel (pull from LVH if needed)
+        id: kernel
+        env:
+          KERNEL_ID: ${{ matrix.kernel.id }}
+        run: |
+          eval "$(bash .obi-src/internal/test/vm/prepare-kernel.sh "$KERNEL_ID" amd64)"
+          echo "kernel=$KERNEL" >> "$GITHUB_OUTPUT"
+          echo "modules-dir=$MODULES_DIR" >> "$GITHUB_OUTPUT"
+          echo "Kernel:  $KERNEL"
+          echo "Modules: $MODULES_DIR"
+
       - name: Run VM integration tests (${{ matrix.test.description }})
         env:
           # zizmor template-injection fixes: pass data as env vars
@@ -204,10 +305,11 @@ jobs:
           MATRIX_JSON: ${{ toJson(matrix.test) }}
           MATRIX_TEST_PATTERN: ${{ matrix.test.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
-          ARCH: ${{ matrix.kernel.arch }}
-          KERNEL_VERSION: ${{ matrix.kernel.kernel-version }}
+          KERNEL_ID: ${{ matrix.kernel.id }}
+          KERNEL: ${{ steps.kernel.outputs.kernel }}
+          MODULES_DIR: ${{ steps.kernel.outputs.modules-dir }}
         run: |
-          echo "VM Partition for kernel $KERNEL_VERSION"
+          echo "VM Partition for kernel ${KERNEL_ID}"
           echo "${MATRIX_JSON}"
 
           if [ -z "${MATRIX_TEST_PATTERN}" ]; then
@@ -217,8 +319,10 @@ jobs:
 
           # Run VM tests with pre-compiled tests
           sudo make -C internal/testgenerated/vm \
-            KERNEL_VER=${KERNEL_VERSION} \
-            ARCH=${ARCH} \
+            WORKDIR="$(pwd)" \
+            KERNEL="$KERNEL" \
+            MODULES_DIR="$MODULES_DIR" \
+            ARCH=amd64 \
             TEST_PATTERN="${MATRIX_TEST_PATTERN}" \
             RUN_NUMBER="${RUN_NUMBER}" \
             PRECOMPILED_TESTS_DIR="$(pwd)/compiled-tests" \
@@ -239,14 +343,14 @@ jobs:
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ./testoutput/itest-covdata.txt
-          flags: integration-test-vm-${{ matrix.kernel.arch }}-${{ matrix.kernel.kernel-version }}
-          name: vm-integration-test-coverage-${{ matrix.kernel.kernel-version }}-${{ matrix.kernel.arch }}-${{ matrix.test.id }}-${{ github.run_number }}
+          flags: integration-test-vm-${{ matrix.kernel.id }}
+          name: vm-integration-test-coverage-${{ matrix.kernel.id }}-${{ matrix.test.id }}-${{ github.run_number }}
 
       - name: Upload integration test logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: vm-integration-test-logs-${{ matrix.kernel.kernel-version }}-${{ matrix.kernel.arch }}-${{ matrix.test.id }}-${{ github.run_number }}
+          name: vm-integration-test-logs-${{ matrix.kernel.id }}-${{ matrix.test.id }}-${{ github.run_number }}
           path: |
             testoutput/*.log
             testoutput/kind

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -215,6 +215,10 @@ jobs:
           mv rootfs.qcow2 compiled-tests/rootfs.qcow2
           ls -lh compiled-tests/rootfs.qcow2
 
+      - name: Stage generated test tree
+        run: |
+          tar cf compiled-tests/testgenerated.tar internal/testgenerated
+
       - name: Upload prep artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -275,6 +279,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86
+
+      - name: Restore generated test tree
+        run: |
+          tar xf compiled-tests/testgenerated.tar
+          rm compiled-tests/testgenerated.tar
 
       - name: Stage rootfs.qcow2
         run: |

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -979,6 +979,15 @@
         "response"
       ]
     },
+    "HealthCheckConfig": {
+      "properties": {
+        "port": {
+          "type": "integer",
+          "x-env-var": "OTEL_EBPF_HEALTH_CHECK_PORT"
+        }
+      },
+      "type": "object"
+    },
     "HostIDConfig": {
       "properties": {
         "override": {
@@ -2424,6 +2433,9 @@
     "grafana": {
       "$ref": "#/$defs/GrafanaConfig",
       "description": "Grafana overrides some values of the otel.MetricsConfig and otel.TracesConfig below for a simpler submission of OTEL metrics to Grafana Cloud"
+    },
+    "health_check": {
+      "$ref": "#/$defs/HealthCheckConfig"
     },
     "injector": {
       "$ref": "#/$defs/SDKInject",

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -182,6 +182,8 @@ type Config struct {
 	// WARNING: This is purely experimental and undocumented feature and can be removed in the future without warning.
 	Injector SDKInject `yaml:"injector"`
 
+	HealthCheck obi.HealthCheckConfig `yaml:"health_check"`
+
 	// cached equivalent for the OBI conversion
 	obi *obi.Config `yaml:"-"`
 }

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -13,8 +13,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/obi/pkg/appolly/services"
 )
 
 const (

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -8,7 +8,13 @@
 package configmap
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -99,6 +105,7 @@ type EligibleDeployment struct {
 	Kind      string `yaml:"kind,omitempty"`
 	Name      string `yaml:"name"`
 	Language  string `yaml:"language,omitempty"`
+	Hash      string `yaml:"hash,omitempty"`
 }
 
 // SDKExportedSignals defines which telemetry signals should be exported from injected SDKs.
@@ -169,4 +176,27 @@ type SDKResource struct {
 	//   - `app.kubernetes.io/name` becomes `service.name`
 	//   - `app.kubernetes.io/version` becomes `service.version`
 	UseLabelsForResourceAttributes bool `yaml:"use_k8s_labels_for_resource_attributes,omitempty" env:"BEYLA_RESOURCE_USE_LABELS_FOR_RESOURCE_ATTRIBUTES"`
+}
+
+func (d *EligibleDeployment) Valid() bool {
+	return d.Name != "" && d.Namespace != ""
+}
+
+func (c *InjectConfig) PackageVersion() string {
+	h := sha256.Sum224([]byte(c.ImageVolumePath))
+	return fmt.Sprintf("%x", h)
+}
+
+// Hash returns a stable SHA-256 hex digest of the YAML serialization of c,
+// suitable for detecting whether any field value has changed between two
+// InjectConfig instances. Equality of the returned strings implies the two
+// configs marshal identically (which is what gets written to the ConfigMap).
+func (c *InjectConfig) Hash() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		slog.Error("cannot marshal injector config, using the package version instead", "error", err)
+		return c.PackageVersion()
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/webhook/pods.go
+++ b/pkg/webhook/pods.go
@@ -55,7 +55,7 @@ func addMetadata(pp *ProcessInfo, info *informer.ObjectMeta) *ProcessInfo {
 	return ret
 }
 
-func deploymentFromProcess(a *ProcessInfo) *configmap.EligibleDeployment {
+func deploymentFromProcess(a *ProcessInfo, stateHash string) *configmap.EligibleDeployment {
 	namespace := a.metadata[services.AttrNamespace]
 	deployment := a.metadata[attr.K8sDeploymentName.Prom()]
 
@@ -66,6 +66,7 @@ func deploymentFromProcess(a *ProcessInfo) *configmap.EligibleDeployment {
 		Kind:      "Deployment",
 		Name:      deployment,
 		Language:  language,
+		Hash:      stateHash,
 	}
 }
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -49,6 +49,8 @@ type Server struct {
 	nodeName                string
 	initialPodScan          atomic.Bool
 	uuid                    string
+	stateCfg                *configmap.InjectConfig
+	stateHash               string
 }
 
 func (s *Server) ID() string { return s.uuid }
@@ -88,7 +90,25 @@ func NewServer(cfg *beyla.Config, ctxInfo *global.ContextInfo) (*Server, error) 
 
 	nodeName := OwnNodeName()
 
-	stateWriter, err := NewStateConfigMapWriter(cfg, ctxInfo, nodeName)
+	stateCfg := configmap.InjectConfig{
+		NodeName:  nodeName,
+		Discovery: cfg.Injector.Instrument,
+		OtelExport: configmap.OtelExport{
+			Endpoint: mutator.Endpoint(),
+			Protocol: mutator.Protocol(),
+		},
+		ExportedSignals: cfg.Injector.ExportedSignals,
+		ImageVolumePath: cfg.Injector.ImageVolumePath,
+		DefaultSampler:  cfg.Injector.DefaultSampler,
+		Propagators:     cfg.Injector.Propagators,
+		Resources:       cfg.Injector.Resources,
+	}
+
+	stateHash := stateCfg.Hash()
+
+	logger.Info("SDK injection config established", "hash", stateHash)
+
+	stateWriter, err := NewStateConfigMapWriter(ctxInfo, nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("error creating configmap state writer: %w", err)
 	}
@@ -117,6 +137,8 @@ func NewServer(cfg *beyla.Config, ctxInfo *global.ContextInfo) (*Server, error) 
 		instrumentationManager: NewInstrumentationManager(cfg),
 		nodeName:               nodeName,
 		uuid:                   uuid.NewString(),
+		stateCfg:               &stateCfg,
+		stateHash:              stateHash,
 	}
 
 	s.lastEligiblePodLaunchNS.Store(now.UnixNano())
@@ -218,7 +240,12 @@ func (s *Server) recordEligibleDeployment(a *ProcessInfo) {
 	defer s.eligibleDeploymentsMux.Unlock()
 
 	key := deploymentKeyFromProcess(a)
-	d := deploymentFromProcess(a)
+	d := deploymentFromProcess(a, s.stateHash)
+
+	if !d.Valid() {
+		s.logger.Debug("invalid deployment", "key", key, "deployment", d)
+		return
+	}
 
 	s.eligibleDeployments.Add(key, d)
 
@@ -314,21 +341,7 @@ func (s *Server) writeStateConfigMap(ctx context.Context) error {
 	eligible = append(eligible, s.eligibleDeployments.Values()...)
 	sortEligible(eligible)
 
-	config := configmap.InjectConfig{
-		NodeName:  s.nodeName,
-		Discovery: s.cfg.Injector.Instrument,
-		OtelExport: configmap.OtelExport{
-			Endpoint: s.mutator.Endpoint(),
-			Protocol: s.mutator.Protocol(),
-		},
-		ExportedSignals: s.cfg.Injector.ExportedSignals,
-		ImageVolumePath: s.cfg.Injector.ImageVolumePath,
-		DefaultSampler:  s.cfg.Injector.DefaultSampler,
-		Propagators:     s.cfg.Injector.Propagators,
-		Resources:       s.cfg.Injector.Resources,
-	}
-
-	return s.stateWriter.Write(ctx, &config, eligible)
+	return s.stateWriter.Write(ctx, s.stateCfg, eligible)
 }
 
 func sortEligible(eligible []*configmap.EligibleDeployment) {

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -17,7 +17,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 
-	"github.com/grafana/beyla/v3/pkg/beyla"
 	"github.com/grafana/beyla/v3/pkg/webhook/configmap"
 )
 
@@ -44,7 +43,7 @@ type StateConfigMapWriter struct {
 	owner        *metav1.OwnerReference
 }
 
-func NewStateConfigMapWriter(cfg *beyla.Config, ctxInfo *global.ContextInfo, nodeName string) (*StateConfigMapWriter, error) {
+func NewStateConfigMapWriter(ctxInfo *global.ContextInfo, nodeName string) (*StateConfigMapWriter, error) {
 	logger := slog.Default().With("component", "webhook.StateConfigMapWriter")
 
 	ownContainer, err := ownContainerID()

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
+
+import (
+	"encoding/json"
+)
+
+// Semconv-compliant message types per:
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-input-messages.json
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-output-messages.json
+
+type normalizedPart struct {
+	Type      string          `json:"type"`
+	Content   string          `json:"content,omitempty"`
+	Response  any             `json:"result,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	URI       string          `json:"uri,omitempty"`
+	FileID    string          `json:"file_id,omitempty"`
+	Modality  string          `json:"modality,omitempty"`
+	MimeType  string          `json:"mime_type,omitempty"`
+}
+
+type normalizedMessage struct {
+	Role         string           `json:"role"`
+	Parts        []normalizedPart `json:"parts"`
+	FinishReason string           `json:"finish_reason,omitempty"`
+}
+
+func wrapTextAsInputMessage(text string) string {
+	msg := normalizedMessage{
+		Role:  "user",
+		Parts: []normalizedPart{{Type: "text", Content: text}},
+	}
+	b, err := json.Marshal([]normalizedMessage{msg})
+	if err != nil {
+		return text
+	}
+	return string(b)
+}
+
+func wrapTextAsOutputMessage(role, text, finishReason string) string {
+	msg := normalizedMessage{
+		Role:         role,
+		Parts:        []normalizedPart{{Type: "text", Content: text}},
+		FinishReason: finishReason,
+	}
+	b, err := json.Marshal([]normalizedMessage{msg})
+	if err != nil {
+		return text
+	}
+	return string(b)
+}
+
+// NormalizeSystemInstructions converts a plain text system instruction
+// to the semconv JSON schema: [{"type":"text","content":"..."}]
+func NormalizeSystemInstructions(text string) string {
+	if text == "" {
+		return ""
+	}
+	parts := []normalizedPart{{Type: "text", Content: text}}
+	b, err := json.Marshal(parts)
+	if err != nil {
+		return text
+	}
+	return string(b)
+}
+
+type normalizedTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// NormalizeToolDefinitions converts provider-native tool definitions to the
+// semconv schema: [{"type":"function","name":"...","description":"...","parameters":{}}]
+func NormalizeToolDefinitions(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedTool, 0, len(items))
+	for _, item := range items {
+		out = append(out, normalizeToolItem(item)...)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+func normalizeToolItem(raw json.RawMessage) []normalizedTool {
+	var probe struct {
+		// OpenAI wrapper: {"type":"function","function":{...}}
+		Type     string `json:"type"`
+		Function *struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description,omitempty"`
+			Parameters  json.RawMessage `json:"parameters,omitempty"`
+		} `json:"function,omitempty"`
+		// Anthropic direct: {"name":"...","description":"...","input_schema":{}}
+		Name        string          `json:"name,omitempty"`
+		Description string          `json:"description,omitempty"`
+		InputSchema json.RawMessage `json:"input_schema,omitempty"`
+		// Gemini: {"functionDeclarations":[{"name":"..."}]}
+		FunctionDeclarations []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description,omitempty"`
+			Parameters  json.RawMessage `json:"parameters,omitempty"`
+		} `json:"functionDeclarations,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil
+	}
+
+	if len(probe.FunctionDeclarations) > 0 {
+		out := make([]normalizedTool, 0, len(probe.FunctionDeclarations))
+		for _, fd := range probe.FunctionDeclarations {
+			if fd.Name == "" {
+				continue
+			}
+			out = append(out, normalizedTool{
+				Type:        "function",
+				Name:        fd.Name,
+				Description: fd.Description,
+				Parameters:  fd.Parameters,
+			})
+		}
+		return out
+	}
+
+	// OpenAI wrapper: only normalize when the wrapper declares type:"function"
+	// and carries a function object. Other wrapper types are not in semconv.
+	if probe.Function != nil && probe.Function.Name != "" && (probe.Type == "" || probe.Type == "function") {
+		return []normalizedTool{{
+			Type:        "function",
+			Name:        probe.Function.Name,
+			Description: probe.Function.Description,
+			Parameters:  probe.Function.Parameters,
+		}}
+	}
+
+	// Anthropic direct shape. Only emit when a name is present; non-function
+	// Anthropic tools (computer_*, text_editor_*, bash_*) carry a type field
+	// but are not part of semconv's gen_ai.tool.definitions schema, so drop them.
+	if probe.Name != "" && probe.Type == "" {
+		return []normalizedTool{{
+			Type:        "function",
+			Name:        probe.Name,
+			Description: probe.Description,
+			Parameters:  probe.InputSchema,
+		}}
+	}
+
+	return nil
+}

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_anthropic.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_anthropic.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
+
+import (
+	"encoding/json"
+)
+
+// NormalizeAnthropicInput converts Anthropic request messages to semconv
+// schema. Anthropic content blocks can contain tool_use and tool_result
+// entries that require separate handling from OpenAI format.
+func NormalizeAnthropicInput(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var msgs []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msgs); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedMessage, 0, len(msgs))
+	for _, m := range msgs {
+		nm := normalizedMessage{Role: m.Role}
+		nm.Parts = anthropicContentToParts(m.Content)
+		out = append(out, nm)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+func anthropicContentToParts(content json.RawMessage) []normalizedPart {
+	if len(content) == 0 {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return []normalizedPart{{Type: "text", Content: s}}
+	}
+
+	var blocks []struct {
+		Type      string          `json:"type"`
+		Text      string          `json:"text,omitempty"`
+		ID        string          `json:"id,omitempty"`
+		Name      string          `json:"name,omitempty"`
+		Input     json.RawMessage `json:"input,omitempty"`
+		ToolUseID string          `json:"tool_use_id,omitempty"`
+		Content   json.RawMessage `json:"content,omitempty"`
+		Thinking  string          `json:"thinking,omitempty"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return []normalizedPart{{Type: "text", Content: string(content)}}
+	}
+
+	parts := make([]normalizedPart, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, normalizedPart{Type: "text", Content: b.Text})
+		case "tool_use":
+			parts = append(parts, normalizedPart{
+				Type:      "tool_call",
+				ID:        b.ID,
+				Name:      b.Name,
+				Arguments: b.Input,
+			})
+		case "tool_result":
+			parts = append(parts, normalizedPart{
+				Type:     "tool_call_response",
+				ID:       b.ToolUseID,
+				Response: extractToolResultContent(b.Content),
+			})
+		case "thinking":
+			parts = append(parts, normalizedPart{Type: "reasoning", Content: b.Thinking})
+		default:
+			parts = append(parts, normalizedPart{Type: b.Type, Content: b.Text})
+		}
+	}
+	return parts
+}
+
+// extractToolResultContent returns the tool result content as a string.
+// Anthropic tool_result content can be a string or an array of content blocks.
+func extractToolResultContent(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+
+	var obj any
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj
+	}
+
+	return string(raw)
+}
+
+// NormalizeAnthropicOutput converts Anthropic response content blocks
+// to semconv output messages schema.
+func NormalizeAnthropicOutput(resp *AnthropicResponse) string {
+	if len(resp.Content) == 0 {
+		return ""
+	}
+
+	var blocks []struct {
+		Type     string          `json:"type"`
+		Text     string          `json:"text,omitempty"`
+		ID       string          `json:"id,omitempty"`
+		Name     string          `json:"name,omitempty"`
+		Input    json.RawMessage `json:"input,omitempty"`
+		Thinking string          `json:"thinking,omitempty"`
+	}
+	if err := json.Unmarshal(resp.Content, &blocks); err != nil {
+		return wrapTextAsOutputMessage(resp.Role, string(resp.Content), resp.StopReason)
+	}
+
+	var parts []normalizedPart
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, normalizedPart{Type: "text", Content: b.Text})
+		case "tool_use":
+			parts = append(parts, normalizedPart{
+				Type:      "tool_call",
+				ID:        b.ID,
+				Name:      b.Name,
+				Arguments: b.Input,
+			})
+		case "thinking":
+			parts = append(parts, normalizedPart{Type: "reasoning", Content: b.Thinking})
+		default:
+			parts = append(parts, normalizedPart{Type: b.Type, Content: b.Text})
+		}
+	}
+
+	msg := normalizedMessage{
+		Role:         resp.Role,
+		Parts:        parts,
+		FinishReason: resp.StopReason,
+	}
+
+	out, err := json.Marshal([]normalizedMessage{msg})
+	if err != nil {
+		return string(resp.Content)
+	}
+	return string(out)
+}

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_bedrock.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_bedrock.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
+
+import (
+	"encoding/json"
+)
+
+// NormalizeBedrockOutput converts Bedrock Claude-style content blocks
+// to the semconv output messages schema. For Bedrock responses that use
+// Anthropic Claude format, the content blocks are identical to Anthropic.
+func NormalizeBedrockOutput(resp *BedrockResponse) string {
+	if len(resp.Content) == 0 {
+		return ""
+	}
+
+	var blocks []struct {
+		Type  string          `json:"type"`
+		Text  string          `json:"text,omitempty"`
+		ID    string          `json:"id,omitempty"`
+		Name  string          `json:"name,omitempty"`
+		Input json.RawMessage `json:"input,omitempty"`
+	}
+	if err := json.Unmarshal(resp.Content, &blocks); err != nil {
+		return wrapTextAsOutputMessage("assistant", string(resp.Content), resp.StopReason)
+	}
+
+	var parts []normalizedPart
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, normalizedPart{Type: "text", Content: b.Text})
+		case "tool_use":
+			parts = append(parts, normalizedPart{
+				Type:      "tool_call",
+				ID:        b.ID,
+				Name:      b.Name,
+				Arguments: b.Input,
+			})
+		default:
+			parts = append(parts, normalizedPart{Type: b.Type, Content: b.Text})
+		}
+	}
+
+	msg := normalizedMessage{
+		Role:         "assistant",
+		Parts:        parts,
+		FinishReason: resp.StopReason,
+	}
+
+	out, err := json.Marshal([]normalizedMessage{msg})
+	if err != nil {
+		return string(resp.Content)
+	}
+	return string(out)
+}

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_gemini.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_gemini.go
@@ -1,0 +1,130 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
+
+import (
+	"encoding/json"
+)
+
+// geminiPart captures all Gemini part types including function calls/responses.
+type geminiPart struct {
+	Text             string          `json:"text,omitempty"`
+	FunctionCall     *geminiFuncCall `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFuncResp `json:"functionResponse,omitempty"`
+}
+
+type geminiFuncCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+type geminiFuncResp struct {
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+func geminiPartToNormalized(p geminiPart) normalizedPart {
+	if p.FunctionCall != nil {
+		return normalizedPart{
+			Type:      "tool_call",
+			Name:      p.FunctionCall.Name,
+			Arguments: p.FunctionCall.Args,
+		}
+	}
+	if p.FunctionResponse != nil {
+		var resp any
+		if len(p.FunctionResponse.Response) > 0 {
+			_ = json.Unmarshal(p.FunctionResponse.Response, &resp)
+		}
+		return normalizedPart{
+			Type:     "tool_call_response",
+			Name:     p.FunctionResponse.Name,
+			Response: resp,
+		}
+	}
+	return normalizedPart{Type: "text", Content: p.Text}
+}
+
+// normalizeGeminiInput converts Gemini contents to the semconv schema.
+func normalizeGeminiInput(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var contents []struct {
+		Role  string       `json:"role"`
+		Parts []geminiPart `json:"parts"`
+	}
+	if err := json.Unmarshal(raw, &contents); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedMessage, 0, len(contents))
+	for _, c := range contents {
+		nm := normalizedMessage{Role: c.Role}
+		for _, p := range c.Parts {
+			nm.Parts = append(nm.Parts, geminiPartToNormalized(p))
+		}
+		out = append(out, nm)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+// normalizeGeminiOutput converts Gemini candidates to semconv output messages.
+func normalizeGeminiOutput(resp *GeminiResponse) string {
+	if len(resp.Candidates) == 0 {
+		return ""
+	}
+
+	out := make([]normalizedMessage, 0, len(resp.Candidates))
+	for _, c := range resp.Candidates {
+		nm := normalizedMessage{FinishReason: c.FinishReason}
+		if c.Content != nil {
+			nm.Role = c.Content.Role
+
+			var parts []geminiPart
+			if err := json.Unmarshal(c.Content.Parts, &parts); err == nil {
+				for _, p := range parts {
+					nm.Parts = append(nm.Parts, geminiPartToNormalized(p))
+				}
+			}
+		}
+		out = append(out, nm)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// normalizeGeminiParts converts Gemini-style parts from a single
+// content block to semconv parts.
+func normalizeGeminiParts(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var parts []geminiPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedPart, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, geminiPartToNormalized(p))
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_openai.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/genai_normalize_openai.go
@@ -1,0 +1,303 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// normalizeOpenAIMessages converts OpenAI-style messages (flat "content")
+// to the semconv parts schema.
+func normalizeOpenAIMessages(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var msgs []struct {
+		Role       string          `json:"role"`
+		Content    json.RawMessage `json:"content"`
+		ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+		ToolCallID string          `json:"tool_call_id,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &msgs); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedMessage, 0, len(msgs))
+	for _, m := range msgs {
+		nm := normalizedMessage{Role: m.Role}
+		nm.Parts = openAIContentToParts(m.Content)
+
+		if len(m.ToolCalls) > 0 {
+			nm.Parts = append(nm.Parts, openAIToolCallsToParts(m.ToolCalls)...)
+		}
+		if m.ToolCallID != "" {
+			for i := range nm.Parts {
+				nm.Parts[i].ID = m.ToolCallID
+				nm.Parts[i].Type = "tool_call_response"
+				nm.Parts[i].Response = nm.Parts[i].Content
+				nm.Parts[i].Content = ""
+			}
+		}
+		out = append(out, nm)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+// openAIContentToParts converts OpenAI message content (string or
+// structured array) to semconv parts. Structured content blocks
+// (image_url, input_audio, file, refusal) map to the corresponding
+// semconv part types (uri, blob, file, text) per the GenAI semconv
+// schema, which requires modality on uri/blob/file parts.
+func openAIContentToParts(content json.RawMessage) []normalizedPart {
+	if len(content) == 0 {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return []normalizedPart{{Type: "text", Content: s}}
+	}
+
+	var blocks []struct {
+		Type     string `json:"type"`
+		Text     string `json:"text,omitempty"`
+		Refusal  string `json:"refusal,omitempty"`
+		ImageURL *struct {
+			URL    string `json:"url"`
+			Detail string `json:"detail,omitempty"`
+		} `json:"image_url,omitempty"`
+		InputAudio *struct {
+			Data   string `json:"data"`
+			Format string `json:"format,omitempty"`
+		} `json:"input_audio,omitempty"`
+		File *struct {
+			FileID   string `json:"file_id,omitempty"`
+			Filename string `json:"filename,omitempty"`
+			FileData string `json:"file_data,omitempty"`
+		} `json:"file,omitempty"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return []normalizedPart{{Type: "text", Content: string(content)}}
+	}
+
+	parts := make([]normalizedPart, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, normalizedPart{Type: "text", Content: b.Text})
+		case "image_url":
+			if b.ImageURL != nil {
+				parts = append(parts, normalizedPart{
+					Type:     "uri",
+					URI:      b.ImageURL.URL,
+					Modality: "image",
+				})
+			}
+		case "input_audio":
+			if b.InputAudio != nil {
+				p := normalizedPart{
+					Type:     "blob",
+					Content:  b.InputAudio.Data,
+					Modality: "audio",
+				}
+				if b.InputAudio.Format != "" {
+					p.MimeType = "audio/" + b.InputAudio.Format
+				}
+				parts = append(parts, p)
+			}
+		case "file":
+			if b.File != nil {
+				modality := modalityFromFilename(b.File.Filename)
+				if b.File.FileID != "" {
+					parts = append(parts, normalizedPart{
+						Type:     "file",
+						FileID:   b.File.FileID,
+						Modality: modality,
+					})
+				} else if b.File.FileData != "" {
+					parts = append(parts, normalizedPart{
+						Type:     "blob",
+						Content:  b.File.FileData,
+						Modality: modality,
+					})
+				}
+			}
+		case "refusal":
+			parts = append(parts, normalizedPart{Type: "text", Content: b.Refusal})
+		default:
+			parts = append(parts, normalizedPart{Type: b.Type, Content: b.Text})
+		}
+	}
+	return parts
+}
+
+// modalityFromFilename returns a semconv modality string derived from a
+// filename's extension, or "file" when the modality cannot be determined.
+// The semconv schema accepts the enum image|video|audio or any string.
+func modalityFromFilename(filename string) string {
+	if filename == "" {
+		return "file"
+	}
+	dot := strings.LastIndex(filename, ".")
+	if dot < 0 || dot == len(filename)-1 {
+		return "file"
+	}
+	switch strings.ToLower(filename[dot+1:]) {
+	case "png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "tiff":
+		return "image"
+	case "mp3", "wav", "ogg", "flac", "m4a", "aac", "opus":
+		return "audio"
+	case "mp4", "webm", "mov", "mkv", "avi":
+		return "video"
+	}
+	return "file"
+}
+
+func openAIToolCallsToParts(raw json.RawMessage) []normalizedPart {
+	var calls []struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return nil
+	}
+
+	parts := make([]normalizedPart, 0, len(calls))
+	for _, c := range calls {
+		parts = append(parts, normalizedPart{
+			Type:      "tool_call",
+			ID:        c.ID,
+			Name:      c.Function.Name,
+			Arguments: c.Function.Arguments,
+		})
+	}
+	return parts
+}
+
+// normalizeOpenAIOutput converts OpenAI response choices to semconv output
+// messages schema.
+func normalizeOpenAIOutput(ai *VendorOpenAI) string {
+	if len(ai.Choices) > 0 {
+		return normalizeOpenAIChoices(ai.Choices)
+	}
+
+	if len(ai.Output) > 0 {
+		return normalizeOpenAIResponsesOutput(ai.Output)
+	}
+	if len(ai.Items) > 0 {
+		return string(ai.Items)
+	}
+	if len(ai.Data) > 0 {
+		return string(ai.Data)
+	}
+	return ""
+}
+
+// normalizeOpenAIResponsesOutput converts the OpenAI Responses API output
+// array to the semconv output messages schema. The Responses API output is a
+// heterogeneous array whose item types include "message", "function_call", and
+// others ("reasoning", "web_search_call", ...). Only message and function_call
+// items have semconv mappings; unknown item types are dropped.
+func normalizeOpenAIResponsesOutput(raw json.RawMessage) string {
+	var items []struct {
+		Type    string `json:"type"`
+		Role    string `json:"role"`
+		Status  string `json:"status"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		// function_call items
+		ID        string          `json:"id"`
+		CallID    string          `json:"call_id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedMessage, 0, len(items))
+	for _, item := range items {
+		switch item.Type {
+		case "function_call":
+			id := item.CallID
+			if id == "" {
+				id = item.ID
+			}
+			out = append(out, normalizedMessage{
+				Role: "assistant",
+				Parts: []normalizedPart{{
+					Type:      "tool_call",
+					ID:        id,
+					Name:      item.Name,
+					Arguments: item.Arguments,
+				}},
+			})
+		case "", "message":
+			parts := make([]normalizedPart, 0, len(item.Content))
+			for _, c := range item.Content {
+				parts = append(parts, normalizedPart{Type: "text", Content: c.Text})
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			out = append(out, normalizedMessage{
+				Role:         item.Role,
+				Parts:        parts,
+				FinishReason: item.Status,
+			})
+		}
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+func normalizeOpenAIChoices(raw json.RawMessage) string {
+	var choices []struct {
+		Message struct {
+			Role      string          `json:"role"`
+			Content   json.RawMessage `json:"content"`
+			ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	}
+	if err := json.Unmarshal(raw, &choices); err != nil {
+		return string(raw)
+	}
+
+	out := make([]normalizedMessage, 0, len(choices))
+	for _, c := range choices {
+		nm := normalizedMessage{
+			Role:         c.Message.Role,
+			FinishReason: c.FinishReason,
+		}
+		nm.Parts = openAIContentToParts(c.Message.Content)
+		if len(c.Message.ToolCalls) > 0 {
+			nm.Parts = append(nm.Parts, openAIToolCallsToParts(c.Message.ToolCalls)...)
+		}
+		out = append(out, nm)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/span.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/span.go
@@ -287,12 +287,23 @@ type GenAI struct {
 	Retrieval *VendorRetrieval
 }
 
+type OpenAIPromptTokensDetails struct {
+	CachedTokens        int `json:"cached_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+}
+
 type OpenAIUsage struct {
-	InputTokens      int `json:"input_tokens"`
-	OutputTokens     int `json:"output_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
+	InputTokens         int                        `json:"input_tokens"`
+	OutputTokens        int                        `json:"output_tokens"`
+	TotalTokens         int                        `json:"total_tokens"`
+	PromptTokens        int                        `json:"prompt_tokens"`
+	CompletionTokens    int                        `json:"completion_tokens"`
+	CompletionDetails   *OpenAICompletionDetails   `json:"completion_tokens_details,omitempty"`
+	PromptTokensDetails *OpenAIPromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+type OpenAICompletionDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 }
 
 func (u *OpenAIUsage) GetInputTokens() int {
@@ -333,64 +344,98 @@ type ToolCall struct {
 }
 
 type VendorOpenAI struct {
-	OperationName    string          `json:"object"`
-	ResponseModel    string          `json:"model"`
-	Error            OpenAIError     `json:"error"`
-	ID               string          `json:"id"`
-	FrequencyPenalty float64         `json:"frequency_penalty"`
-	Temperature      float64         `json:"temperature"`
-	TopP             float64         `json:"top_p"`
-	Usage            OpenAIUsage     `json:"usage"`
-	Output           json.RawMessage `json:"output"`
-	Request          OpenAIInput
-	Choices          json.RawMessage `json:"choices"`
-	Items            json.RawMessage `json:"items"`
-	Metadata         json.RawMessage `json:"metadata"`
-	Data             json.RawMessage `json:"data"`
-	ToolCalls        []ToolCall      `json:"-"`
+	OperationName     string          `json:"object"`
+	ResponseModel     string          `json:"model"`
+	Error             OpenAIError     `json:"error"`
+	ID                string          `json:"id"`
+	FrequencyPenalty  float64         `json:"frequency_penalty"`
+	Temperature       float64         `json:"temperature"`
+	TopP              float64         `json:"top_p"`
+	Usage             OpenAIUsage     `json:"usage"`
+	Output            json.RawMessage `json:"output"`
+	Request           OpenAIInput
+	Choices           json.RawMessage `json:"choices"`
+	Items             json.RawMessage `json:"items"`
+	Metadata          json.RawMessage `json:"metadata"`
+	Data              json.RawMessage `json:"data"`
+	ServiceTier       string          `json:"service_tier,omitempty"`
+	SystemFingerprint string          `json:"system_fingerprint,omitempty"`
+	APIType           string          `json:"-"`
+	ToolCalls         []ToolCall      `json:"-"`
+}
+
+func (ai *VendorOpenAI) GetFinishReasons() []string {
+	if len(ai.Choices) == 0 {
+		return nil
+	}
+	var choices []struct {
+		FinishReason string `json:"finish_reason"`
+	}
+	if err := json.Unmarshal(ai.Choices, &choices); err != nil {
+		return nil
+	}
+	var reasons []string
+	for _, c := range choices {
+		if c.FinishReason != "" {
+			reasons = append(reasons, c.FinishReason)
+		}
+	}
+	return reasons
 }
 
 func (ai *VendorOpenAI) GetOutput() string {
-	if len(ai.Output) > 0 {
-		return string(ai.Output)
-	}
-
-	if len(ai.Items) > 0 {
-		return string(ai.Items)
-	}
-
-	if len(ai.Data) > 0 {
-		return string(ai.Data)
-	}
-
-	return string(ai.Choices)
+	return normalizeOpenAIOutput(ai)
 }
 
 type OpenAIInput struct {
-	Input        string          `json:"input"`
-	Prompt       string          `json:"prompt"`
-	Model        string          `json:"model"`
-	Instructions string          `json:"instructions"`
-	Messages     json.RawMessage `json:"messages"`
-	Items        json.RawMessage `json:"items"`
-	Temperature  float64         `json:"temperature"`
-	Dimensions   int             `json:"dimensions,omitempty"`
+	Input           string          `json:"input"`
+	Prompt          string          `json:"prompt"`
+	Model           string          `json:"model"`
+	Instructions    string          `json:"instructions"`
+	Messages        json.RawMessage `json:"messages"`
+	Items           json.RawMessage `json:"items"`
+	Temperature     float64         `json:"temperature"`
+	Dimensions      int             `json:"dimensions,omitempty"`
+	MaxTokens       int             `json:"max_tokens,omitempty"`
+	N               int             `json:"n,omitempty"`
+	Stop            json.RawMessage `json:"stop,omitempty"`
+	PresencePenalty float64         `json:"presence_penalty,omitempty"`
+	Stream          bool            `json:"stream,omitempty"`
+	EncodingFormat  string          `json:"encoding_format,omitempty"`
+	Seed            *int            `json:"seed,omitempty"`
+	Tools           json.RawMessage `json:"tools,omitempty"`
+	ServiceTier     string          `json:"service_tier,omitempty"`
+}
+
+func (air *OpenAIInput) GetStopSequences() []string {
+	if len(air.Stop) == 0 {
+		return nil
+	}
+	var arr []string
+	if err := json.Unmarshal(air.Stop, &arr); err == nil {
+		return arr
+	}
+	var s string
+	if err := json.Unmarshal(air.Stop, &s); err == nil {
+		return []string{s}
+	}
+	return nil
 }
 
 func (air *OpenAIInput) GetInput() string {
 	if len(air.Input) > 0 {
-		return air.Input
+		return wrapTextAsInputMessage(air.Input)
 	}
 
 	if len(air.Prompt) > 0 {
-		return air.Prompt
+		return wrapTextAsInputMessage(air.Prompt)
 	}
 
 	if len(air.Items) > 0 {
 		return string(air.Items)
 	}
 
-	return string(air.Messages)
+	return normalizeOpenAIMessages(air.Messages)
 }
 
 type VendorAnthropic struct {
@@ -400,12 +445,16 @@ type VendorAnthropic struct {
 }
 
 type AnthropicRequest struct {
-	MaxTokens int             `json:"max_tokens"`
-	Messages  json.RawMessage `json:"messages"`
-	Model     string          `json:"model"`
-	Stream    bool            `json:"stream"`
-	System    string          `json:"system"`
-	Tools     json.RawMessage `json:"tools"`
+	MaxTokens     int             `json:"max_tokens"`
+	Messages      json.RawMessage `json:"messages"`
+	Model         string          `json:"model"`
+	Stream        bool            `json:"stream"`
+	System        string          `json:"system"`
+	Tools         json.RawMessage `json:"tools"`
+	Temperature   *float64        `json:"temperature,omitempty"`
+	TopP          *float64        `json:"top_p,omitempty"`
+	TopK          int             `json:"top_k,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
 }
 
 type AnthropicResponse struct {
@@ -422,10 +471,13 @@ type AnthropicResponse struct {
 }
 
 type AnthropicUsage struct {
-	InputTokens  int    `json:"input_tokens"`
-	OutputTokens int    `json:"output_tokens"`
-	ServiceTier  string `json:"service_tier"`
-	InferenceGeo string `json:"inference_geo"`
+	InputTokens              int    `json:"input_tokens"`
+	OutputTokens             int    `json:"output_tokens"`
+	CacheCreationInputTokens int    `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int    `json:"cache_read_input_tokens,omitempty"`
+	ReasoningOutputTokens    int    `json:"reasoning_output_tokens,omitempty"`
+	ServiceTier              string `json:"service_tier"`
+	InferenceGeo             string `json:"inference_geo"`
 }
 
 type AnthropicError struct {
@@ -444,6 +496,7 @@ type VendorGemini struct {
 	Output    GeminiResponse
 	Model     string
 	Operation string
+	IsStream  bool
 	ToolCalls []ToolCall `json:"-"`
 }
 
@@ -469,6 +522,7 @@ type GeminiGenCfg struct {
 	StopSequences    []string `json:"stopSequences,omitempty"`
 	Seed             *int     `json:"seed,omitempty"`
 	CandidateCount   int      `json:"candidateCount"`
+	ResponseMimeType string   `json:"responseMimeType,omitempty"`
 }
 
 type GeminiResponse struct {
@@ -517,19 +571,16 @@ func (g *VendorGemini) OperationName() string {
 }
 
 func (g *VendorGemini) GetOutput() string {
-	if len(g.Output.Candidates) > 0 && g.Output.Candidates[0].Content != nil {
-		return string(g.Output.Candidates[0].Content.Parts)
-	}
-	return ""
+	return normalizeGeminiOutput(&g.Output)
 }
 
 func (g *VendorGemini) GetInput() string {
-	return string(g.Input.Contents)
+	return normalizeGeminiInput(g.Input.Contents)
 }
 
 func (g *VendorGemini) GetSystemInstruction() string {
 	if g.Input.SystemInstruction != nil {
-		return string(g.Input.SystemInstruction.Parts)
+		return normalizeGeminiParts(g.Input.SystemInstruction.Parts)
 	}
 	return ""
 }
@@ -539,9 +590,11 @@ func (g *VendorGemini) GetSystemInstruction() string {
 // We capture the unified superset using omitempty and RawMessage for variable fields.
 
 type VendorBedrock struct {
-	Input  BedrockRequest
-	Output BedrockResponse
-	Model  string // extracted from URL path: /model/{modelId}/invoke
+	Input       BedrockRequest
+	Output      BedrockResponse
+	Model       string // extracted from URL path: /model/{modelId}/invoke
+	IsStream    bool
+	GuardrailID string
 }
 
 // BedrockRequest covers the common fields across all model families.
@@ -562,7 +615,8 @@ type BedrockRequest struct {
 	Prompt    string `json:"prompt,omitempty"`
 	MaxGenLen int    `json:"max_gen_len,omitempty"`
 	// Tool use (Claude / Nova)
-	Tools json.RawMessage `json:"tools,omitempty"`
+	Tools         json.RawMessage `json:"tools,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
 }
 
 type TitanGenConfig struct {
@@ -616,39 +670,43 @@ type TitanResult struct {
 
 func (b *VendorBedrock) GetInput() string {
 	if len(b.Input.Messages) > 0 {
-		return string(b.Input.Messages)
+		return NormalizeAnthropicInput(b.Input.Messages)
 	}
 	if b.Input.Prompt != "" {
-		return b.Input.Prompt
+		return wrapTextAsInputMessage(b.Input.Prompt)
 	}
 	if b.Input.InputText != "" {
-		return b.Input.InputText
+		return wrapTextAsInputMessage(b.Input.InputText)
 	}
 	return ""
 }
 
 func (b *VendorBedrock) GetOutput() string {
-	// Anthropic Claude: content array
+	// Anthropic Claude: content array (normalized via NormalizeBedrockOutput in tracesgen)
 	if len(b.Output.Content) > 0 {
 		return string(b.Output.Content)
 	}
 	// Amazon Nova: output.message.content
 	if b.Output.Output != nil && b.Output.Output.Message != nil && len(b.Output.Output.Message.Content) > 0 {
-		return string(b.Output.Output.Message.Content)
+		return wrapTextAsOutputMessage(
+			b.Output.Output.Message.Role,
+			string(b.Output.Output.Message.Content),
+			b.Output.StopReasonNova,
+		)
 	}
 	// Meta Llama: generation
 	if b.Output.Generation != "" {
-		return b.Output.Generation
+		return wrapTextAsOutputMessage("assistant", b.Output.Generation, b.GetStopReason())
 	}
 	// Amazon Titan: results[0].outputText
 	if len(b.Output.Results) > 0 {
-		return b.Output.Results[0].OutputText
+		return wrapTextAsOutputMessage("assistant", b.Output.Results[0].OutputText, b.Output.Results[0].CompletionReason)
 	}
 	return ""
 }
 
 func (b *VendorBedrock) GetSystemInstruction() string {
-	return b.Input.System
+	return NormalizeSystemInstructions(b.Input.System)
 }
 
 func (b *VendorBedrock) GetStopReason() string {
@@ -693,8 +751,14 @@ type JSONRPC struct {
 
 // Generic embedding provider types (Voyage AI, Cohere, Jina AI)
 
-// EmbeddingOperationName is the canonical operation name for embedding spans.
-const EmbeddingOperationName = "embeddings"
+// GenAI operation name constants aligned with OTel semantic conventions.
+const (
+	ChatOperationName        = "chat"
+	CompletionOperationName  = "text_completion"
+	GenerationOperationName  = "generation"
+	InvokeModelOperationName = "invoke_model"
+	EmbeddingOperationName   = "embeddings"
+)
 
 // VendorEmbedding represents a generic embedding API provider such as
 // Voyage AI, Cohere, or Jina AI.
@@ -1617,9 +1681,9 @@ func (s *Span) TraceName() string {
 
 		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAWSBedrock && s.GenAI != nil && s.GenAI.Bedrock != nil {
 			if s.GenAI.Bedrock.Model != "" {
-				return "invoke_model " + s.GenAI.Bedrock.Model
+				return InvokeModelOperationName + " " + s.GenAI.Bedrock.Model
 			}
-			return "invoke_model"
+			return InvokeModelOperationName
 		}
 
 		if s.SubType == HTTPSubtypeMCP && s.GenAI != nil && s.GenAI.MCP != nil {
@@ -1894,7 +1958,10 @@ func (s *Span) GenAIInputTokens() int {
 	}
 
 	if s.GenAI.Anthropic != nil {
-		return s.GenAI.Anthropic.Output.Usage.InputTokens
+		// Per Anthropic semconv: input_tokens excludes cached tokens.
+		// Total = input_tokens + cache_read + cache_creation.
+		u := s.GenAI.Anthropic.Output.Usage
+		return u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 	}
 
 	if s.GenAI.Gemini != nil {
@@ -1973,7 +2040,7 @@ func (s *Span) GenAIOperationName() string {
 		return s.GenAI.Qwen.OperationName
 	}
 	if s.GenAI.Bedrock != nil {
-		return "invoke_model"
+		return InvokeModelOperationName
 	}
 	if s.GenAI.Embedding != nil {
 		return s.GenAI.Embedding.OperationName()

--- a/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/span_getters.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/appolly/app/request/span_getters.go
@@ -363,7 +363,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 				return semconv.GenAIInputMessagesKey.String(s.GenAI.OpenAI.Request.GetInput())
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAnthropic && s.GenAI != nil && s.GenAI.Anthropic != nil {
-				return semconv.GenAIInputMessagesKey.String(string(s.GenAI.Anthropic.Input.Messages))
+				return semconv.GenAIInputMessagesKey.String(NormalizeAnthropicInput(s.GenAI.Anthropic.Input.Messages))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeGemini && s.GenAI != nil && s.GenAI.Gemini != nil {
 				return semconv.GenAIInputMessagesKey.String(s.GenAI.Gemini.GetInput())
@@ -379,18 +379,27 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.GenAIOutput:
 		getter = func(s *Span) attribute.KeyValue {
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeOpenAI && s.GenAI != nil && s.GenAI.OpenAI != nil {
+				if s.GenAI.OpenAI.OperationName == EmbeddingOperationName {
+					return semconv.GenAIOutputMessagesKey.String("")
+				}
 				return semconv.GenAIOutputMessagesKey.String(s.GenAI.OpenAI.GetOutput())
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAnthropic && s.GenAI != nil && s.GenAI.Anthropic != nil {
-				return semconv.GenAIOutputMessagesKey.String(string(s.GenAI.Anthropic.Output.Content))
+				return semconv.GenAIOutputMessagesKey.String(NormalizeAnthropicOutput(&s.GenAI.Anthropic.Output))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeGemini && s.GenAI != nil && s.GenAI.Gemini != nil {
 				return semconv.GenAIOutputMessagesKey.String(s.GenAI.Gemini.GetOutput())
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeQwen && s.GenAI != nil && s.GenAI.Qwen != nil {
+				if s.GenAI.Qwen.OperationName == EmbeddingOperationName {
+					return semconv.GenAIOutputMessagesKey.String("")
+				}
 				return semconv.GenAIOutputMessagesKey.String(s.GenAI.Qwen.GetOutput())
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAWSBedrock && s.GenAI != nil && s.GenAI.Bedrock != nil {
+				if len(s.GenAI.Bedrock.Output.Content) > 0 {
+					return semconv.GenAIOutputMessagesKey.String(NormalizeBedrockOutput(&s.GenAI.Bedrock.Output))
+				}
 				return semconv.GenAIOutputMessagesKey.String(s.GenAI.Bedrock.GetOutput())
 			}
 			return semconv.GenAIOutputMessagesKey.String("")
@@ -398,16 +407,16 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.GenAIInstructions:
 		getter = func(s *Span) attribute.KeyValue {
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeOpenAI && s.GenAI != nil && s.GenAI.OpenAI != nil {
-				return semconv.GenAISystemInstructionsKey.String(s.GenAI.OpenAI.Request.Instructions)
+				return semconv.GenAISystemInstructionsKey.String(NormalizeSystemInstructions(s.GenAI.OpenAI.Request.Instructions))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAnthropic && s.GenAI != nil && s.GenAI.Anthropic != nil {
-				return semconv.GenAISystemInstructionsKey.String(s.GenAI.Anthropic.Input.System)
+				return semconv.GenAISystemInstructionsKey.String(NormalizeSystemInstructions(s.GenAI.Anthropic.Input.System))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeGemini && s.GenAI != nil && s.GenAI.Gemini != nil {
 				return semconv.GenAISystemInstructionsKey.String(s.GenAI.Gemini.GetSystemInstruction())
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeQwen && s.GenAI != nil && s.GenAI.Qwen != nil {
-				return semconv.GenAISystemInstructionsKey.String(s.GenAI.Qwen.Request.Instructions)
+				return semconv.GenAISystemInstructionsKey.String(NormalizeSystemInstructions(s.GenAI.Qwen.Request.Instructions))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAWSBedrock && s.GenAI != nil && s.GenAI.Bedrock != nil {
 				return semconv.GenAISystemInstructionsKey.String(s.GenAI.Bedrock.GetSystemInstruction())
@@ -416,14 +425,20 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		}
 	case attr.GenAITools:
 		getter = func(s *Span) attribute.KeyValue {
+			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeOpenAI && s.GenAI != nil && s.GenAI.OpenAI != nil {
+				return semconv.GenAIToolDefinitionsKey.String(NormalizeToolDefinitions(s.GenAI.OpenAI.Request.Tools))
+			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAnthropic && s.GenAI != nil && s.GenAI.Anthropic != nil {
-				return semconv.GenAIToolDefinitionsKey.String(string(s.GenAI.Anthropic.Input.Tools))
+				return semconv.GenAIToolDefinitionsKey.String(NormalizeToolDefinitions(s.GenAI.Anthropic.Input.Tools))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeGemini && s.GenAI != nil && s.GenAI.Gemini != nil {
-				return semconv.GenAIToolDefinitionsKey.String(string(s.GenAI.Gemini.Input.Tools))
+				return semconv.GenAIToolDefinitionsKey.String(NormalizeToolDefinitions(s.GenAI.Gemini.Input.Tools))
+			}
+			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeQwen && s.GenAI != nil && s.GenAI.Qwen != nil {
+				return semconv.GenAIToolDefinitionsKey.String(NormalizeToolDefinitions(s.GenAI.Qwen.Request.Tools))
 			}
 			if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeAWSBedrock && s.GenAI != nil && s.GenAI.Bedrock != nil {
-				return semconv.GenAIToolDefinitionsKey.String(string(s.GenAI.Bedrock.Input.Tools))
+				return semconv.GenAIToolDefinitionsKey.String(NormalizeToolDefinitions(s.GenAI.Bedrock.Input.Tools))
 			}
 			return semconv.GenAIToolDefinitionsKey.String("")
 		}

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/amqp_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/amqp_detect_transform.go
@@ -47,6 +47,9 @@ func processAMQPBuffer(pkt *largebuf.LargeBuffer, direction uint8) (bool, []AMQP
 	}
 
 	reader := pkt.NewReader()
+	if !amqpparser.IsLikelyAMQP(&reader) {
+		return false, nil, nil
+	}
 	result, err := amqpparser.Parse(&reader)
 	if err != nil {
 		if errors.Is(err, amqpparser.ErrNotAMQP) {

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/common.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/common.go
@@ -513,14 +513,6 @@ func SupportsEBPFLoops(log *slog.Logger, overrideKernelVersion bool) bool {
 }
 
 func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
-	if !SupportsEBPFLoops(ptlog(), overrideKernelVersion) {
-		// Hack: instead of redefining bpf2go generated struct for mutually exclusive conditional programs,
-		// use one predefined field name to store either of them.
-		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]
-		spec.Programs["obi_protocol_http"].Name = "obi_protocol_http"
-		spec.Programs["obi_continue_protocol_http"] = spec.Programs["obi_continue_protocol_http_legacy"]
-		spec.Programs["obi_continue_protocol_http"].Name = "obi_continue_protocol_http"
-	}
 	dummy := &ebpf.ProgramSpec{
 		Name: "obi_dummy",
 		Type: ebpf.Kprobe,
@@ -530,8 +522,30 @@ func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
 		},
 		License: "MIT",
 	}
-	// Hack: insert dummy unused programs in order to be able to use bpf2go generated struct to load
-	// the collection.
+
+	if !SupportsEBPFLoops(ptlog(), overrideKernelVersion) {
+		// Swap the bpf_loop-based programs with their legacy counterparts so
+		// bpf2go-generated struct fields still bind on kernels without bpf_loop.
+		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]
+		spec.Programs["obi_protocol_http"].Name = "obi_protocol_http"
+		spec.Programs["obi_continue_protocol_http"] = spec.Programs["obi_continue_protocol_http_legacy"]
+		spec.Programs["obi_continue_protocol_http"].Name = "obi_continue_protocol_http"
+
+		// gotracer's obi_uprobe_readMimeHeader inlines a bpf_loop call. The
+		// runtime probe map (see gotracer.Tracer.UProbes) only attaches it on
+		// kernels >= 5.17, but the program still loads as part of the spec.
+		// Const-DCE removes the bpf_loop call when g_bpf_loop_enabled=false,
+		// orphaning the tp_match subprog. Pre-5.13 kernels then reject the
+		// load with "number of funcs in func_info doesn't match number of
+		// subprogs" because their func_info validator runs before DCE-aware
+		// subprog reconciliation. Replace with a dummy so it loads safely.
+		if _, ok := spec.Programs["obi_uprobe_readMimeHeader"]; ok {
+			spec.Programs["obi_uprobe_readMimeHeader"] = dummy
+		}
+	}
+
+	// Slot dummies in place of the legacy programs we already moved, so the
+	// bpf2go struct binding still resolves them.
 	spec.Programs["obi_protocol_http_legacy"] = dummy
 	spec.Programs["obi_continue_protocol_http_legacy"] = dummy
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/couchbase_detect_transform.go
@@ -32,6 +32,8 @@ type CouchbaseInfo struct {
 	IsError    bool
 }
 
+var errInvalidCouchbase = errors.New("no valid Couchbase request packets found")
+
 // buildCouchbaseStatement builds a db.query.text string for a KV request packet.
 // See devdocs/protocols/tcp/couchbase.md for the full format specification.
 //
@@ -241,7 +243,7 @@ func processCouchbaseEvent(connInfo BpfConnectionInfoT, requestBuf []byte, respo
 	for reqPacket, err := range couchbasekv.ParsePackets(requestBuf) {
 		if err != nil {
 			if !hasPackets {
-				return nil, true, errors.New("no valid Couchbase request packets found")
+				return nil, true, errInvalidCouchbase
 			}
 			break
 		}

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"strconv"
 	"unsafe"
@@ -25,7 +24,17 @@ const (
 	responseStatusKey       = "Status: "
 )
 
-const fcgiFrameTypeParams = 4
+const (
+	fcgiVersion1          = 1
+	fcgiFrameTypeBeginReq = 1
+	fcgiFrameTypeUnknown  = 11
+	fcgiFrameTypeParams   = 4
+)
+
+var (
+	errFastCGIPayloadTooShort  = errors.New("payload too short")
+	errFastCGIHeaderReadFailed = errors.New("failed to read FastCGI header")
+)
 
 // fastCGIHeader represents the structure of a FastCGI header
 type fastCGIHeader struct {
@@ -43,7 +52,7 @@ func readFastCGIHeader(b []byte) (*fastCGIHeader, error) {
 	// FastCGI header is always 8 bytes
 	headerBytes := make([]byte, fastCGIRequestHeaderLen)
 	if _, err := io.ReadFull(reader, headerBytes); err != nil {
-		return nil, fmt.Errorf("failed to read FastCGI header: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 
 	// Parse the header
@@ -51,22 +60,22 @@ func readFastCGIHeader(b []byte) (*fastCGIHeader, error) {
 	buffer := bytes.NewReader(headerBytes)
 
 	if err := binary.Read(buffer, binary.BigEndian, &header.Version); err != nil {
-		return nil, fmt.Errorf("failed to read version: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.Type); err != nil {
-		return nil, fmt.Errorf("failed to read type: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.RequestID); err != nil {
-		return nil, fmt.Errorf("failed to read request ID: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.ContentLength); err != nil {
-		return nil, fmt.Errorf("failed to read content length: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.PaddingLength); err != nil {
-		return nil, fmt.Errorf("failed to read padding length: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.Reserved); err != nil {
-		return nil, fmt.Errorf("failed to read reserved byte: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 
 	return header, nil
@@ -113,6 +122,22 @@ func maybeFastCGI(b *largebuf.LargeBuffer) bool {
 	if b.Len() <= fastCGIRequestHeaderLen {
 		return false
 	}
+	// FastCGI 1.0: every record starts with version=1 and a record type in
+	// 1..11. Cheap 2-byte check that filters ~99.98% of non-FastCGI payloads
+	// before the more expensive REQUEST_METHOD substring scan.
+
+	ver, err := b.U8At(0)
+
+	if err != nil || ver != fcgiVersion1 {
+		return false
+	}
+
+	frameType, err := b.U8At(1)
+
+	if err != nil || frameType < fcgiFrameTypeBeginReq || frameType > fcgiFrameTypeUnknown {
+		return false
+	}
+
 	return bytes.Contains(b.UnsafeView(), []byte(requestMethodKey))
 }
 
@@ -120,27 +145,27 @@ func parseHeader(b *largebuf.LargeBuffer) ([]byte, error) {
 	r := b.NewReader()
 	for {
 		if r.Remaining() < fastCGIRequestHeaderLen {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 		hdrBytes, err := r.ReadN(fastCGIRequestHeaderLen)
 		if err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 		hdr, err := readFastCGIHeader(hdrBytes)
 		if err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 
 		if hdr.Type == fcgiFrameTypeParams {
 			if r.Remaining() == 0 {
-				return nil, errors.New("payload too short")
+				return nil, errFastCGIPayloadTooShort
 			}
 			rest, _ := r.ReadN(r.Remaining())
 			return rest, nil
 		}
 		payloadOffset := int(hdr.ContentLength) + int(hdr.PaddingLength)
 		if err := r.Skip(payloadOffset); err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 	}
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/anthropic.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/anthropic.go
@@ -141,8 +141,10 @@ type MessageStartEvent struct {
 		Type  string `json:"type"`
 		Role  string `json:"role"`
 		Usage struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 		} `json:"usage"`
 	} `json:"message"`
 }
@@ -163,8 +165,10 @@ type MessageDeltaEvent struct {
 		StopSequence *string `json:"stop_sequence"`
 	} `json:"delta"`
 	Usage struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 	} `json:"usage"`
 }
 
@@ -227,6 +231,8 @@ func processEvent(eventType, data string, response *request.AnthropicResponse, c
 		response.Type = event.Message.Type
 		response.Usage.InputTokens += event.Message.Usage.InputTokens
 		response.Usage.OutputTokens += event.Message.Usage.OutputTokens
+		response.Usage.CacheCreationInputTokens += event.Message.Usage.CacheCreationInputTokens
+		response.Usage.CacheReadInputTokens += event.Message.Usage.CacheReadInputTokens
 
 	case "content_block_delta":
 		var event ContentBlockDelta
@@ -246,6 +252,8 @@ func processEvent(eventType, data string, response *request.AnthropicResponse, c
 		response.StopSequence = event.Delta.StopSequence
 		response.Usage.InputTokens += event.Usage.InputTokens
 		response.Usage.OutputTokens += event.Usage.OutputTokens
+		response.Usage.CacheCreationInputTokens += event.Usage.CacheCreationInputTokens
+		response.Usage.CacheReadInputTokens += event.Usage.CacheReadInputTokens
 
 	case "content_block_start":
 		var event struct {

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/bedrock.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/bedrock.go
@@ -69,13 +69,17 @@ func BedrockSpan(baseSpan *request.Span, req *http.Request, resp *http.Response)
 	parsedResponse.OutputTokens, _ = strconv.Atoi(resp.Header.Get("X-Amzn-Bedrock-Output-Token-Count"))
 
 	model := extractBedrockModel(req)
+	isStream := isBedrockStream(req)
+	guardrailID := extractBedrockGuardrailID(req, resp)
 
 	baseSpan.SubType = request.HTTPSubtypeAWSBedrock
 	baseSpan.GenAI = &request.GenAI{
 		Bedrock: &request.VendorBedrock{
-			Input:  parsedRequest,
-			Output: parsedResponse,
-			Model:  model,
+			Input:       parsedRequest,
+			Output:      parsedResponse,
+			Model:       model,
+			IsStream:    isStream,
+			GuardrailID: guardrailID,
 		},
 	}
 
@@ -100,4 +104,35 @@ func extractBedrockModel(req *http.Request) string {
 		return remainder
 	}
 	return remainder[:slashIdx]
+}
+
+// isBedrockStream detects streaming Bedrock calls by checking the URL path
+// for the invoke-with-response-stream suffix.
+func isBedrockStream(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	return strings.Contains(req.URL.Path, "invoke-with-response-stream")
+}
+
+// extractBedrockGuardrailID extracts the guardrail identifier from the
+// response header or the request URL path.
+func extractBedrockGuardrailID(req *http.Request, resp *http.Response) string {
+	if id := resp.Header.Get("X-Amzn-Bedrock-Guardrail-Id"); id != "" {
+		return id
+	}
+
+	if req != nil && req.URL != nil {
+		path := req.URL.Path
+		const prefix = "/guardrail/"
+		if idx := strings.Index(path, prefix); idx >= 0 {
+			remainder := path[idx+len(prefix):]
+			if slashIdx := strings.Index(remainder, "/"); slashIdx >= 0 {
+				return remainder[:slashIdx]
+			}
+			return remainder
+		}
+	}
+
+	return ""
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/gemini.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/gemini.go
@@ -137,6 +137,7 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 
 	model := extractGeminiModel(req)
 	operation := extractGeminiOperation(req)
+	isStream := isGeminiStream(req)
 	toolCalls := extractGeminiFunctionCalls(&parsedResponse)
 
 	baseSpan.SubType = request.HTTPSubtypeGemini
@@ -146,11 +147,21 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 			Output:    parsedResponse,
 			Model:     model,
 			Operation: operation,
+			IsStream:  isStream,
 			ToolCalls: toolCalls,
 		},
 	}
 
 	return *baseSpan, true
+}
+
+// isGeminiStream detects whether the Gemini call is a streaming request
+// by checking if the URL path contains "streamGenerateContent".
+func isGeminiStream(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	return strings.Contains(req.URL.Path, "streamGenerateContent")
 }
 
 // extractGeminiModel extracts the model name from the URL path.

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/openai.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/openai.go
@@ -92,11 +92,18 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	parsedResponse.Request = parsedRequest
 	parsedResponse.ToolCalls = extractToolCalls(parsedResponse.Choices)
 
-	// Override operation name for embedding requests.
+	// Override operation name and derive API type from URL path.
 	if req.URL != nil {
 		path := strings.TrimSuffix(req.URL.Path, "/")
-		if path == "/v1/embeddings" {
+		switch path {
+		case "/v1/chat/completions":
+			parsedResponse.OperationName = request.ChatOperationName
+			parsedResponse.APIType = "chat_completions"
+		case "/v1/embeddings":
 			parsedResponse.OperationName = request.EmbeddingOperationName
+			parsedResponse.APIType = "embeddings"
+		case "/v1/responses":
+			parsedResponse.APIType = "responses"
 		}
 	}
 

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/qwen.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http/qwen.go
@@ -82,9 +82,7 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 		}
 	}
 
-	if parsedResponse.OperationName == "" {
-		parsedResponse.OperationName = extractQwenOperation(req)
-	}
+	parsedResponse.OperationName = extractQwenOperation(req)
 	if parsedResponse.ResponseModel == "" {
 		parsedResponse.ResponseModel = parsedRequest.Model
 	}
@@ -105,20 +103,20 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 
 func extractQwenOperation(req *http.Request) string {
 	if req == nil {
-		return "generation"
+		return request.GenerationOperationName
 	}
 
 	path := requestPath(req)
 	switch {
 	case strings.Contains(path, "/chat/completions"):
-		return "chat.completion"
+		return request.ChatOperationName
 	case strings.Contains(path, "/completions"):
-		return "completion"
+		return request.CompletionOperationName
 	case strings.Contains(path, "/embeddings"):
-		return "embedding"
+		return request.EmbeddingOperationName
 	case strings.Contains(path, "/generation"):
-		return "generation"
+		return request.GenerationOperationName
 	default:
-		return "generation"
+		return request.GenerationOperationName
 	}
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http2grpc_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/http2grpc_transform.go
@@ -488,8 +488,25 @@ const (
 
 const frameHeaderLen = 9
 
+// maxPlausibleHTTP2FrameLen is a deliberately loose upper bound on HTTP/2
+// frame payload length, chosen well above any realistic SETTINGS_MAX_FRAME_SIZE
+// negotiation. Per RFC 7540 6.5.2 the spec default is 2^14 and the absolute
+// maximum is 2^24 - 1; we pick 4 MiB so that eBPF captures starting after a
+// peer has bumped the limit (e.g. gRPC streaming workloads) still pass the
+// prefilter, while ~75% of random 24-bit length values are still rejected.
+// Bump this if real traffic is dropped - false negatives are worse than
+// false positives here, since the downstream parser rejects garbage anyway.
+const maxPlausibleHTTP2FrameLen = 1 << 22
+
 func readHTTP2Frame(buf []uint8, length int) (*frameHeader, bool) {
 	if length < frameHeaderLen {
+		return nil, false
+	}
+
+	// RFC 7540 4.1: the high bit of the stream-identifier word is reserved
+	// and MUST be 0 when sent. Real HTTP/2 implementations set it to 0;
+	// rejecting it filters ~50% of random byte sequences with one bit test.
+	if buf[5]&0x80 != 0 {
 		return nil, false
 	}
 
@@ -515,6 +532,69 @@ func isInvalidFrame(frame *frameHeader) bool {
 	return frame.Length == 0 && frame.Type == FrameData
 }
 
+// http2FlagsMask returns the bitmask of flag bits that have spec-defined
+// semantics for the given frame type. RFC 7540 4.1 requires senders to leave
+// all other flag bits zero (receivers MUST ignore them), so a non-zero bit
+// outside this mask is a strong signal that the bytes did not come from a
+// real HTTP/2 sender.
+func http2FlagsMask(t http2FrameType) uint8 {
+	switch t {
+	case FrameData:
+		return 0x09 // END_STREAM | PADDED
+	case FrameHeaders:
+		return 0x2D // END_STREAM | END_HEADERS | PADDED | PRIORITY
+	case FrameSettings, FramePing:
+		return 0x01 // ACK
+	case FramePushPromise:
+		return 0x0C // END_HEADERS | PADDED
+	case FrameContinuation:
+		return 0x04 // END_HEADERS
+	case FramePriority, FrameRSTStream, FrameGoAway, FrameWindowUpdate:
+		return 0x00 // no defined flags
+	}
+	return 0x00
+}
+
+// isPlausibleHTTP2Frame applies the per-frame-type stream-ID, payload-length
+// and flag constraints from RFC 7540 6 + 4.1. Real HTTP/2 implementations
+// cannot send frames that violate these rules, so we can safely abort the
+// prefilter walk when a candidate frame fails them - almost no random byte
+// sequence satisfies the fixed-length / stream-zero / known-flag rules.
+func isPlausibleHTTP2Frame(fr *frameHeader) bool {
+	// Reserved flag bits must be zero (4.1).
+	if fr.Flags & ^http2FlagsMask(fr.Type) != 0 {
+		return false
+	}
+
+	switch fr.Type {
+	case FrameData, FrameHeaders, FramePushPromise, FrameContinuation:
+		// 6.1 / 6.2 / 6.6 / 6.10: MUST be associated with a stream. Length
+		// is capped by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID != 0 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FramePriority:
+		// 6.3: stream-associated, length MUST be 5.
+		return fr.StreamID != 0 && fr.Length == 5
+	case FrameRSTStream:
+		// 6.4: stream-associated, length MUST be 4.
+		return fr.StreamID != 0 && fr.Length == 4
+	case FrameSettings:
+		// 6.5: MUST be on stream 0, length MUST be a multiple of 6 and
+		// bounded by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID == 0 && fr.Length%6 == 0 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FramePing:
+		// 6.7: MUST be on stream 0, length MUST be 8.
+		return fr.StreamID == 0 && fr.Length == 8
+	case FrameGoAway:
+		// 6.8: MUST be on stream 0, length MUST be at least 8 and bounded
+		// by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID == 0 && fr.Length >= 8 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FrameWindowUpdate:
+		// 6.9: length MUST be 4; allowed on any stream.
+		return fr.Length == 4
+	}
+	return false
+}
+
 func isLikelyHTTP2(data []uint8, eventLen int) bool {
 	pos := 0
 	l := min(eventLen, len(data))
@@ -525,6 +605,13 @@ func isLikelyHTTP2(data []uint8, eventLen int) bool {
 
 		fr, ok := readHTTP2Frame(data[pos:], l)
 		if !ok {
+			break
+		}
+
+		// A frame that violates the per-type spec rules cannot have come
+		// from a real HTTP/2 sender; bail out of the walk so random bytes
+		// can't accidentally land on a HEADERS frame later in the buffer.
+		if !isPlausibleHTTP2Frame(fr) {
 			break
 		}
 
@@ -557,6 +644,7 @@ func isHTTP2(data *largebuf.LargeBuffer, eventLen int) bool {
 	}
 
 	dataReader := data.NewReader()
+
 	framer := http2.NewFramer(io.Discard, &dataReader)
 
 	for {

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/kafka_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/kafka_detect_transform.go
@@ -22,6 +22,11 @@ const (
 	Fetch   Operation = 1
 )
 
+var (
+	errKafkaUnsupportedAPIKey           = errors.New("unsupported Kafka API key")
+	errKafkaNoResponseBufferForMetadata = errors.New("no response buffer for metadata request")
+)
+
 type PartitionInfo struct {
 	Partition int
 	Offset    int64
@@ -73,7 +78,7 @@ func ProcessKafkaEvent(pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, ka
 	case kafkaparser.APIKeyMetadata:
 		return processMetadataResponse(rpkt, hdr, kafkaTopicUUIDToName)
 	default:
-		return nil, true, errors.New("unsupported Kafka API key")
+		return nil, true, errKafkaUnsupportedAPIKey
 	}
 }
 
@@ -153,7 +158,7 @@ func processFetchRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToNam
 
 func processMetadataResponse(rpkt *largebuf.LargeBuffer, hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
 	if rpkt == nil {
-		return nil, true, errors.New("no response buffer for metadata request")
+		return nil, true, errKafkaNoResponseBufferForMetadata
 	}
 	// only interested in response
 	r := rpkt.NewReader()
@@ -182,7 +187,7 @@ func ProcessKafkaRequest(pkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simple
 	case kafkaparser.APIKeyFetch:
 		return processFetchRequest(hdr, kafkaTopicUUIDToName)
 	default:
-		return nil, true, errors.New("unsupported Kafka API key")
+		return nil, true, errKafkaUnsupportedAPIKey
 	}
 }
 

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/memcached_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/memcached_detect_transform.go
@@ -22,6 +22,25 @@ const (
 	minMemcachedFrameLen = 3
 )
 
+// https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+// memcachedFirstByteBitmap is the set of valid first-byte characters for any
+// memcached text-protocol frame: classic command letters (lowercase), classic
+// response keywords (uppercase first letters), numeric reply lines (digits),
+// plus the meta-protocol additions ('m' for mg/ms/md/me/ma/mn; 'H' for HD; 'M'
+// for ME/MN). O(1) prefilter that rejects ~87% of random byte values before
+// scanning for the CRLF line terminator.
+var memcachedFirstByteBitmap = func() [4]uint64 {
+	var m [4]uint64
+	for _, c := range []byte("acdfgimprstvVESNDTOCHM0123456789") {
+		m[c>>6] |= 1 << (c & 63)
+	}
+	return m
+}()
+
+func isMemcachedFirstByte(b byte) bool {
+	return memcachedFirstByteBitmap[b>>6]&(1<<(b&63)) != 0
+}
+
 var (
 	memcachedDelimBytes = []byte(memcachedDelim)
 	memcachedCommands   = map[string]struct{}{
@@ -47,6 +66,14 @@ type memcachedParseResult struct {
 
 func isMemcachedBuf(buf *largebuf.LargeBuffer) bool {
 	if buf.Len() < minMemcachedFrameLen {
+		return false
+	}
+
+	// Cheap prefilter: every memcached text frame starts with a command
+	// letter, a response keyword, or a digit. Reject anything else without
+	// scanning the buffer for a CRLF that doesn't exist.
+	first, err := buf.U8At(0)
+	if err != nil || !isMemcachedFirstByte(first) {
 		return false
 	}
 

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/mongo_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/mongo_detect_transform.go
@@ -6,7 +6,6 @@ package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"strconv"
 	"unsafe"
 
@@ -19,6 +18,35 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
+)
+
+var (
+	errMongoPacketTooShortForHeader              = errors.New("packet too short for MongoDB header")
+	errMongoNoInFlightRequestForResponse         = errors.New("no in-flight MongoDB request found")
+	errMongoFailedToParseResponse                = errors.New("failed to parse MongoDB response")
+	errMongoNoRequestOrResponse                  = errors.New("no MongoDB request or response found in the message")
+	errMongoUnsupportedOpCode                    = errors.New("unsupported MongoDB operation code")
+	errMongoMoreToComeWithoutExhaustAllowed      = errors.New("MongoDB response with moreToCome flag set but exhaustAllowed is not set")
+	errMongoRequestExpectsMoreButResponseSent    = errors.New("MongoDB request expects more sections but response is sent")
+	errMongoRequestAfterAlreadyReceivingResponse = errors.New("MongoDB request received already started receiving response")
+	errMongoNewRequestWithoutMoreToCome          = errors.New("MongoDB request with moreToCome flag not set but got another request")
+	errMongoResponseWithoutPendingRequest        = errors.New("MongoDB response received but no pending request found")
+	errMongoPacketTooShortForFlagBits            = errors.New("packet too short for MongoDB flag bits")
+	errMongoFailedToParseSections                = errors.New("failed to parse MongoDB sections")
+	errMongoNoSections                           = errors.New("no MongoDB sections found in the message")
+	errMongoNotEnoughDataForSectionType          = errors.New("not enough data for MongoDB section type")
+	errMongoNotEnoughDataForSectionLength        = errors.New("not enough data for MongoDB section length")
+	errMongoUnsupportedSectionType               = errors.New("unsupported MongoDB section type")
+	errMongoInvalidMessageLength                 = errors.New("invalid MongoDB message length")
+	errMongoInvalidRequestID                     = errors.New("invalid MongoDB request ID")
+	errMongoInvalidResponseID                    = errors.New("invalid MongoDB response ID")
+	errMongoInvalidFlagBits                      = errors.New("invalid MongoDB flag bits")
+	errMongoNoRequestSections                    = errors.New("no MongoDB request sections found")
+	errMongoFirstSectionNotBody                  = errors.New("first MongoDB section is not of type body")
+	errMongoNoResponseBody                       = errors.New("no MongoDB body found in the response section")
+	errMongoNoOkField                            = errors.New("no 'ok' field found in MongoDB response")
+	errMongoHeartbeatIgnored                     = errors.New("MongoDB heartbeat operation is ignored")
+	errMongoNonStringCollectionType              = errors.New("MongoDB command has non-string collection type")
 )
 
 type mongoSpanInfo struct {
@@ -127,7 +155,7 @@ func requestTime(isResponse bool, startTime int64, endTime int64) int64 {
 
 func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo BpfConnectionInfoT, requests PendingMongoDBRequests) (*MongoRequestValue, bool, error) {
 	if len(buf) < msgHeaderSize {
-		return nil, false, errors.New("packet too short for MongoDB header")
+		return nil, false, errMongoPacketTooShortForHeader
 	}
 
 	header, err := parseMongoHeader(buf)
@@ -142,7 +170,7 @@ func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo Bpf
 	key := makeRequestKey(isResponse, header, connInfo)
 	inFlightRequest, ok := requests.Get(key)
 	if !ok && isResponse {
-		return nil, false, fmt.Errorf("no in-flight MongoDB request found for key %d", header.ResponseTo)
+		return nil, false, errMongoNoInFlightRequestForResponse
 	}
 	if isResponse && len(buf) == msgHeaderSize {
 		// TODO (mongo) currently the response is only the header, since the client sends only the first 16 bytes at first,
@@ -154,10 +182,10 @@ func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo Bpf
 	}
 	pendingRequest, moreToCome, err = parseMongoMessage(buf, *header, time, isResponse, inFlightRequest)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse MongoDB response: %w", err)
+		return nil, false, errMongoFailedToParseResponse
 	}
 	if pendingRequest == nil {
-		return nil, false, errors.New("no MongoDB request or response found in the message")
+		return nil, false, errMongoNoRequestOrResponse
 	}
 	if !moreToCome && isResponse {
 		// If this is a response and there are no more sections to come, we can finalize the request
@@ -172,7 +200,7 @@ func parseMongoMessage(buf []uint8, hdr msgHeader, time int64, isResponse bool, 
 	case opMsg:
 		return parseOpMessage(buf, time, isResponse, pendingRequest)
 	default:
-		return nil, false, fmt.Errorf("unsupported MongoDB operation code %d", hdr.OpCode)
+		return nil, false, errMongoUnsupportedOpCode
 	}
 }
 
@@ -182,19 +210,19 @@ func validateOpMsg(isResponse bool, flagBits int32, pendingRequest *MongoRequest
 	if isResponse {
 		exhaustAllowed := pendingRequest.Flags&flagExhaustAllowed != 0
 		if moreToCome && !exhaustAllowed {
-			return false, errors.New("MongoDB response with moreToCome flag set but exhaustAllowed is not set")
+			return false, errMongoMoreToComeWithoutExhaustAllowed
 		}
 		if pendingRequest.inRequest() && pendingRequest.Flags&flagMoreToCome != 0 {
-			return false, errors.New("MongoDB request expects more sections but response is sent")
+			return false, errMongoRequestExpectsMoreButResponseSent
 		}
 	} else {
 		switch {
 		case pendingRequest == nil:
 			return true, nil
 		case !pendingRequest.inRequest():
-			return false, errors.New("MongoDB request received already started receiving response")
+			return false, errMongoRequestAfterAlreadyReceivingResponse
 		case pendingRequest.Flags&flagMoreToCome == 0:
-			return false, errors.New("MongoDB request with moreToCome flag not set but got another request")
+			return false, errMongoNewRequestWithoutMoreToCome
 		}
 	}
 	return moreToCome, nil
@@ -203,7 +231,7 @@ func validateOpMsg(isResponse bool, flagBits int32, pendingRequest *MongoRequest
 func addSectionToMessage(isResponse bool, pendingRequest *MongoRequestValue, sections []mongoSection, flagBits int32, time int64) (*MongoRequestValue, error) {
 	if isResponse {
 		if pendingRequest == nil {
-			return nil, errors.New("MongoDB response received but no pending request found")
+			return nil, errMongoResponseWithoutPendingRequest
 		}
 		pendingRequest.ResponseSections = append(pendingRequest.ResponseSections, sections...)
 		pendingRequest.Flags = flagBits
@@ -236,7 +264,7 @@ func addSectionToMessage(isResponse bool, pendingRequest *MongoRequestValue, sec
 // +------------+-------------+------------------+
 func parseOpMessage(buf []uint8, time int64, isResponse bool, pendingRequest *MongoRequestValue) (*MongoRequestValue, bool, error) {
 	if len(buf) < msgHeaderSize+int32Size {
-		return nil, false, errors.New("packet too short for MongoDB flag bits")
+		return nil, false, errMongoPacketTooShortForFlagBits
 	}
 	flagBits := int32(binary.LittleEndian.Uint32(buf[msgHeaderSize : msgHeaderSize+int32Size]))
 	err := validateFlagBits(flagBits)
@@ -250,10 +278,10 @@ func parseOpMessage(buf []uint8, time int64, isResponse bool, pendingRequest *Mo
 	}
 	sections, err := parseSections(buf[msgHeaderSize+int32Size:])
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse MongoDB sections: %w", err)
+		return nil, false, errMongoFailedToParseSections
 	}
 	if len(sections) == 0 {
-		return nil, false, errors.New("no MongoDB sections found in the message")
+		return nil, false, errMongoNoSections
 	}
 	pendingRequest, err = addSectionToMessage(isResponse, pendingRequest, sections, flagBits, time)
 	if err != nil {
@@ -267,7 +295,7 @@ func parseSections(buf []uint8) ([]mongoSection, error) {
 	var sections []mongoSection
 	for offSet < len(buf) {
 		if len(buf[offSet:]) == 0 {
-			return nil, fmt.Errorf("not enough data for section[%d] type", len(sections))
+			return nil, errMongoNotEnoughDataForSectionType
 		}
 
 		sectionType := SectionType(buf[offSet])
@@ -288,17 +316,17 @@ func parseSections(buf []uint8) ([]mongoSection, error) {
 				Type: sectionTypeDocumentSequence,
 			})
 			if len(buf) < offSet+int32Size {
-				return nil, fmt.Errorf("not enough data for section[%d] length", len(sections))
+				return nil, errMongoNotEnoughDataForSectionLength
 			}
 			length := int(binary.LittleEndian.Uint32(buf[offSet : offSet+int32Size]))
 			offSet += length
 			// TODO (mongo) actually read documents? for now we just skip them
 		default:
-			return nil, errors.New("unsupported MongoDB section type: " + string(sectionType))
+			return nil, errMongoUnsupportedSectionType
 		}
 	}
 	if len(sections) == 0 {
-		return nil, errors.New("no MongoDB sections found in the message")
+		return nil, errMongoNoSections
 	}
 	return sections, nil
 }
@@ -339,13 +367,13 @@ func parseMongoHeader(pkt []byte) (*msgHeader, error) {
 
 func validateMsgHeader(header *msgHeader) error {
 	if header.MessageLength < msgHeaderSize {
-		return errors.New("invalid MongoDB message length")
+		return errMongoInvalidMessageLength
 	}
 	if header.RequestID < 0 {
-		return errors.New("invalid MongoDB request ID")
+		return errMongoInvalidRequestID
 	}
 	if header.ResponseTo < 0 {
-		return errors.New("invalid MongoDB response ID")
+		return errMongoInvalidResponseID
 	}
 	return nil
 }
@@ -355,7 +383,7 @@ The first 16 bits (0-15) are required and parsers MUST Error if an unknown bit i
 */
 func validateFlagBits(flagBits int32) error {
 	if uint16(flagBits&0xFFFF)&^allowedFlags != 0 {
-		return fmt.Errorf("invalid MongoDB flag bits: %d, allowed bits are: %d", flagBits, allowedFlags)
+		return errMongoInvalidFlagBits
 	}
 	return nil
 }
@@ -386,14 +414,14 @@ func mongoInfoFromEvent(event *TCPRequestInfo, requestBuffer *largebuf.LargeBuff
 func getMongoInfo(request *MongoRequestValue) (*mongoSpanInfo, error) {
 	spanInfo := &mongoSpanInfo{}
 	if request == nil || len(request.RequestSections) == 0 {
-		return nil, errors.New("no MongoDB request sections found")
+		return nil, errMongoNoRequestSections
 	}
 
 	// For simplicity, we assume the first section is the main one.
 	// In a real-world scenario, you might want to handle multiple sections.
 	requestSection := request.RequestSections[0]
 	if requestSection.Type != sectionTypeBody {
-		return nil, errors.New("first MongoDB section is not of type body")
+		return nil, errMongoFirstSectionNotBody
 	}
 	if len(requestSection.Body) == 0 {
 		// couldn't parse mongodb section, assume operation is *
@@ -418,11 +446,11 @@ func getMongoInfo(request *MongoRequestValue) (*mongoSpanInfo, error) {
 	} else {
 		responseSection := request.ResponseSections[0]
 		if len(responseSection.Body) == 0 {
-			return nil, errors.New("no MongoDB body found in the response section")
+			return nil, errMongoNoResponseBody
 		}
 		success, ok := findDoubleInBson(responseSection.Body, "ok")
 		if !ok {
-			return nil, errors.New("no 'ok' field found in MongoDB response")
+			return nil, errMongoNoOkField
 		}
 		spanInfo.Success = success == float64(1)
 		if spanInfo.Success {
@@ -515,12 +543,12 @@ func isCollectionCommand(comm string) bool {
 func parseFirstField(field bson.E) (string, string, error) {
 	comm := field.Key
 	if isHeartbeat(comm) {
-		return "", "", fmt.Errorf("MongoDB heartbeat operation '%s' is ignored", comm)
+		return "", "", errMongoHeartbeatIgnored
 	}
 	if isCollectionCommand(comm) {
 		collection, ok := field.Value.(string)
 		if !ok {
-			return "", "", fmt.Errorf("MongoDB command '%s' has non-string collection type %T", comm, field.Value)
+			return "", "", errMongoNonStringCollectionType
 		}
 		return comm, collection, nil
 	}

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/mqtt_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/mqtt_detect_transform.go
@@ -14,6 +14,14 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
+var (
+	errPacketTooShortForMQTT     = errors.New("packet too short for MQTT")
+	errNoMQTTPacketsFound        = errors.New("no MQTT packets found")
+	errNoSpanWorthyMQTTPackets   = errors.New("no span-worthy MQTT packets found")
+	errUnsupportedMQTTPacketType = errors.New("unsupported MQTT packet type")
+	errNoMQTTSubscriptionsFound  = errors.New("no subscriptions found")
+)
+
 // MQTTInfo holds parsed information from an MQTT packet.
 type MQTTInfo struct {
 	// PacketType is the MQTT packet type (PUBLISH, SUBSCRIBE, etc.)
@@ -48,11 +56,14 @@ func packetTypeToMethod(packetType mqttparser.PacketType) string {
 // Otherwise, returns MQTTInfo with the processed data. The ignore bool indicates whether the event
 // should be ignored for span creation (e.g., control packets like CONNECT).
 func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer) (*MQTTInfo, bool, error) {
-	m, ignore, err := ProcessMQTTEvent(pkt.UnsafeView())
+	pktView := pkt.UnsafeView()
+	rpktView := rpkt.UnsafeView()
+
+	m, ignore, err := ProcessMQTTEvent(pktView)
 	if err != nil {
 		// If we are getting the information in the response buffer, the event
 		// must be reversed and that's how we captured it.
-		m, ignore, err = ProcessMQTTEvent(rpkt.UnsafeView())
+		m, ignore, err = ProcessMQTTEvent(rpktView)
 		if err == nil && !ignore {
 			reverseTCPEvent(event)
 		}
@@ -64,7 +75,7 @@ func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, 
 // Returns MQTTInfo for span-worthy packets, or ignore=true for control packets.
 func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 	if len(pkt) < mqttparser.MinPacketLen {
-		return nil, true, errors.New("packet too short for MQTT")
+		return nil, true, errPacketTooShortForMQTT
 	}
 
 	packets, err := mqttparser.ParseMQTTPackets(pkt)
@@ -73,7 +84,7 @@ func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 	}
 
 	if len(packets) == 0 {
-		return nil, true, errors.New("no MQTT packets found")
+		return nil, true, errNoMQTTPacketsFound
 	}
 
 	// Process the first packet that we can extract span information from
@@ -94,11 +105,11 @@ func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 		offset += packet.Length()
 	}
 
-	return nil, true, errors.New("no span-worthy MQTT packets found")
+	return nil, true, errNoSpanWorthyMQTTPackets
 }
 
 // processMQTTPacket processes a single MQTT packet based on its type.
-func processMQTTPacket(pkt []byte, startOffset int, packet mqttparser.MQTTControlPacket) (*MQTTInfo, bool, error) {
+func processMQTTPacket(pkt []byte, startOffset int, packet *mqttparser.MQTTControlPacket) (*MQTTInfo, bool, error) {
 	// Variable header starts after fixed header
 	varHeaderOffset := startOffset + packet.FixedHeader.Length
 
@@ -124,7 +135,7 @@ func processMQTTPacket(pkt []byte, startOffset int, packet mqttparser.MQTTContro
 		// Control packets - ignore for span creation
 		return nil, true, nil
 	default:
-		return nil, true, errors.New("unsupported MQTT packet type")
+		return nil, true, errUnsupportedMQTTPacketType
 	}
 }
 
@@ -149,7 +160,7 @@ func processSubscribePacket(pkt []byte, offset int, remainingLength int) (*MQTTI
 	}
 
 	if len(subscribe.Subscriptions) == 0 {
-		return nil, true, errors.New("no subscriptions found")
+		return nil, true, errNoMQTTSubscriptionsFound
 	}
 
 	// Use the first subscription for the span

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/nats_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/nats_detect_transform.go
@@ -15,6 +15,25 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
+// https://docs.nats.io/reference/reference-protocols/nats-protocol
+// https://docs.nats.io/reference/reference-protocols/nats-server-protocol
+// natsCmdFirstByteBitmap is the set of valid first-byte characters for any NATS
+// control frame: +OK, -ERR, PING, PONG, INFO, CONNECT, SUB, UNSUB, PUB, MSG,
+// HPUB, HMSG. Case-insensitive (lowercase variants accepted by the parser).
+// Used as an O(1) prefilter that rejects ~94% of random byte values.
+
+var natsCmdFirstByteBitmap = func() [4]uint64 {
+	var m [4]uint64
+	for _, c := range []byte("+-PpIiCcSsUuMmHhRr") {
+		m[c>>6] |= 1 << (c & 63)
+	}
+	return m
+}()
+
+func isNATSCmdFirstByte(b byte) bool {
+	return natsCmdFirstByteBitmap[b>>6]&(1<<(b&63)) != 0
+}
+
 var (
 	natsCRLF       = []byte("\r\n")
 	natsCmdOK      = []byte("+OK")
@@ -29,6 +48,37 @@ var (
 	natsCmdMsg     = []byte("MSG")
 	natsCmdHPub    = []byte("HPUB")
 	natsCmdHMsg    = []byte("HMSG")
+)
+
+var (
+	errMissingNatsTerminator               = errors.New("missing NATS control line terminator")
+	errPacketTooShortForNATS               = errors.New("packet too short for NATS")
+	errNotLikelyNATS                       = errors.New("packet does not look like NATS")
+	errEmptyNATSCommand                    = errors.New("empty NATS command")
+	errUnsupportedNATSCommand              = errors.New("unsupported NATS command")
+	errInvalidNATSJSONPayload              = errors.New("invalid NATS JSON payload")
+	errMissingNATSJSONPayload              = errors.New("missing NATS JSON payload")
+	errInvalidSUBControlLine               = errors.New("invalid SUB control line")
+	errInvalidUNSUBControlLine             = errors.New("invalid UNSUB control line")
+	errInvalidUNSUBMaxMsgs                 = errors.New("invalid UNSUB max_msgs")
+	errInvalidMSGControlLine               = errors.New("invalid MSG control line")
+	errInvalidMSGPayloadSize               = errors.New("invalid MSG payload size")
+	errInvalidHMSGControlLine              = errors.New("invalid HMSG control line")
+	errInvalidHMSGHeaderSize               = errors.New("invalid HMSG header size")
+	errInvalidHMSGTotalSize                = errors.New("invalid HMSG total size")
+	errHMSGHeaderSizeExceedsTotal          = errors.New("HMSG header size exceeds total size")
+	errInvalidIntegerField                 = errors.New("invalid integer field")
+	errInvalidNATSPayloadControlLine       = errors.New("invalid NATS payload control line")
+	errInvalidNATSPayloadSize              = errors.New("invalid NATS payload size")
+	errInvalidNATSHeaderPayloadControlLine = errors.New("invalid NATS header payload control line")
+	errInvalidNATSHeaderSize               = errors.New("invalid NATS header size")
+	errInvalidNATSTotalSize                = errors.New("invalid NATS total size")
+	errNATSHeaderSizeExceedsTotal          = errors.New("NATS header size exceeds total size")
+	errNegativeNATSPayloadSize             = errors.New("negative NATS payload size")
+	errTruncatedNATSPayload                = errors.New("truncated NATS payload")
+	errMissingNATSPayloadTerminator        = errors.New("missing NATS payload terminator")
+	errEmptyNATSControlLine                = errors.New("empty NATS control line")
+	errInvalidNATSSID                      = errors.New("invalid NATS sid")
 )
 
 type NATSInfo struct {
@@ -91,7 +141,17 @@ func ProcessPossibleNATSEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, 
 // contains non-span control frames.
 func ProcessNATSEvent(pkt *largebuf.LargeBuffer) (*NATSInfo, bool, error) {
 	if pkt == nil || pkt.Len() == 0 {
-		return nil, true, errors.New("packet too short for NATS")
+		return nil, true, errPacketTooShortForNATS
+	}
+
+	first, err := pkt.U8At(0)
+
+	// Cheap prefilter: every NATS frame starts with the first letter of one of
+	// the protocol commands (+OK, -ERR, PING/PONG/PUB, INFO, CONNECT, SUB,
+	// UNSUB, MSG, HPUB/HMSG). Reject anything else without invoking the
+	// frame parser.
+	if err != nil || !isNATSCmdFirstByte(first) {
+		return nil, true, errNotLikelyNATS
 	}
 
 	reader := pkt.NewReader()
@@ -123,7 +183,7 @@ func parseNATSFrame(reader *largebuf.LargeBufferReader) (natsFrame, error) {
 
 	fields := bytes.Fields(line)
 	if len(fields) == 0 {
-		return natsFrame{}, errors.New("empty NATS command")
+		return natsFrame{}, errEmptyNATSCommand
 	}
 
 	command := fields[0]
@@ -149,7 +209,7 @@ func parseNATSFrame(reader *largebuf.LargeBufferReader) (natsFrame, error) {
 	case equalFoldASCII(command, natsCmdHMsg):
 		return parseNATSHMSGFrame(reader, fields)
 	default:
-		return natsFrame{}, errors.New("unsupported NATS command")
+		return natsFrame{}, errUnsupportedNATSCommand
 	}
 }
 
@@ -167,7 +227,7 @@ func parseNATSInfoOrConnectFrame(command, line []byte) (natsFrame, error) {
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(rest, &meta); err != nil {
-		return natsFrame{}, errors.New("invalid NATS JSON payload")
+		return natsFrame{}, errInvalidNATSJSONPayload
 	}
 
 	return natsFrame{clientID: meta.Name, valid: true}, nil
@@ -175,7 +235,7 @@ func parseNATSInfoOrConnectFrame(command, line []byte) (natsFrame, error) {
 
 func parseNATSSubFrame(fields [][]byte) (natsFrame, error) {
 	if len(fields) != 3 && len(fields) != 4 {
-		return natsFrame{}, errors.New("invalid SUB control line")
+		return natsFrame{}, errInvalidSUBControlLine
 	}
 	if err := validateNATSSID(fields[len(fields)-1]); err != nil {
 		return natsFrame{}, err
@@ -185,14 +245,14 @@ func parseNATSSubFrame(fields [][]byte) (natsFrame, error) {
 
 func parseNATSUnsubFrame(fields [][]byte) (natsFrame, error) {
 	if len(fields) != 2 && len(fields) != 3 {
-		return natsFrame{}, errors.New("invalid UNSUB control line")
+		return natsFrame{}, errInvalidUNSUBControlLine
 	}
 	if err := validateNATSSID(fields[1]); err != nil {
 		return natsFrame{}, err
 	}
 	if len(fields) == 3 {
 		if _, err := parseIntField(fields[2]); err != nil {
-			return natsFrame{}, errors.New("invalid UNSUB max_msgs")
+			return natsFrame{}, errInvalidUNSUBMaxMsgs
 		}
 	}
 	return natsFrame{valid: true}, nil
@@ -214,14 +274,14 @@ func parseNATSPUBFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (nat
 
 func parseNATSMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (natsFrame, error) {
 	if len(fields) != 4 && len(fields) != 5 {
-		return natsFrame{}, errors.New("invalid MSG control line")
+		return natsFrame{}, errInvalidMSGControlLine
 	}
 	if err := validateNATSSID(fields[2]); err != nil {
 		return natsFrame{}, err
 	}
 	size, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid MSG payload size")
+		return natsFrame{}, errInvalidMSGPayloadSize
 	}
 	if err := consumeNATSPayload(reader, size); err != nil {
 		return natsFrame{}, err
@@ -248,21 +308,21 @@ func parseNATSHPUBFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (na
 
 func parseNATSHMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (natsFrame, error) {
 	if len(fields) != 5 && len(fields) != 6 {
-		return natsFrame{}, errors.New("invalid HMSG control line")
+		return natsFrame{}, errInvalidHMSGControlLine
 	}
 	if err := validateNATSSID(fields[2]); err != nil {
 		return natsFrame{}, err
 	}
 	hdrSize, err := parseIntField(fields[len(fields)-2])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid HMSG header size")
+		return natsFrame{}, errInvalidHMSGHeaderSize
 	}
 	totalSize, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid HMSG total size")
+		return natsFrame{}, errInvalidHMSGTotalSize
 	}
 	if hdrSize > totalSize {
-		return natsFrame{}, errors.New("HMSG header size exceeds total size")
+		return natsFrame{}, errHMSGHeaderSizeExceedsTotal
 	}
 	if err := consumeNATSPayload(reader, totalSize); err != nil {
 		return natsFrame{}, err
@@ -275,19 +335,19 @@ func parseNATSHMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (na
 
 func parseIntField(field []byte) (int, error) {
 	if len(field) == 0 {
-		return 0, errors.New("invalid integer field")
+		return 0, errInvalidIntegerField
 	}
 	return strconv.Atoi(unsafe.String(unsafe.SliceData(field), len(field)))
 }
 
 func parseNATSPayloadFields(fields [][]byte) (string, int, error) {
 	if len(fields) != 3 && len(fields) != 4 {
-		return "", 0, errors.New("invalid NATS payload control line")
+		return "", 0, errInvalidNATSPayloadControlLine
 	}
 
 	size, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS payload size")
+		return "", 0, errInvalidNATSPayloadSize
 	}
 
 	return string(fields[1]), size, nil
@@ -295,19 +355,19 @@ func parseNATSPayloadFields(fields [][]byte) (string, int, error) {
 
 func parseNATSHeaderPayloadFields(fields [][]byte) (string, int, error) {
 	if len(fields) != 4 && len(fields) != 5 {
-		return "", 0, errors.New("invalid NATS header payload control line")
+		return "", 0, errInvalidNATSHeaderPayloadControlLine
 	}
 
 	hdrSize, err := parseIntField(fields[len(fields)-2])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS header size")
+		return "", 0, errInvalidNATSHeaderSize
 	}
 	totalSize, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS total size")
+		return "", 0, errInvalidNATSTotalSize
 	}
 	if hdrSize > totalSize {
-		return "", 0, errors.New("NATS header size exceeds total size")
+		return "", 0, errNATSHeaderSizeExceedsTotal
 	}
 
 	return string(fields[1]), totalSize, nil
@@ -315,19 +375,19 @@ func parseNATSHeaderPayloadFields(fields [][]byte) (string, int, error) {
 
 func consumeNATSPayload(reader *largebuf.LargeBufferReader, size int) error {
 	if size < 0 {
-		return errors.New("negative NATS payload size")
+		return errNegativeNATSPayloadSize
 	}
 
 	if err := reader.Skip(size); err != nil {
-		return errors.New("truncated NATS payload")
+		return errTruncatedNATSPayload
 	}
 
 	terminator, err := reader.ReadN(len(natsCRLF))
 	if err != nil {
-		return errors.New("truncated NATS payload")
+		return errTruncatedNATSPayload
 	}
 	if !bytes.Equal(terminator, natsCRLF) {
-		return errors.New("missing NATS payload terminator")
+		return errMissingNATSPayloadTerminator
 	}
 
 	return nil
@@ -336,22 +396,22 @@ func consumeNATSPayload(reader *largebuf.LargeBufferReader, size int) error {
 func readNATSControlLine(reader *largebuf.LargeBufferReader) ([]byte, error) {
 	crPos := reader.IndexByte('\r')
 	if crPos < 0 {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	line, err := reader.ReadN(crPos)
 	if err != nil {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	terminator, err := reader.ReadN(len(natsCRLF))
 	if err != nil || !bytes.Equal(terminator, natsCRLF) {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	line = bytes.TrimSpace(line)
 	if len(line) == 0 {
-		return nil, errors.New("empty NATS control line")
+		return nil, errEmptyNATSControlLine
 	}
 
 	return line, nil
@@ -359,12 +419,12 @@ func readNATSControlLine(reader *largebuf.LargeBufferReader) ([]byte, error) {
 
 func natsJSONPayload(line, command []byte) ([]byte, error) {
 	if len(line) <= len(command) {
-		return nil, errors.New("missing NATS JSON payload")
+		return nil, errMissingNATSJSONPayload
 	}
 
 	rest := bytes.TrimSpace(line[len(command):])
 	if !json.Valid(rest) {
-		return nil, errors.New("invalid NATS JSON payload")
+		return nil, errInvalidNATSJSONPayload
 	}
 
 	return rest, nil
@@ -372,7 +432,7 @@ func natsJSONPayload(line, command []byte) ([]byte, error) {
 
 func validateNATSSID(field []byte) error {
 	if !isASCIIAlnumBytes(field) {
-		return errors.New("invalid NATS sid")
+		return errInvalidNATSSID
 	}
 	return nil
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/sql_detect_postgres.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/sql_detect_postgres.go
@@ -38,6 +38,17 @@ const (
 	pgHeaderLen = 5
 )
 
+var (
+	errPGTooShort                     = errors.New("too short")
+	errPGTooShortStatement            = errors.New("too short, while parsing statement")
+	errPGTooShortPortal               = errors.New("too short, while parsing portal")
+	errPGTooShortFormatCodes          = errors.New("too short, while parsing format codes")
+	errPGTooShortParams               = errors.New("too short, while parsing params")
+	errPGRemainingTooShortHeader      = errors.New("remaining buffer too short for message header")
+	errPGMalformedMessage             = errors.New("malformed Postgres message")
+	errPGRemainingTooShortMessageData = errors.New("remaining buffer too short for message data")
+)
+
 func isPostgres(b *largebuf.LargeBuffer) bool {
 	op, ok := isValidPostgresPayload(b)
 
@@ -80,13 +91,13 @@ func isValidPostgresPayload(b *largebuf.LargeBuffer) (byte, bool) {
 func msgBody(b *largebuf.LargeBuffer) ([]byte, error) {
 	size, err := b.I32BEAt(1)
 	if err != nil {
-		return nil, errors.New("too short")
+		return nil, errPGTooShort
 	}
 
 	msgSize := min(1+int(size), b.Len())
 
 	if msgSize < pgHeaderLen {
-		return nil, errors.New("too short")
+		return nil, errPGTooShort
 	}
 
 	return b.UnsafeViewAt(pgHeaderLen, msgSize-pgHeaderLen)
@@ -97,11 +108,11 @@ func msgBody(b *largebuf.LargeBuffer) ([]byte, error) {
 func msgBodyReader(b *largebuf.LargeBuffer) (largebuf.LargeBufferReader, error) {
 	size, err := b.I32BEAt(1)
 	if err != nil {
-		return largebuf.LargeBufferReader{}, errors.New("too short")
+		return largebuf.LargeBufferReader{}, errPGTooShort
 	}
 	end := min(1+int(size), b.Len())
 	if end < pgHeaderLen {
-		return largebuf.LargeBufferReader{}, errors.New("too short")
+		return largebuf.LargeBufferReader{}, errPGTooShort
 	}
 	return b.NewLimitedReader(pgHeaderLen, end)
 }
@@ -115,29 +126,29 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 
 	stmtBytes, err := r.ReadCStr()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing statement")
+		return "", "", nil, errPGTooShortStatement
 	}
 
 	portalBytes, err := r.ReadCStr()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing portal")
+		return "", "", nil, errPGTooShortPortal
 	}
 
 	// skip format codes: Int16 count + count*Int16 entries
 	formats, err := r.ReadI16BE()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing format codes")
+		return "", "", nil, errPGTooShortFormatCodes
 	}
 	if formats > 0 {
 		if err := r.Skip(2 * int(formats)); err != nil {
-			return "", "", nil, errors.New("too short, while parsing format codes")
+			return "", "", nil, errPGTooShortFormatCodes
 		}
 	}
 
 	// parse parameter values: Int16 count + repeated (Int32 length + bytes)
 	params, err := r.ReadI16BE()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing params")
+		return "", "", nil, errPGTooShortParams
 	}
 	if params <= 0 {
 		return string(stmtBytes), string(portalBytes), nil, nil
@@ -146,7 +157,7 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 	for range int(params) {
 		argLen, err := r.ReadI32BE()
 		if err != nil {
-			return "", "", nil, errors.New("too short, while parsing params")
+			return "", "", nil, errPGTooShortParams
 		}
 		if argLen < 0 {
 			// NULL parameter value (-1 in the protocol)
@@ -155,7 +166,7 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 		n := min(int(argLen), r.Remaining())
 		arg, err := r.ReadN(n)
 		if err != nil {
-			return "", "", nil, errors.New("too short, while parsing params")
+			return "", "", nil, errPGTooShortParams
 		}
 		args = append(args, string(arg))
 	}
@@ -239,7 +250,7 @@ func (it *postgresMessageIterator) next() (msg postgresMessage) {
 		return
 	}
 	if it.r.Remaining() < sqlprune.PostgresHdrSize {
-		it.err = errors.New("remaining buffer too short for message header")
+		it.err = errPGRemainingTooShortHeader
 		return
 	}
 
@@ -254,13 +265,13 @@ func (it *postgresMessageIterator) next() (msg postgresMessage) {
 	size := int32(binary.BigEndian.Uint32(hdrBuf[1:5]))
 
 	if size < sqlprune.PostgresHdrSize-1 {
-		it.err = errors.New("malformed Postgres message")
+		it.err = errPGMalformedMessage
 		return
 	}
 
 	payloadSize := size - sqlprune.PostgresHdrSize + 1
 	if it.r.Remaining() < int(payloadSize) {
-		it.err = fmt.Errorf("remaining buffer too short for message data: expected %d bytes, got %d", payloadSize, it.r.Remaining())
+		it.err = errPGRemainingTooShortMessageData
 		return
 	}
 

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/sql_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/sql_detect_transform.go
@@ -75,6 +75,34 @@ var sqlKeywords = [][]byte{
 
 var sqlExecuteKeyword = []byte("EXECUTE ")
 
+const minSQLPrintableRun = len("SELECT 1")
+
+// isSQLByte reports whether b is a byte that can appear inside a SQL statement
+// (printable ASCII plus the common whitespace characters).
+func isSQLByte(b byte) bool {
+	return (b >= 0x20 && b < 0x7f) || b == '\t' || b == '\n' || b == '\r'
+}
+
+// firstSQLRun returns the start index of the first contiguous run of at least
+// minLen SQL-plausible bytes in buf, or -1 if no such run exists.
+func firstSQLRun(buf []byte, minLen int) int {
+	if len(buf) < minLen {
+		return -1
+	}
+	run := 0
+	for i, b := range buf {
+		if isSQLByte(b) {
+			run++
+			if run >= minLen {
+				return i - minLen + 1
+			}
+		} else {
+			run = 0
+		}
+	}
+	return -1
+}
+
 func detectSQLPayload(useHeuristics bool, b *largebuf.LargeBuffer) (string, string, string, request.SQLKind) {
 	sqlKind := sqlKind(b)
 
@@ -101,16 +129,25 @@ func detectSQLPayload(useHeuristics bool, b *largebuf.LargeBuffer) (string, stri
 }
 
 func detectSQL(buf []byte) (string, string, string) {
+	// Cheap prefilter: most SQL wire protocols carry a small binary header
+	// followed by the statement as plain text. If no printable-ASCII run long
+	// enough to fit the shortest valid SQL exists, skip the case-fold scan.
+	start := firstSQLRun(buf, minSQLPrintableRun)
+	if start < 0 {
+		return "", "", ""
+	}
+	scan := buf[start:]
+
 	minIdx := -1
 	for _, q := range sqlKeywords {
-		i := asciiIndexFold(buf, q)
+		i := asciiIndexFold(scan, q)
 		if i >= 0 && (minIdx < 0 || i < minIdx) {
 			minIdx = i
 		}
 	}
 
 	if minIdx >= 0 {
-		sql := cstr(buf[minIdx:])
+		sql := cstr(scan[minIdx:])
 		op, table := sqlprune.SQLParseOperationAndTable(sql)
 		return op, table, sql
 	}

--- a/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/tcp_detect_transform.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/tcp_detect_transform.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
@@ -405,6 +406,17 @@ func matchAMQP(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer,
 }
 
 func matchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	isLikelyMQTT := func(pkt *largebuf.LargeBuffer) bool {
+		first, err := pkt.U8At(0)
+
+		return err == nil && mqttparser.IsLikelyMQTT(first, pkt.Len())
+	}
+	// Cheap prefilter: if neither buffer has a plausible MQTT fixed-header
+	// byte 0, skip the variable-length parsing entirely.
+	if !isLikelyMQTT(requestBuffer) && !isLikelyMQTT(responseBuffer) {
+		return request.Span{}, false, false, nil
+	}
+
 	if !isMQTT(requestBuffer) && !isMQTT(responseBuffer) {
 		return request.Span{}, false, false, nil
 	}

--- a/vendor/go.opentelemetry.io/obi/pkg/export/attributes/attr_defs.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/export/attributes/attr_defs.go
@@ -388,6 +388,7 @@ func getDefinitions(
 				attr.GenAIOutput:       false,
 				attr.GenAIInstructions: false,
 				attr.GenAIMetadata:     false,
+				attr.GenAITools:        false,
 				attr.DBResponseError:   false,
 			},
 		},

--- a/vendor/go.opentelemetry.io/obi/pkg/export/otel/tracesgen/tracesgen.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/export/otel/tracesgen/tracesgen.go
@@ -34,6 +34,17 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 )
 
+// Attribute keys not yet available in semconv v1.38.0.
+// Replace with semconv helpers when the package is updated.
+var (
+	genAIRequestStreamKey              = attribute.Key("gen_ai.request.stream")
+	genAIUsageCacheCreationInputTokens = attribute.Key("gen_ai.usage.cache_creation.input_tokens")
+	genAIUsageCacheReadInputTokens     = attribute.Key("gen_ai.usage.cache_read.input_tokens")
+	genAIUsageReasoningOutputTokens    = attribute.Key("gen_ai.usage.reasoning.output_tokens")
+	openAIAPITypeKey                   = attribute.Key("openai.api.type")
+	awsBedrockGuardrailIDKey           = attribute.Key("aws.bedrock.guardrail.id")
+)
+
 type TraceSpanAndAttributes struct {
 	Span       *request.Span
 	Attributes []attribute.KeyValue
@@ -598,15 +609,66 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			}
 			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.Usage.GetInputTokens()))
 			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.Usage.GetOutputTokens()))
+			if reasons := ai.GetFinishReasons(); len(reasons) > 0 {
+				attrs = append(attrs, semconv.GenAIResponseFinishReasons(reasons...))
+			}
+			if ai.Request.MaxTokens > 0 {
+				attrs = append(attrs, semconv.GenAIRequestMaxTokens(ai.Request.MaxTokens))
+			}
+			if ai.Request.PresencePenalty != 0 {
+				attrs = append(attrs, semconv.GenAIRequestPresencePenalty(ai.Request.PresencePenalty))
+			}
+			if ai.Request.N > 1 {
+				attrs = append(attrs, semconv.GenAIRequestChoiceCount(ai.Request.N))
+			}
+			if ai.Request.Stream {
+				attrs = append(attrs, genAIRequestStreamKey.Bool(true))
+			}
+			if ai.Request.Seed != nil {
+				attrs = append(attrs, semconv.GenAIRequestSeed(*ai.Request.Seed))
+			}
+			if stopSeqs := ai.Request.GetStopSequences(); len(stopSeqs) > 0 {
+				attrs = append(attrs, semconv.GenAIRequestStopSequences(stopSeqs...))
+			}
+			if ai.Usage.CompletionDetails != nil && ai.Usage.CompletionDetails.ReasoningTokens > 0 {
+				attrs = append(attrs, genAIUsageReasoningOutputTokens.Int(ai.Usage.CompletionDetails.ReasoningTokens))
+			}
+			if ai.Usage.PromptTokensDetails != nil {
+				if ai.Usage.PromptTokensDetails.CachedTokens > 0 {
+					attrs = append(attrs, genAIUsageCacheReadInputTokens.Int(ai.Usage.PromptTokensDetails.CachedTokens))
+				}
+				if ai.Usage.PromptTokensDetails.CacheCreationTokens > 0 {
+					attrs = append(attrs, genAIUsageCacheCreationInputTokens.Int(ai.Usage.PromptTokensDetails.CacheCreationTokens))
+				}
+			}
+			if ai.Request.ServiceTier != "" && ai.Request.ServiceTier != "auto" {
+				attrs = append(attrs, semconv.OpenAIRequestServiceTierKey.String(ai.Request.ServiceTier))
+			}
+			if ai.ServiceTier != "" {
+				attrs = append(attrs, semconv.OpenAIResponseServiceTier(ai.ServiceTier))
+			}
+			if ai.SystemFingerprint != "" {
+				attrs = append(attrs, semconv.OpenAIResponseSystemFingerprint(ai.SystemFingerprint))
+			}
+			if ai.APIType != "" {
+				attrs = append(attrs, openAIAPITypeKey.String(ai.APIType))
+			}
 			if _, ok := optionalAttrs[attr.GenAIInput]; ok {
 				attrs = append(attrs, semconv.GenAIInputMessagesKey.String(ai.Request.GetInput()))
 			}
 			if _, ok := optionalAttrs[attr.GenAIOutput]; ok {
-				attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				if ai.OperationName != request.EmbeddingOperationName {
+					attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIInstructions]; ok {
 				if ai.Request.Instructions != "" {
-					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(ai.Request.Instructions))
+					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(request.NormalizeSystemInstructions(ai.Request.Instructions)))
+				}
+			}
+			if _, ok := optionalAttrs[attr.GenAITools]; ok {
+				if len(ai.Request.Tools) > 0 {
+					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(request.NormalizeToolDefinitions(ai.Request.Tools)))
 				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
@@ -614,14 +676,17 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 					attrs = append(attrs, request.Metadata(string(ai.Metadata)))
 				}
 			}
-			// add error info
 			if ai.Error.Type != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Error.Message))
 			}
-			// embedding-specific extension attributes
-			if ai.OperationName == request.EmbeddingOperationName && ai.Request.Dimensions > 0 {
-				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Request.Dimensions))
+			if ai.OperationName == request.EmbeddingOperationName {
+				if ai.Request.Dimensions > 0 {
+					attrs = append(attrs, semconv.GenAIEmbeddingsDimensionCount(ai.Request.Dimensions))
+				}
+				if ai.Request.EncodingFormat != "" {
+					attrs = append(attrs, semconv.GenAIRequestEncodingFormats(ai.Request.EncodingFormat))
+				}
 			}
 			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
@@ -637,22 +702,57 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			}
 			attrs = append(attrs, semconv.GenAIRequestModel(ai.Input.Model))
 			attrs = append(attrs, semconv.GenAIResponseModel(ai.Output.Model))
-			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.Output.Usage.InputTokens))
+			// Per Anthropic semconv, input_tokens excludes cached tokens.
+			// Span.GenAIInputTokens() returns the cache-inclusive total so
+			// traces and metrics stay in lockstep.
+			attrs = append(attrs, semconv.GenAIUsageInputTokens(span.GenAIInputTokens()))
 			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.Output.Usage.OutputTokens))
+			if ai.Input.MaxTokens > 0 {
+				attrs = append(attrs, semconv.GenAIRequestMaxTokens(ai.Input.MaxTokens))
+			}
+			if ai.Input.Temperature != nil {
+				attrs = append(attrs, semconv.GenAIRequestTemperature(*ai.Input.Temperature))
+			}
+			if ai.Input.TopP != nil {
+				attrs = append(attrs, semconv.GenAIRequestTopP(*ai.Input.TopP))
+			}
+			if ai.Input.TopK > 0 {
+				attrs = append(attrs, semconv.GenAIRequestTopK(float64(ai.Input.TopK)))
+			}
+			if len(ai.Input.StopSequences) > 0 {
+				attrs = append(attrs, semconv.GenAIRequestStopSequences(ai.Input.StopSequences...))
+			}
+			if ai.Output.StopReason != "" {
+				attrs = append(attrs, semconv.GenAIResponseFinishReasons(ai.Output.StopReason))
+			}
+			attrs = append(attrs, genAIRequestStreamKey.Bool(ai.Input.Stream))
+			if ai.Output.Usage.CacheCreationInputTokens > 0 {
+				attrs = append(attrs, genAIUsageCacheCreationInputTokens.Int(ai.Output.Usage.CacheCreationInputTokens))
+			}
+			if ai.Output.Usage.CacheReadInputTokens > 0 {
+				attrs = append(attrs, genAIUsageCacheReadInputTokens.Int(ai.Output.Usage.CacheReadInputTokens))
+			}
+			if ai.Output.Usage.ReasoningOutputTokens > 0 {
+				attrs = append(attrs, genAIUsageReasoningOutputTokens.Int(ai.Output.Usage.ReasoningOutputTokens))
+			}
 			if _, ok := optionalAttrs[attr.GenAIInput]; ok {
-				attrs = append(attrs, semconv.GenAIInputMessagesKey.String(string(ai.Input.Messages)))
+				if len(ai.Input.Messages) > 0 {
+					attrs = append(attrs, semconv.GenAIInputMessagesKey.String(request.NormalizeAnthropicInput(ai.Input.Messages)))
+				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIOutput]; ok {
-				attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(string(ai.Output.Content)))
+				if len(ai.Output.Content) > 0 {
+					attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(request.NormalizeAnthropicOutput(&ai.Output)))
+				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIInstructions]; ok {
 				if ai.Input.System != "" {
-					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(ai.Input.System))
+					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(request.NormalizeSystemInstructions(ai.Input.System)))
 				}
 			}
-			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
+			if _, ok := optionalAttrs[attr.GenAITools]; ok {
 				if len(ai.Input.Tools) > 0 {
-					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(string(ai.Input.Tools)))
+					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(request.NormalizeToolDefinitions(ai.Input.Tools)))
 				}
 			}
 			// add error info
@@ -704,7 +804,16 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				if cfg.CandidateCount > 0 {
 					attrs = append(attrs, semconv.GenAIRequestChoiceCount(cfg.CandidateCount))
 				}
+				if cfg.ResponseMimeType != "" {
+					switch cfg.ResponseMimeType {
+					case "application/json":
+						attrs = append(attrs, semconv.GenAIOutputTypeJSON)
+					case "text/plain":
+						attrs = append(attrs, semconv.GenAIOutputTypeText)
+					}
+				}
 			}
+			attrs = append(attrs, genAIRequestStreamKey.Bool(ai.IsStream))
 			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.Output.UsageMetadata.PromptTokenCount))
 			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.Output.UsageMetadata.CandidatesTokenCount))
 			if reasons := ai.GetFinishReasons(); len(reasons) > 0 {
@@ -721,9 +830,9 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(inst))
 				}
 			}
-			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
+			if _, ok := optionalAttrs[attr.GenAITools]; ok {
 				if len(ai.Input.Tools) > 0 {
-					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(string(ai.Input.Tools)))
+					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(request.NormalizeToolDefinitions(ai.Input.Tools)))
 				}
 			}
 			if ai.Output.Error != nil && ai.Output.Error.Status != "" {
@@ -757,15 +866,46 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			}
 			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.Usage.GetInputTokens()))
 			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.Usage.GetOutputTokens()))
+			if reasons := ai.GetFinishReasons(); len(reasons) > 0 {
+				attrs = append(attrs, semconv.GenAIResponseFinishReasons(reasons...))
+			}
+			if ai.Request.MaxTokens > 0 {
+				attrs = append(attrs, semconv.GenAIRequestMaxTokens(ai.Request.MaxTokens))
+			}
+			if ai.Request.PresencePenalty != 0 {
+				attrs = append(attrs, semconv.GenAIRequestPresencePenalty(ai.Request.PresencePenalty))
+			}
+			if ai.Request.N > 1 {
+				attrs = append(attrs, semconv.GenAIRequestChoiceCount(ai.Request.N))
+			}
+			if ai.Request.Stream {
+				attrs = append(attrs, genAIRequestStreamKey.Bool(true))
+			}
+			if ai.Request.Seed != nil {
+				attrs = append(attrs, semconv.GenAIRequestSeed(*ai.Request.Seed))
+			}
+			if stopSeqs := ai.Request.GetStopSequences(); len(stopSeqs) > 0 {
+				attrs = append(attrs, semconv.GenAIRequestStopSequences(stopSeqs...))
+			}
+			if ai.Usage.CompletionDetails != nil && ai.Usage.CompletionDetails.ReasoningTokens > 0 {
+				attrs = append(attrs, genAIUsageReasoningOutputTokens.Int(ai.Usage.CompletionDetails.ReasoningTokens))
+			}
 			if _, ok := optionalAttrs[attr.GenAIInput]; ok {
 				attrs = append(attrs, semconv.GenAIInputMessagesKey.String(ai.Request.GetInput()))
 			}
 			if _, ok := optionalAttrs[attr.GenAIOutput]; ok {
-				attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				if ai.OperationName != request.EmbeddingOperationName {
+					attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIInstructions]; ok {
 				if ai.Request.Instructions != "" {
-					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(ai.Request.Instructions))
+					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(request.NormalizeSystemInstructions(ai.Request.Instructions)))
+				}
+			}
+			if _, ok := optionalAttrs[attr.GenAITools]; ok {
+				if len(ai.Request.Tools) > 0 {
+					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(request.NormalizeToolDefinitions(ai.Request.Tools)))
 				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
@@ -798,25 +938,36 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if ai.Input.TopK > 0 {
 				attrs = append(attrs, semconv.GenAIRequestTopK(float64(ai.Input.TopK)))
 			}
+			if len(ai.Input.StopSequences) > 0 {
+				attrs = append(attrs, semconv.GenAIRequestStopSequences(ai.Input.StopSequences...))
+			}
+			attrs = append(attrs, genAIRequestStreamKey.Bool(ai.IsStream))
 			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.Output.InputTokens))
 			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.Output.OutputTokens))
 			if stopReason := ai.GetStopReason(); stopReason != "" {
 				attrs = append(attrs, semconv.GenAIResponseFinishReasons(stopReason))
 			}
+			if ai.GuardrailID != "" {
+				attrs = append(attrs, awsBedrockGuardrailIDKey.String(ai.GuardrailID))
+			}
 			if _, ok := optionalAttrs[attr.GenAIInput]; ok {
 				attrs = append(attrs, semconv.GenAIInputMessagesKey.String(ai.GetInput()))
 			}
 			if _, ok := optionalAttrs[attr.GenAIOutput]; ok {
-				attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				if len(ai.Output.Content) > 0 {
+					attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(request.NormalizeBedrockOutput(&ai.Output)))
+				} else {
+					attrs = append(attrs, semconv.GenAIOutputMessagesKey.String(ai.GetOutput()))
+				}
 			}
 			if _, ok := optionalAttrs[attr.GenAIInstructions]; ok {
 				if sys := ai.GetSystemInstruction(); sys != "" {
 					attrs = append(attrs, semconv.GenAISystemInstructionsKey.String(sys))
 				}
 			}
-			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
+			if _, ok := optionalAttrs[attr.GenAITools]; ok {
 				if len(ai.Input.Tools) > 0 {
-					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(string(ai.Input.Tools)))
+					attrs = append(attrs, semconv.GenAIToolDefinitionsKey.String(request.NormalizeToolDefinitions(ai.Input.Tools)))
 				}
 			}
 			if ai.Output.ErrorType != "" {

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser/frame.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser/frame.go
@@ -5,7 +5,6 @@ package amqpparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/amqppars
 
 import (
 	"errors"
-	"fmt"
 
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
@@ -48,9 +47,19 @@ const (
 	descriptorSASLOutcome    descriptor = 0x44
 )
 
-// errIncompleteFrame signals the buffer ends before the full frame body; callers may
-// try to recover the performative from the available prefix.
-var errIncompleteFrame = errors.New("incomplete AMQP frame")
+var (
+	errIncompleteFrame   = errors.New("incomplete AMQP frame")
+	errTooShort          = errors.New("packet too short")
+	errInvalidFrameSize  = errors.New("invalid frame size")
+	errInvalidDataOffset = errors.New("invalid AMQP frame data offset")
+	errInvalidBodyOffset = errors.New("invalid AMQP frame body offset")
+	errInvalidType       = errors.New("invalid AMQP frame type")
+	errBodyTooShort      = errors.New("AMQP frame body too short")
+	errNotDescribed      = errors.New("AMQP performative is not described")
+	errTruncated         = errors.New("AMQP ulong descriptor truncated")
+	errBadEncoding       = errors.New("unsupported AMQP descriptor encoding")
+	errUnknownDescriptor = errors.New("unknown AMQP performative descriptor")
+)
 
 type frameType uint8
 
@@ -70,7 +79,7 @@ func (h frameHeader) bodyOffset() int {
 func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 	remaining := r.Remaining()
 	if remaining < frameHeaderSize {
-		return frameHeader{}, fmt.Errorf("packet too short for AMQP frame header: have %d bytes, need %d", remaining, frameHeaderSize)
+		return frameHeader{}, errTooShort
 	}
 
 	size, err := r.ReadU32BE()
@@ -78,7 +87,7 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 		return frameHeader{}, err
 	}
 	if size < frameHeaderSize {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame size %d (must be >= %d)", size, frameHeaderSize)
+		return frameHeader{}, errInvalidFrameSize
 	}
 
 	doff, err := r.ReadU8()
@@ -86,7 +95,7 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 		return frameHeader{}, err
 	}
 	if doff < minDataOffsetWords {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame data offset %d (must be >= %d)", doff, minDataOffsetWords)
+		return frameHeader{}, errInvalidDataOffset
 	}
 
 	ft, err := r.ReadU8()
@@ -104,13 +113,13 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 	}
 
 	if h.bodyOffset() > int(h.Size) {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame body offset %d (exceeds frame size %d)", h.bodyOffset(), h.Size)
+		return frameHeader{}, errInvalidBodyOffset
 	}
 
 	switch h.Type {
 	case frameTypeAMQP, frameTypeSASL:
 	default:
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame type 0x%02X", byte(h.Type))
+		return frameHeader{}, errInvalidType
 	}
 
 	if int(size) > remaining {
@@ -147,7 +156,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		return 0, false, nil
 	}
 	if bodyLen < smallULongDescriptorSize {
-		return 0, false, fmt.Errorf("AMQP frame body too short for performative: %d bytes", bodyLen)
+		return 0, false, errBodyTooShort
 	}
 
 	constructor, err := r.ReadU8()
@@ -155,7 +164,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		return 0, false, err
 	}
 	if constructor != describedTypeConstructor {
-		return 0, false, fmt.Errorf("AMQP performative is not described (first byte 0x%02X)", constructor)
+		return 0, false, errNotDescribed
 	}
 
 	formatCode, err := r.ReadU8()
@@ -173,7 +182,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		desc = descriptor(value)
 	case formatCodeULong:
 		if bodyLen < uLongDescriptorSize {
-			return 0, false, fmt.Errorf("AMQP ulong descriptor truncated: %d bytes, need %d", bodyLen, uLongDescriptorSize)
+			return 0, false, errTruncated
 		}
 		value, err := r.ReadU64BE()
 		if err != nil {
@@ -181,11 +190,11 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		}
 		desc = descriptor(value)
 	default:
-		return 0, false, fmt.Errorf("unsupported AMQP descriptor encoding 0x%02X", formatCode)
+		return 0, false, errBadEncoding
 	}
 
 	if !isKnownPerformativeDescriptor(ft, desc) {
-		return 0, false, fmt.Errorf("unknown AMQP performative descriptor 0x%X on frame type 0x%02X", uint64(desc), byte(ft))
+		return 0, false, errUnknownDescriptor
 	}
 
 	return desc, true, nil

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser/protocol.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser/protocol.go
@@ -5,6 +5,7 @@ package amqpparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/amqppars
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -42,6 +43,68 @@ type protocolHeader struct {
 func startsWithMagic(r *largebuf.LargeBufferReader) bool {
 	data, err := r.Peek(len(amqpMagic))
 	return err == nil && bytes.Equal(data, amqpMagic)
+}
+
+// IsLikelyAMQP is an O(1) prefilter that reports whether the buffer behind r
+// could plausibly start an AMQP 1.0 conversation. It accepts either the
+// connection preamble ("AMQP" magic) or a structurally valid frame header.
+// The full Parse should still be invoked to confirm - this only filters out
+// obviously non-AMQP payloads cheaply. The reader's cursor is not advanced,
+// so the caller can pass the same reader straight to Parse on success.
+// https://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-transport-v1.0-csprd01.html
+func IsLikelyAMQP(r *largebuf.LargeBufferReader) bool {
+	if r == nil {
+		return false
+	}
+	remaining := r.Remaining()
+
+	if remaining >= len(amqpMagic) {
+		head, err := r.Peek(len(amqpMagic))
+		if err == nil && bytes.Equal(head, amqpMagic) {
+			return true
+		}
+	}
+
+	if remaining < frameHeaderSize {
+		return false
+	}
+
+	hdr, err := r.Peek(frameHeaderSize)
+	if err != nil {
+		return false
+	}
+
+	// Frame header: size(u32 BE) | doff(u8) | type(u8) | channel(u16).
+	// type 0x00 (AMQP) or 0x01 (SASL) alone filters out ~99% of random bytes.
+	size := binary.BigEndian.Uint32(hdr[0:4])
+	if size < frameHeaderSize {
+		return false
+	}
+	if hdr[4] < minDataOffsetWords {
+		return false
+	}
+	ft := hdr[5]
+	if ft != byte(frameTypeAMQP) && ft != byte(frameTypeSASL) {
+		return false
+	}
+
+	// If this frame carries a performative (size > bodyOffset) and that byte
+	// is in the captured buffer, it must begin with the described-type
+	// constructor (0x00). Heartbeat / idle frames have size == bodyOffset and
+	// no body at all (AMQP 1.0 2.4.5), so the byte at bodyOffset belongs to
+	// the next frame and must not be validated.
+	bodyOffset := int(hdr[4]) * dataOffsetUnit
+	if int(size) > bodyOffset && bodyOffset < remaining {
+		body, err := r.Peek(bodyOffset + 1)
+		if err != nil {
+			return false
+		}
+		if body[bodyOffset] != describedTypeConstructor {
+			return false
+		}
+	}
+
+	return true
 }
 
 // parseProtocolHeader validates and parses an AMQP 1.0 protocol header.

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/couchbasekv/header.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/couchbasekv/header.go
@@ -5,8 +5,16 @@ package couchbasekv // import "go.opentelemetry.io/obi/pkg/internal/ebpf/couchba
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"iter"
+)
+
+var (
+	errPacketTooShort   = errors.New("packet too short")
+	errInvalidMagic     = errors.New("invalid magic byte")
+	errInvalidKeyLength = errors.New("invalid key length")
+	errInvalidDataType  = errors.New("invalid data type")
+	errInvalidBodyType  = errors.New("invalid body length")
 )
 
 // Header is a view into a 24-byte memcached binary protocol header.
@@ -84,12 +92,12 @@ func (h Header) IsResponse() bool { return h.Magic().IsResponse() }
 // underlying memory of pkt.
 func ParseHeader(pkt []byte) (Header, error) {
 	if len(pkt) < HeaderLen {
-		return nil, fmt.Errorf("packet too short for header: got %d bytes, need %d", len(pkt), HeaderLen)
+		return nil, errPacketTooShort
 	}
 
 	magic := Magic(pkt[0])
 	if !magic.IsValid() {
-		return nil, fmt.Errorf("invalid magic byte: 0x%02x", pkt[0])
+		return nil, errInvalidMagic
 	}
 
 	h := Header(pkt[:HeaderLen])
@@ -240,17 +248,16 @@ func (p Packet) valueEnd() int {
 // validateHeader checks for basic validity of the parsed header.
 func validateHeader(h Header) error {
 	if int(h.KeyLen()) > MaxKeyLen {
-		return fmt.Errorf("invalid key length: %d > max(%d)", h.KeyLen(), MaxKeyLen)
+		return errInvalidKeyLength
 	}
 
 	if !h.DataType().IsValid() {
-		return fmt.Errorf("invalid data type: 0x%02x has reserved bits set", byte(h.DataType()))
+		return errInvalidDataType
 	}
 
 	minBodyLen := int(h.FramingExtrasLen()) + int(h.ExtrasLen()) + int(h.KeyLen())
 	if int(h.BodyLen()) < minBodyLen {
-		return fmt.Errorf("invalid body length: %d < framingExtras(%d) + extras(%d) + key(%d)",
-			h.BodyLen(), h.FramingExtrasLen(), h.ExtrasLen(), h.KeyLen())
+		return errInvalidBodyType
 	}
 
 	return nil

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/common.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/common.go
@@ -30,6 +30,35 @@ const (
 	KafkaMaxPayloadLen = 20 * 1024 * 1024 // 20 MB max, 1MB is default for most Kafka installations
 )
 
+var (
+	errKafkaPacketTooShortForRequestHeader  = errors.New("packet too short for Kafka request header")
+	errKafkaInvalidClientIDSize             = errors.New("invalid client ID size")
+	errKafkaPacketTooShortForClientID       = errors.New("packet too short for client ID")
+	errKafkaPacketTooShortForResponseHeader = errors.New("packet too short for Kafka response header")
+	errKafkaTaggedFieldValueExceedsBuffer   = errors.New("tagged field value exceeds buffer")
+	errKafkaVarintIncomplete                = errors.New("data ended before varint was complete")
+	errKafkaIllegalVarint                   = errors.New("illegal varint")
+	errKafkaReqMessageSizeTooSmall          = errors.New("invalid Kafka request header: message size too small")
+	errKafkaReqAPIVersionNegative           = errors.New("invalid Kafka request header: API version is negative")
+	errKafkaReqMessageSizeTooLarge          = errors.New("invalid Kafka request header: message size exceeds maximum payload length")
+	errKafkaReqUnsupportedFetchVersion      = errors.New("invalid Kafka request header: unsupported API key version for Fetch")
+	errKafkaReqUnsupportedProduceVersion    = errors.New("invalid Kafka request header: unsupported API key version for Produce")
+	errKafkaReqUnsupportedMetadataVersion   = errors.New("invalid Kafka request header: unsupported API key version for Metadata")
+	errKafkaReqUnsupportedAPIKey            = errors.New("invalid Kafka request header: unsupported API key")
+	errKafkaReqCorrelationIDNegative        = errors.New("invalid Kafka request header: correlation ID is negative")
+	errKafkaRespSizeTooSmall                = errors.New("invalid Kafka response header: size too small")
+	errKafkaRespMessageSizeTooLarge         = errors.New("invalid Kafka response header: message size exceeds maximum payload length")
+	errKafkaRespCorrelationIDNegative       = errors.New("invalid Kafka response header: correlation ID is negative")
+	errKafkaRespCorrelationIDMismatch       = errors.New("invalid Kafka response header: correlation ID does not match request header")
+	errKafkaPacketTooShortForTopicUUID      = errors.New("packet too short for topic UUID")
+	errKafkaStringSizeExceedsPacket         = errors.New("string size exceeds packet size")
+	errKafkaInvalidCharactersInString       = errors.New("invalid characters in string")
+	errKafkaPacketTooShortForStringLength   = errors.New("packet too short for string length")
+	errKafkaInvalidStringSize               = errors.New("invalid string size")
+	errKafkaDataTooShortForInt32            = errors.New("data too short for int32")
+	errKafkaDataTooShortForInt64            = errors.New("data too short for int64")
+)
+
 type KafkaAPIKey int8
 
 const (
@@ -93,7 +122,7 @@ func (h KafkaRequestHeader) NewBodyReader() (largebuf.LargeBufferReader, error) 
 
 func NewKafkaRequestHeader(lb *largebuf.LargeBuffer) (KafkaRequestHeader, error) {
 	if lb.Len() < MinKafkaRequestLen {
-		return KafkaRequestHeader{}, errors.New("packet too short for Kafka request header")
+		return KafkaRequestHeader{}, errKafkaPacketTooShortForRequestHeader
 	}
 
 	h := KafkaRequestHeader{lb: lb}
@@ -109,12 +138,12 @@ func NewKafkaRequestHeader(lb *largebuf.LargeBuffer) (KafkaRequestHeader, error)
 	}
 
 	if clientIDLen < 0 {
-		return KafkaRequestHeader{}, errors.New("invalid client ID size")
+		return KafkaRequestHeader{}, errKafkaInvalidClientIDSize
 	}
 
 	clientIDEnd := 14 + int(clientIDLen)
 	if lb.Len() < clientIDEnd {
-		return KafkaRequestHeader{}, errors.New("packet too short for client ID")
+		return KafkaRequestHeader{}, errKafkaPacketTooShortForClientID
 	}
 
 	h.clientIDLen = clientIDLen
@@ -137,7 +166,7 @@ type KafkaResponseHeader struct {
 
 func ParseKafkaResponseHeader(r *largebuf.LargeBufferReader, requestHeader KafkaRequestHeader) (*KafkaResponseHeader, error) {
 	if r.Remaining() < MinKafkaResponseLen {
-		return nil, errors.New("packet too short for Kafka response header")
+		return nil, errKafkaPacketTooShortForResponseHeader
 	}
 	msgSizeBytes, err := r.ReadN(Int32Len)
 	if err != nil {
@@ -203,7 +232,7 @@ func skipTaggedFieldsAt(lb *largebuf.LargeBuffer, off int) (int, error) {
 			return 0, err
 		}
 		if tagLen < 0 || tagLen > lb.Len()-off-n {
-			return 0, errors.New("tagged field value exceeds buffer")
+			return 0, errKafkaTaggedFieldValueExceedsBuffer
 		}
 		off += n + tagLen
 	}
@@ -217,7 +246,7 @@ func readUVarintAt(lb *largebuf.LargeBuffer, off int) (int, int, error) {
 	for {
 		b, err := lb.U8At(off + n)
 		if err != nil {
-			return 0, 0, errors.New("data ended before varint was complete")
+			return 0, 0, errKafkaVarintIncomplete
 		}
 		n++
 		if b&0x80 == 0 {
@@ -227,60 +256,60 @@ func readUVarintAt(lb *largebuf.LargeBuffer, off int) (int, int, error) {
 		value |= int(b&0x7F) << shift
 		shift += 7
 		if shift > 28 {
-			return 0, 0, errors.New("illegal varint")
+			return 0, 0, errKafkaIllegalVarint
 		}
 	}
 }
 
 func (h KafkaRequestHeader) validate() error {
 	if h.MessageSize() < int32(MinKafkaRequestLen) {
-		return errors.New("invalid Kafka request header: message size too small")
+		return errKafkaReqMessageSizeTooSmall
 	}
 
 	if h.APIVersion() < 0 {
-		return errors.New("invalid Kafka request header: API version is negative")
+		return errKafkaReqAPIVersionNegative
 	}
 
 	if h.MessageSize() > KafkaMaxPayloadLen {
-		return errors.New("invalid Kafka request header: message size exceeds maximum payload length")
+		return errKafkaReqMessageSizeTooLarge
 	}
 
 	switch h.APIKey() {
 	case APIKeyFetch:
 		if h.APIVersion() > 18 { // latest: Fetch Request (Version: 17)
-			return errors.New("invalid Kafka request header: unsupported API key version for Fetch")
+			return errKafkaReqUnsupportedFetchVersion
 		}
 	case APIKeyProduce:
 		if h.APIVersion() > 13 { // latest: Produce Request (Version: 13)
-			return errors.New("invalid Kafka request header: unsupported API key version for Produce")
+			return errKafkaReqUnsupportedProduceVersion
 		}
 	case APIKeyMetadata:
 		if h.APIVersion() < 10 || h.APIVersion() > 13 { // latest: Metadata Request (Version: 13), only versions 10-13 contain topic_id which we are interested in
-			return errors.New("invalid Kafka request header: unsupported API key version for Metadata")
+			return errKafkaReqUnsupportedMetadataVersion
 		}
 	default:
-		return errors.New("invalid Kafka request header: unsupported API key")
+		return errKafkaReqUnsupportedAPIKey
 	}
 	if h.CorrelationID() < 0 {
-		return errors.New("invalid Kafka request header: correlation ID is negative")
+		return errKafkaReqCorrelationIDNegative
 	}
 	return nil
 }
 
 func validateKafkaResponseHeader(header *KafkaResponseHeader, requestHeader KafkaRequestHeader) error {
 	if header.MessageSize < MinKafkaResponseLen {
-		return errors.New("invalid Kafka response header: size too small")
+		return errKafkaRespSizeTooSmall
 	}
 
 	if header.MessageSize > KafkaMaxPayloadLen {
-		return errors.New("invalid Kafka response header: message size exceeds maximum payload length")
+		return errKafkaRespMessageSizeTooLarge
 	}
 
 	if header.CorrelationID < 0 {
-		return errors.New("invalid Kafka response header: correlation ID is negative")
+		return errKafkaRespCorrelationIDNegative
 	}
 	if header.CorrelationID != requestHeader.CorrelationID() {
-		return errors.New("invalid Kafka response header: correlation ID does not match request header")
+		return errKafkaRespCorrelationIDMismatch
 	}
 	return nil
 }
@@ -321,7 +350,7 @@ func readArrayLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (
 func readUUID(r *largebuf.LargeBufferReader) (*UUID, error) {
 	b, err := r.ReadN(UUIDLen)
 	if err != nil {
-		return nil, errors.New("packet too short for topic UUID")
+		return nil, errKafkaPacketTooShortForTopicUUID
 	}
 	var uuid UUID
 	copy(uuid[:], b)
@@ -337,14 +366,14 @@ func readString(r *largebuf.LargeBufferReader, header KafkaRequestHeader, nullab
 		return "", nil // return empty string for null
 	}
 	if r.Remaining() < size {
-		return "", errors.New("string size exceeds packet size")
+		return "", errKafkaStringSizeExceedsPacket
 	}
 	b, err := r.ReadN(size)
 	if err != nil {
-		return "", errors.New("string size exceeds packet size")
+		return "", errKafkaStringSizeExceedsPacket
 	}
 	if !validateKafkaString(b, size) {
-		return "", errors.New("invalid characters in string")
+		return "", errKafkaInvalidCharactersInString
 	}
 	return string(b), nil
 }
@@ -364,18 +393,18 @@ func readStringLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader, 
 	if !isFlexible(header) {
 		// length is stored as a fixed size int16
 		if r.Remaining() < Int16Len {
-			return 0, errors.New("packet too short for string length")
+			return 0, errKafkaPacketTooShortForStringLength
 		}
 		b, err := r.ReadN(Int16Len)
 		if err != nil {
-			return 0, errors.New("packet too short for string length")
+			return 0, errKafkaPacketTooShortForStringLength
 		}
 		size := int16(binary.BigEndian.Uint16(b))
 		if nullable && size == -1 {
 			return 0, nil // return 0 for null
 		}
 		if size < 1 {
-			return 0, errors.New("invalid string size")
+			return 0, errKafkaInvalidStringSize
 		}
 		return int(size), nil
 	}
@@ -389,11 +418,11 @@ func readStringLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader, 
 		return 0, nil // return 0 for null
 	}
 	if size <= 0 {
-		return 0, errors.New("invalid string size")
+		return 0, errKafkaInvalidStringSize
 	}
 	size-- // size is stored as a varint, so we subtract 1
 	if size < 0 {
-		return 0, errors.New("invalid string size")
+		return 0, errKafkaInvalidStringSize
 	}
 	return size, nil
 }
@@ -403,7 +432,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 	i := 0
 	for {
 		if r.Remaining() == 0 {
-			return 0, errors.New("data ended before varint was complete")
+			return 0, errKafkaVarintIncomplete
 		}
 		b, err := r.ReadN(1)
 		if err != nil {
@@ -416,7 +445,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 		value |= int(b[0]&0x7F) << i
 		i += 7
 		if i > 28 {
-			return 0, errors.New("illegal varint")
+			return 0, errKafkaIllegalVarint
 		}
 	}
 }
@@ -424,7 +453,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 func readInt32(r *largebuf.LargeBufferReader) (int, error) {
 	b, err := r.ReadN(Int32Len)
 	if err != nil {
-		return 0, errors.New("data too short for int32")
+		return 0, errKafkaDataTooShortForInt32
 	}
 	return int(binary.BigEndian.Uint32(b)), nil
 }
@@ -432,7 +461,7 @@ func readInt32(r *largebuf.LargeBufferReader) (int, error) {
 func readInt64(r *largebuf.LargeBufferReader) (int64, error) {
 	b, err := r.ReadN(Int64Len)
 	if err != nil {
-		return 0, errors.New("data too short for int64")
+		return 0, errKafkaDataTooShortForInt64
 	}
 	return int64(binary.BigEndian.Uint64(b)), nil
 }

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/fetch.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/fetch.go
@@ -23,19 +23,24 @@ type FetchRequest struct {
 	Topics []*FetchTopic
 }
 
+var (
+	errOffsetExceedsPacketSize = errors.New("offset exceeds packet size")
+	errNoTopics                = errors.New("no Topics found in fetch request")
+)
+
 func ParseFetchRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*FetchRequest, error) {
 	if err := fetchRequestSkipUntilTopics(r, header); err != nil {
 		return nil, err
 	}
 	if r.Remaining() == 0 {
-		return nil, errors.New("offset exceeds packet size")
+		return nil, errOffsetExceedsPacketSize
 	}
 	topics, err := parseFetchTopics(r, header)
 	if err != nil {
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in fetch request")
+		return nil, errNoTopics
 	}
 	return &FetchRequest{
 		Topics: topics,

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/metadata.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/metadata.go
@@ -27,6 +27,8 @@ type MetadataResponse struct {
 	Topics []*MetadataTopic
 }
 
+var errNoTopicsInMetadata = errors.New("no Topics found in metadata response")
+
 func ParseMetadataResponse(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*MetadataResponse, error) {
 	if err := metadataResponseSkipUntilTopics(r, header); err != nil {
 		return nil, err
@@ -36,7 +38,7 @@ func ParseMetadataResponse(r *largebuf.LargeBufferReader, header KafkaRequestHea
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in metadata response")
+		return nil, errNoTopicsInMetadata
 	}
 	return &MetadataResponse{
 		Topics: topics,

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/produce.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser/produce.go
@@ -19,6 +19,8 @@ type ProduceRequest struct {
 	Topics []*ProduceTopic
 }
 
+var errNoTopicsInProduce = errors.New("no Topics found in produce request")
+
 func ParseProduceRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*ProduceRequest, error) {
 	if err := produceRequestSkipUntilTopics(r, header); err != nil {
 		return nil, err
@@ -28,7 +30,7 @@ func ParseProduceRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeade
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in produce request")
+		return nil, errNoTopicsInProduce
 	}
 	return &ProduceRequest{
 		Topics: topics,

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/header.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/header.go
@@ -11,6 +11,12 @@ const (
 	MinPacketLen = 2 // fixed header (1 byte) + remaining length (1 byte)
 )
 
+var (
+	errIncompletePacket  = errors.New("incomplete packet")
+	errPacketTooShort    = errors.New("packet too short for MQTT fixed header")
+	errInvalidPacketType = errors.New("invalid MQTT packet type")
+)
+
 type (
 	// PacketType is the type of MQTT Control Packet.
 	PacketType uint8
@@ -64,10 +70,46 @@ type FixedHeader struct {
 	Length int
 }
 
+// IsLikelyMQTT is an O(1) prefilter that validates the MQTT fixed-header byte 0
+// against the strict per-type flag constraints from the MQTT 3.1.1 / 5.0 spec.
+// Roughly 90% of random byte values fail this check, allowing callers to avoid
+// the more expensive remaining-length + variable-header parsing when a payload
+// is obviously not MQTT.
+// https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
+// https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html
+func IsLikelyMQTT(first byte, pktLen int) bool {
+	if pktLen < MinPacketLen {
+		return false
+	}
+	pt := PacketType((first >> 4) & 0x0F)
+	flags := first & 0x0F
+	switch pt {
+	case PacketTypePUBLISH:
+		// QoS occupies bits 2-1 of the flag nibble; QoS=3 is invalid.
+		return (flags>>1)&0x03 != 3
+	case PacketTypePUBREL, PacketTypeSUBSCRIBE, PacketTypeUNSUBSCRIBE:
+		return flags == 0x02
+	case PacketTypeCONNECT,
+		PacketTypeCONNACK,
+		PacketTypePUBACK,
+		PacketTypePUBREC,
+		PacketTypePUBCOMP,
+		PacketTypeSUBACK,
+		PacketTypeUNSUBACK,
+		PacketTypePINGREQ,
+		PacketTypePINGRESP,
+		PacketTypeDISCONNECT,
+		PacketTypeAUTH:
+		return flags == 0x00
+	default:
+		return false
+	}
+}
+
 // ParseMQTTPackets parses multiple MQTT packets from a single byte slice, as
 // there may be cases where multiple MQTT packets are present in one TCP segment.
-func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
-	var packets []MQTTControlPacket
+func ParseMQTTPackets(segment []byte) ([]*MQTTControlPacket, error) {
+	var packets []*MQTTControlPacket
 	offset := 0
 
 	for offset < len(segment) {
@@ -81,7 +123,7 @@ func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
 		}
 
 		if offset+packet.Length() > len(segment) {
-			return packets, errors.New("incomplete packet")
+			return packets, errIncompletePacket
 		}
 
 		packets = append(packets, packet)
@@ -92,9 +134,9 @@ func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
 }
 
 // NewMQTTControlPacket parses the MQTT fixed header from a packet.
-func NewMQTTControlPacket(pkt []byte) (MQTTControlPacket, error) {
+func NewMQTTControlPacket(pkt []byte) (*MQTTControlPacket, error) {
 	if len(pkt) < MinPacketLen {
-		return MQTTControlPacket{}, errors.New("packet too short for MQTT fixed header")
+		return nil, errPacketTooShort
 	}
 
 	// Parse first byte: packet type (bits 7-4) and flags (bits 3-0)
@@ -104,17 +146,17 @@ func NewMQTTControlPacket(pkt []byte) (MQTTControlPacket, error) {
 
 	// Validate packet type (0 is reserved, valid range is 1-15)
 	if packetType < PacketTypeCONNECT || packetType > PacketTypeAUTH {
-		return MQTTControlPacket{}, errors.New("invalid MQTT packet type")
+		return nil, errInvalidPacketType
 	}
 
 	// Parse remaining length (variable-length encoding)
 	r := NewPacketReader(pkt, 1)
 	rl, err := r.ReadVariableByteInteger()
 	if err != nil {
-		return MQTTControlPacket{}, err
+		return nil, err
 	}
 
-	return MQTTControlPacket{
+	return &MQTTControlPacket{
 		FixedHeader: FixedHeader{
 			PacketType:      packetType,
 			Flags:           flags,

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_connect.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_connect.go
@@ -32,13 +32,19 @@ type ConnectPacket struct {
 	ClientID string
 }
 
+var (
+	errInsufficientConnectData       = errors.New("insufficient data for CONNECT packet")
+	errUnrecognizedMQTTProtocolName  = errors.New("unrecognized mqtt protocol name")
+	errUnrecognizedMQTTProtocolLevel = errors.New("unrecognized mqtt protocol level")
+)
+
 // ParseConnectPacket parses an MQTT CONNECT packet.
 // offset should point to the start of the variable header (after fixed header).
 func ParseConnectPacket(pkt []byte, offset Offset) (*ConnectPacket, Offset, error) {
 	var connect ConnectPacket
 
 	if offset >= len(pkt) {
-		return &connect, offset, errors.New("insufficient data for CONNECT packet")
+		return &connect, offset, errInsufficientConnectData
 	}
 
 	r := NewConnectPacketReader(pkt, offset)
@@ -183,7 +189,7 @@ func NewProtocolName(name string) (ProtocolName, error) {
 	case string(ProtocolNameMQTT), string(ProtocolNameMQIsdp):
 		return ProtocolName(name), nil
 	default:
-		return "", fmt.Errorf("%q is not a recognized mqtt protocol name", name)
+		return "", errUnrecognizedMQTTProtocolName
 	}
 }
 
@@ -208,7 +214,7 @@ func NewProtocolLevel(level uint8) (ProtocolLevel, error) {
 	case 5:
 		return ProtocolLevelMQTT50, nil
 	}
-	return 0, fmt.Errorf("%d is not a recognized mqtt protocol level", level)
+	return 0, errUnrecognizedMQTTProtocolLevel
 }
 
 func (pl ProtocolLevel) String() string {

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_publish.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_publish.go
@@ -27,6 +27,8 @@ type PublishPacket struct {
 	PacketID uint16
 }
 
+var errInsufficientPublishData = errors.New("insufficient data for PUBLISH packet")
+
 // ParsePublishPacket parses an MQTT PUBLISH packet.
 // offset should point to the start of the variable header (after fixed header).
 // flags should contain the flags byte from the fixed header.
@@ -34,7 +36,7 @@ func ParsePublishPacket(pkt []byte, offset Offset, flags uint8) (*PublishPacket,
 	var publish PublishPacket
 
 	if offset >= len(pkt) {
-		return &publish, offset, errors.New("insufficient data for PUBLISH packet")
+		return &publish, offset, errInsufficientPublishData
 	}
 
 	r := NewPublishPacketReader(pkt, offset)

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_subscribe.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/packet_subscribe.go
@@ -7,6 +7,13 @@ import (
 	"errors"
 )
 
+var (
+	errSubscribeInsufficientData   = errors.New("insufficient data for SUBSCRIBE packet")
+	errSubscribeReadTopicFilter    = errors.New("failed to read topic filter")
+	errSubscribeReadOptions        = errors.New("failed to read subscription options")
+	errSubscribeRequiresAtLeastOne = errors.New("SUBSCRIBE packet must contain at least one subscription")
+)
+
 // Subscription represents a single topic subscription with its QoS level.
 type Subscription struct {
 	// TopicFilter is the topic filter string for the subscription.
@@ -41,7 +48,7 @@ func ParseSubscribePacket(pkt []byte, offset Offset, remainingLength int) (*Subs
 	var subscribe SubscribePacket
 
 	if offset+remainingLength > len(pkt) {
-		return &subscribe, offset, errors.New("insufficient data for SUBSCRIBE packet")
+		return &subscribe, offset, errSubscribeInsufficientData
 	}
 
 	// Create a bounded slice to prevent reading beyond this packet
@@ -136,7 +143,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 			if targetVersion < ProtocolLevelMQTT50 {
 				return nil, ErrProtocolMismatch
 			}
-			return nil, errors.New("failed to read topic filter")
+			return nil, errSubscribeReadTopicFilter
 		}
 
 		options, err := r.ReadUint8()
@@ -147,7 +154,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 			if targetVersion < ProtocolLevelMQTT50 {
 				return nil, ErrProtocolMismatch
 			}
-			return nil, errors.New("failed to read subscription options")
+			return nil, errSubscribeReadOptions
 		}
 
 		// In MQTT 3.1.1, options byte contains only QoS (0, 1, or 2).
@@ -166,7 +173,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 		if targetVersion < ProtocolLevelMQTT50 {
 			return nil, ErrProtocolMismatch
 		}
-		return nil, errors.New("SUBSCRIBE packet must contain at least one subscription")
+		return nil, errSubscribeRequiresAtLeastOne
 	}
 
 	return subscriptions, nil

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/reader.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser/reader.go
@@ -5,7 +5,13 @@ package mqttparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/mqttpars
 
 import (
 	"errors"
-	"fmt"
+)
+
+var (
+	errNotEnoughData          = errors.New("not enough data for variable byte integer")
+	errBadIntEncoding         = errors.New("variable byte integer encoding exceeds 4 bytes or incomplete")
+	errNotEnoughStringLen     = errors.New("not enough data for string length")
+	errNotEnoughStringContent = errors.New("not enough data for string content")
 )
 
 // PacketReader provides primitive binary reading operations for MQTT packets.
@@ -39,7 +45,7 @@ func (r *PacketReader) Remaining() int {
 // Skip advances the offset by n bytes.
 func (r *PacketReader) Skip(n int) error {
 	if r.offset+n > len(r.pkt) {
-		return fmt.Errorf("not enough data to skip by %d bytes, remaining: %d", n, r.Remaining())
+		return errNotEnoughData
 	}
 	r.offset += n
 	return nil
@@ -48,7 +54,7 @@ func (r *PacketReader) Skip(n int) error {
 // ReadUint8 reads a single byte.
 func (r *PacketReader) ReadUint8() (uint8, error) {
 	if r.offset >= len(r.pkt) {
-		return 0, errors.New("not enough data for uint8")
+		return 0, errNotEnoughData
 	}
 	value := r.pkt[r.offset]
 	r.offset++
@@ -58,7 +64,7 @@ func (r *PacketReader) ReadUint8() (uint8, error) {
 // ReadUint16 reads a big-endian 16-bit unsigned integer.
 func (r *PacketReader) ReadUint16() (uint16, error) {
 	if r.offset+2 > len(r.pkt) {
-		return 0, errors.New("not enough data for uint16")
+		return 0, errNotEnoughData
 	}
 	value := uint16(r.pkt[r.offset])<<8 | uint16(r.pkt[r.offset+1])
 	r.offset += 2
@@ -73,7 +79,7 @@ func (r *PacketReader) ReadUint16() (uint16, error) {
 //   - Maximum 4 bytes (max value: 268,435,455 = 2^28 - 1)
 func (r *PacketReader) ReadVariableByteInteger() (int, error) {
 	if r.offset >= len(r.pkt) {
-		return 0, errors.New("not enough data for variable byte integer")
+		return 0, errNotEnoughData
 	}
 
 	multiplier := 1 // Multiplier for current byte position (1, 128, 128^2, 128^3)
@@ -94,18 +100,18 @@ func (r *PacketReader) ReadVariableByteInteger() (int, error) {
 		pos++
 	}
 
-	return 0, errors.New("variable byte integer encoding exceeds 4 bytes or incomplete")
+	return 0, errBadIntEncoding
 }
 
 // ReadString reads an MQTT string (2-byte length prefix + UTF-8 string).
 func (r *PacketReader) ReadString() (string, error) {
 	strLen, err := r.ReadUint16()
 	if err != nil {
-		return "", errors.New("not enough data for string length")
+		return "", errNotEnoughStringLen
 	}
 
 	if r.offset+int(strLen) > len(r.pkt) {
-		return "", errors.New("not enough data for string content")
+		return "", errNotEnoughStringContent
 	}
 
 	str := string(r.pkt[r.offset : r.offset+int(strLen)])

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -52,23 +52,30 @@ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
 		return nil, err
 	}
 
-	iterSpec, err := LoadBpfIter()
-	if err != nil {
-		return nil, err
-	}
+	bundles := []*ebpfcommon.SpecBundle{{
+		Spec:      spec,
+		Objects:   &p.bpfObjects,
+		Constants: p.constants(),
+	}}
 
-	return []*ebpfcommon.SpecBundle{
-		{
-			Spec:      spec,
-			Objects:   &p.bpfObjects,
-			Constants: p.constants(),
-		},
-		{
+	// BpfIter uses bpf_iter__tcp. The verifier needs bpf_iter_tcp_get_func_proto
+	// to recognize the sock_iter ctx type; that landed in 5.11. Loading on older
+	// kernels fails with "Unrecognized arg#0 type PTR". Iters() additionally
+	// gates attach on >= 6.4 (RCU stall bug), so skipping the bundle below 5.11
+	// is strictly an extension of that.
+	if major, minor := ebpfcommon.KernelVersion(); major > 5 || (major == 5 && minor >= 11) {
+		iterSpec, err := LoadBpfIter()
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, &ebpfcommon.SpecBundle{
 			Spec:      iterSpec,
 			Objects:   &p.bpfIterObjects,
 			Constants: p.iterConstants(),
-		},
-	}, nil
+		})
+	}
+
+	return bundles, nil
 }
 
 func (p *Tracer) constants() map[string]any {

--- a/vendor/go.opentelemetry.io/obi/pkg/internal/java/build.gradle.kts
+++ b/vendor/go.opentelemetry.io/obi/pkg/internal/java/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("com.diffplug.spotless") version "8.4.0" apply false
+    id("com.diffplug.spotless") version "8.5.1" apply false
 }
 
 import org.gradle.api.tasks.compile.JavaCompile

--- a/vendor/go.opentelemetry.io/obi/pkg/obi/config.go
+++ b/vendor/go.opentelemetry.io/obi/pkg/obi/config.go
@@ -332,6 +332,9 @@ var DefaultConfig = Config{
 		Enabled: true,
 		Timeout: 10 * time.Second,
 	},
+	HealthCheck: HealthCheckConfig{
+		Port: 0,
+	},
 }
 
 type Config struct {
@@ -421,6 +424,12 @@ type Config struct {
 
 	NodeJS NodeJSConfig `yaml:"nodejs"`
 	Java   JavaConfig   `yaml:"javaagent"`
+
+	HealthCheck HealthCheckConfig `yaml:"health_check"`
+}
+
+type HealthCheckConfig struct {
+	Port int `yaml:"port" env:"OTEL_EBPF_HEALTH_CHECK_PORT"`
 }
 
 func (c *Config) Unmarshal(component *confmap.Conf) error {


### PR DESCRIPTION
This adds instrumented hash, which is hashed from the injection configuration so that we can pass on to the controller that the already instrumented services have to be restarted for the changes to be taken in.