### PR TITLE
fix(ci): update-offsets needs submodule checkout

### DIFF
--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+        submodules: recursive
     - name: "Update Go"
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:


### PR DESCRIPTION
Fixing this error:

```
2026/05/27 02:15:48 error running go list:
 go: go.opentelemetry.io/obi@v0.9.0 (replaced by ./.obi-src): reading .obi-src/go.mod: open /home/runner/work/beyla/beyla/.obi-src/go.mod: no such file or directory

2026/05/27 02:15:48 ERROR: loading github.com/IBM/sarama offsets: exit status 1
make: *** [Makefile:212: update-offsets] Error 1
```

https://github.com/grafana/beyla/actions/runs/26485744216/job/77992702512