### PR TITLE
Rename image volume path to version

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -2070,9 +2070,9 @@
           "type": "array",
           "description": "List of enabled SDK auto-instrumentations. Can be used to disable specific language instrumentations."
         },
-        "image_volume_path": {
+        "image_version": {
           "type": "string",
-          "description": "OCI image mount, supported on k8s 1.31+. Must not be empty."
+          "description": "OCI image version to inject"
         },
         "instrument": {
           "$ref": "#/$defs/WebhookInstrument",

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -243,8 +243,8 @@ type SDKInject struct {
 	// a responsibility of the end-user to bounce the pods to be instrumented
 	// TODO: move to controller?
 	NoAutoRestart bool `yaml:"disable_auto_restart"`
-	// OCI image mount, supported on k8s 1.31+. Must not be empty.
-	ImageVolumePath string `yaml:"image_volume_path"`
+	// OCI image version to inject
+	ImageVolumeVersion string `yaml:"image_volume_version"`
 	// Default sampler configuration for SDK instrumentation
 	// This is used when no sampler is specified in the selector
 	DefaultSampler *services.SamplerConfig `yaml:"trace_sampler"`
@@ -262,19 +262,15 @@ type SDKInject struct {
 }
 
 func (s *SDKInject) Validate() error {
-	if s.ImageVolumePath == "" {
-		return fmt.Errorf("image volume path is required")
+	if s.ImageVolumeVersion == "" {
+		return fmt.Errorf("image volume version is required")
 	}
 	return nil
 }
 
 func (s *SDKInject) PackageVersion() string {
-	h := sha256.Sum224([]byte(s.ImageVolumePath))
+	h := sha256.Sum224([]byte(s.ImageVolumeVersion))
 	return hex.EncodeToString(h[:]) // 56 chars, fits in 63-char label limit
-}
-
-func (s *SDKInject) UsesImageVolume() bool {
-	return s.ImageVolumePath != ""
 }
 
 // WebhookConfig contains the configuration for the mutating webhook

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -244,7 +244,7 @@ type SDKInject struct {
 	// TODO: move to controller?
 	NoAutoRestart bool `yaml:"disable_auto_restart"`
 	// OCI image version to inject
-	ImageVolumeVersion string `yaml:"image_volume_version"`
+	ImageVersion string `yaml:"image_version"`
 	// Default sampler configuration for SDK instrumentation
 	// This is used when no sampler is specified in the selector
 	DefaultSampler *services.SamplerConfig `yaml:"trace_sampler"`
@@ -262,14 +262,14 @@ type SDKInject struct {
 }
 
 func (s *SDKInject) Validate() error {
-	if s.ImageVolumeVersion == "" {
+	if s.ImageVersion == "" {
 		return fmt.Errorf("image volume version is required")
 	}
 	return nil
 }
 
 func (s *SDKInject) PackageVersion() string {
-	h := sha256.Sum224([]byte(s.ImageVolumeVersion))
+	h := sha256.Sum224([]byte(s.ImageVersion))
 	return hex.EncodeToString(h[:]) // 56 chars, fits in 63-char label limit
 }
 

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -766,7 +766,7 @@ injector:
     port: 8443
     cert_path: /etc/webhook/certs/tls.crt
     key_path: /etc/webhook/certs/tls.key
-  image_volume_path: my-registry/sdk-image:v1.0.0
+  image_volume_version: v1.0.0
 otel_traces_export:
   endpoint: http://localhost:4317/v1/traces
 `)
@@ -799,7 +799,7 @@ injector:
     port: 8443
     cert_path: /etc/webhook/certs/tls.crt
     key_path: /etc/webhook/certs/tls.key
-  image_volume_path: my-registry/sdk-image:v1.0.0
+  image_volume_version: v1.0.0
 `)
 	cfg, err := LoadConfig(userConfig)
 	require.NoError(t, err)

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -766,7 +766,7 @@ injector:
     port: 8443
     cert_path: /etc/webhook/certs/tls.crt
     key_path: /etc/webhook/certs/tls.key
-  image_volume_version: v1.0.0
+  image_version: v1.0.0
 otel_traces_export:
   endpoint: http://localhost:4317/v1/traces
 `)
@@ -799,7 +799,7 @@ injector:
     port: 8443
     cert_path: /etc/webhook/certs/tls.crt
     key_path: /etc/webhook/certs/tls.key
-  image_volume_version: v1.0.0
+  image_version: v1.0.0
 `)
 	cfg, err := LoadConfig(userConfig)
 	require.NoError(t, err)

--- a/pkg/beyla/sdk_inject_test.go
+++ b/pkg/beyla/sdk_inject_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestSDKInject_Validate(t *testing.T) {
-	t.Run("image_volume_version set is valid", func(t *testing.T) {
-		s := SDKInject{ImageVolumeVersion: "v1.0.0"}
+	t.Run("image_version set is valid", func(t *testing.T) {
+		s := SDKInject{ImageVersion: "v1.0.0"}
 		require.NoError(t, s.Validate())
 	})
 
-	t.Run("missing image_volume_version is invalid", func(t *testing.T) {
+	t.Run("missing image_version is invalid", func(t *testing.T) {
 		s := SDKInject{}
 		err := s.Validate()
 		require.Error(t, err)
@@ -24,17 +24,17 @@ func TestSDKInject_Validate(t *testing.T) {
 }
 
 func TestSDKInject_PackageVersion(t *testing.T) {
-	t.Run("returns sha256 hash of image_volume_version", func(t *testing.T) {
+	t.Run("returns sha256 hash of image_version", func(t *testing.T) {
 		path := "v1.0.0"
-		s := SDKInject{ImageVolumeVersion: path}
+		s := SDKInject{ImageVersion: path}
 		h := sha256.Sum224([]byte(path))
 		assert.Equal(t, hex.EncodeToString(h[:]), s.PackageVersion())
 		assert.Len(t, s.PackageVersion(), 56) // 224-bit hash → 56 hex chars
 	})
 
 	t.Run("different image versions produce different versions", func(t *testing.T) {
-		s1 := SDKInject{ImageVolumeVersion: "v1.0.0"}
-		s2 := SDKInject{ImageVolumeVersion: "v1.0.1"}
+		s1 := SDKInject{ImageVersion: "v1.0.0"}
+		s2 := SDKInject{ImageVersion: "v1.0.1"}
 		assert.NotEqual(t, s1.PackageVersion(), s2.PackageVersion())
 	})
 }

--- a/pkg/beyla/sdk_inject_test.go
+++ b/pkg/beyla/sdk_inject_test.go
@@ -10,43 +10,31 @@ import (
 )
 
 func TestSDKInject_Validate(t *testing.T) {
-	t.Run("image_volume_path set is valid", func(t *testing.T) {
-		s := SDKInject{ImageVolumePath: "/mnt/image"}
+	t.Run("image_volume_version set is valid", func(t *testing.T) {
+		s := SDKInject{ImageVolumeVersion: "v1.0.0"}
 		require.NoError(t, s.Validate())
 	})
 
-	t.Run("missing image_volume_path is invalid", func(t *testing.T) {
+	t.Run("missing image_volume_version is invalid", func(t *testing.T) {
 		s := SDKInject{}
 		err := s.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "image volume path is required")
+		assert.Contains(t, err.Error(), "image volume version is required")
 	})
 }
 
 func TestSDKInject_PackageVersion(t *testing.T) {
-	t.Run("returns sha256 hash of image_volume_path", func(t *testing.T) {
-		path := "/mnt/oci/image"
-		s := SDKInject{ImageVolumePath: path}
+	t.Run("returns sha256 hash of image_volume_version", func(t *testing.T) {
+		path := "v1.0.0"
+		s := SDKInject{ImageVolumeVersion: path}
 		h := sha256.Sum224([]byte(path))
 		assert.Equal(t, hex.EncodeToString(h[:]), s.PackageVersion())
 		assert.Len(t, s.PackageVersion(), 56) // 224-bit hash → 56 hex chars
 	})
 
-	t.Run("different image paths produce different versions", func(t *testing.T) {
-		s1 := SDKInject{ImageVolumePath: "/mnt/image/v1"}
-		s2 := SDKInject{ImageVolumePath: "/mnt/image/v2"}
+	t.Run("different image versions produce different versions", func(t *testing.T) {
+		s1 := SDKInject{ImageVolumeVersion: "v1.0.0"}
+		s2 := SDKInject{ImageVolumeVersion: "v1.0.1"}
 		assert.NotEqual(t, s1.PackageVersion(), s2.PackageVersion())
-	})
-}
-
-func TestSDKInject_UsesImageVolume(t *testing.T) {
-	t.Run("returns true when image_volume_path is set", func(t *testing.T) {
-		s := SDKInject{ImageVolumePath: "/mnt/image"}
-		assert.True(t, s.UsesImageVolume())
-	})
-
-	t.Run("returns false when image_volume_path is empty", func(t *testing.T) {
-		s := SDKInject{}
-		assert.False(t, s.UsesImageVolume())
 	})
 }

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -77,8 +77,8 @@ type InjectConfig struct {
 	// Controls which signals (traces, metrics, logs) should be exported from injected SDKs
 	ExportedSignals SDKExportedSignals `yaml:"otel_exported_signals,omitempty"`
 
-	// OCI image mount, supported on k8s 1.31+. Must not be empty.
-	ImageVolumePath string `yaml:"image_volume_path,omitempty"`
+	// OCI image version to inject. Must not be empty.
+	ImageVolumeVersion string `yaml:"image_volume_version,omitempty"`
 
 	// Default sampler configuration for SDK instrumentation
 	// This is used when no sampler is specified in the selector
@@ -184,7 +184,7 @@ func (d *EligibleDeployment) Valid() bool {
 }
 
 func (c *InjectConfig) PackageVersion() string {
-	h := sha256.Sum224([]byte(c.ImageVolumePath))
+	h := sha256.Sum224([]byte(c.ImageVolumeVersion))
 	return fmt.Sprintf("%x", h)
 }
 

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -78,7 +78,7 @@ type InjectConfig struct {
 	ExportedSignals SDKExportedSignals `yaml:"otel_exported_signals,omitempty"`
 
 	// OCI image version to inject. Must not be empty.
-	ImageVolumeVersion string `yaml:"image_volume_version,omitempty"`
+	ImageVersion string `yaml:"image_version,omitempty"`
 
 	// Default sampler configuration for SDK instrumentation
 	// This is used when no sampler is specified in the selector
@@ -184,7 +184,7 @@ func (d *EligibleDeployment) Valid() bool {
 }
 
 func (c *InjectConfig) PackageVersion() string {
-	h := sha256.Sum224([]byte(c.ImageVolumeVersion))
+	h := sha256.Sum224([]byte(c.ImageVersion))
 	return fmt.Sprintf("%x", h)
 }
 

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -156,7 +156,7 @@ func (pm *PodMutator) buildVolumeDefinition() corev1.Volume {
 		Name: injectVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Image: &corev1.ImageVolumeSource{
-				Reference:  pm.cfg.Injector.ImageVolumePath,
+				Reference:  pm.cfg.Injector.ImageVolumeVersion,
 				PullPolicy: corev1.PullIfNotPresent,
 			},
 		},

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -156,7 +156,7 @@ func (pm *PodMutator) buildVolumeDefinition() corev1.Volume {
 		Name: injectVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Image: &corev1.ImageVolumeSource{
-				Reference:  pm.cfg.Injector.ImageVolumeVersion,
+				Reference:  pm.cfg.Injector.ImageVersion,
 				PullPolicy: corev1.PullIfNotPresent,
 			},
 		},

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -193,9 +193,9 @@ func TestPodMutator_PreloadsSomethingElse(t *testing.T) {
 }
 
 func TestPodMutator_AlreadyInstrumented(t *testing.T) {
-	cfg := &beyla.Config{Injector: beyla.SDKInject{ImageVolumePath: "/img/current"}}
+	cfg := &beyla.Config{Injector: beyla.SDKInject{ImageVolumeVersion: "v1.0.1"}}
 	currentVer := cfg.Injector.PackageVersion()
-	oldVer := (&beyla.SDKInject{ImageVolumePath: "/img/old"}).PackageVersion()
+	oldVer := (&beyla.SDKInject{ImageVolumeVersion: "v1.0.0"}).PackageVersion()
 
 	tests := []struct {
 		name     string
@@ -792,13 +792,13 @@ func TestPodMutator_BuildVolumeDefinition(t *testing.T) {
 		{
 			name: "image volume when ImageVolumePath is set",
 			injector: beyla.SDKInject{
-				ImageVolumePath: "my-registry/sdk-image:v1.0.0",
+				ImageVolumeVersion: "v1.0.0",
 			},
 			check: func(t *testing.T, vol corev1.Volume) {
 				assert.Equal(t, injectVolumeName, vol.Name)
 				assert.NotNil(t, vol.Image)
 				assert.Nil(t, vol.HostPath)
-				assert.Equal(t, "my-registry/sdk-image:v1.0.0", vol.Image.Reference)
+				assert.Equal(t, "v1.0.0", vol.Image.Reference)
 				assert.Equal(t, corev1.PullIfNotPresent, vol.Image.PullPolicy)
 			},
 		},

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -193,9 +193,9 @@ func TestPodMutator_PreloadsSomethingElse(t *testing.T) {
 }
 
 func TestPodMutator_AlreadyInstrumented(t *testing.T) {
-	cfg := &beyla.Config{Injector: beyla.SDKInject{ImageVolumeVersion: "v1.0.1"}}
+	cfg := &beyla.Config{Injector: beyla.SDKInject{ImageVersion: "v1.0.1"}}
 	currentVer := cfg.Injector.PackageVersion()
-	oldVer := (&beyla.SDKInject{ImageVolumeVersion: "v1.0.0"}).PackageVersion()
+	oldVer := (&beyla.SDKInject{ImageVersion: "v1.0.0"}).PackageVersion()
 
 	tests := []struct {
 		name     string
@@ -790,9 +790,9 @@ func TestPodMutator_BuildVolumeDefinition(t *testing.T) {
 		check    func(t *testing.T, vol corev1.Volume)
 	}{
 		{
-			name: "image volume when ImageVolumePath is set",
+			name: "image volume when ImageVersion is set",
 			injector: beyla.SDKInject{
-				ImageVolumeVersion: "v1.0.0",
+				ImageVersion: "v1.0.0",
 			},
 			check: func(t *testing.T, vol corev1.Volume) {
 				assert.Equal(t, injectVolumeName, vol.Name)

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -97,11 +97,11 @@ func NewServer(cfg *beyla.Config, ctxInfo *global.ContextInfo) (*Server, error) 
 			Endpoint: mutator.Endpoint(),
 			Protocol: mutator.Protocol(),
 		},
-		ExportedSignals:    cfg.Injector.ExportedSignals,
-		ImageVolumeVersion: cfg.Injector.ImageVolumeVersion,
-		DefaultSampler:     cfg.Injector.DefaultSampler,
-		Propagators:        cfg.Injector.Propagators,
-		Resources:          cfg.Injector.Resources,
+		ExportedSignals: cfg.Injector.ExportedSignals,
+		ImageVersion:    cfg.Injector.ImageVersion,
+		DefaultSampler:  cfg.Injector.DefaultSampler,
+		Propagators:     cfg.Injector.Propagators,
+		Resources:       cfg.Injector.Resources,
 	}
 
 	stateHash := stateCfg.Hash()

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -97,11 +97,11 @@ func NewServer(cfg *beyla.Config, ctxInfo *global.ContextInfo) (*Server, error) 
 			Endpoint: mutator.Endpoint(),
 			Protocol: mutator.Protocol(),
 		},
-		ExportedSignals: cfg.Injector.ExportedSignals,
-		ImageVolumePath: cfg.Injector.ImageVolumePath,
-		DefaultSampler:  cfg.Injector.DefaultSampler,
-		Propagators:     cfg.Injector.Propagators,
-		Resources:       cfg.Injector.Resources,
+		ExportedSignals:    cfg.Injector.ExportedSignals,
+		ImageVolumeVersion: cfg.Injector.ImageVolumeVersion,
+		DefaultSampler:     cfg.Injector.DefaultSampler,
+		Propagators:        cfg.Injector.Propagators,
+		Resources:          cfg.Injector.Resources,
 	}
 
 	stateHash := stateCfg.Hash()

--- a/pkg/webhook/state_collector_test.go
+++ b/pkg/webhook/state_collector_test.go
@@ -566,7 +566,7 @@ func TestPodStateCache_On(t *testing.T) {
 
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
-			ImageVolumeVersion: "v1.2.3",
+			ImageVersion: "v1.2.3",
 			Instrument: configmap.WebhookInstrument{
 				{Metadata: services.MetadataGlobMap{services.AttrNamespace: strToGlob(ns)}},
 			},
@@ -648,7 +648,7 @@ func TestPodStateCache_Collect(t *testing.T) {
 
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
-			ImageVolumeVersion: "v1.2.3",
+			ImageVersion: "v1.2.3",
 			Instrument: configmap.WebhookInstrument{
 				{Metadata: services.MetadataGlobMap{services.AttrNamespace: strToGlob(ns)}},
 			},

--- a/pkg/webhook/state_collector_test.go
+++ b/pkg/webhook/state_collector_test.go
@@ -566,7 +566,7 @@ func TestPodStateCache_On(t *testing.T) {
 
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
-			ImageVolumePath: "/img/v1.2.3",
+			ImageVolumeVersion: "v1.2.3",
 			Instrument: configmap.WebhookInstrument{
 				{Metadata: services.MetadataGlobMap{services.AttrNamespace: strToGlob(ns)}},
 			},
@@ -648,7 +648,7 @@ func TestPodStateCache_Collect(t *testing.T) {
 
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
-			ImageVolumePath: "/img/v1.2.3",
+			ImageVolumeVersion: "v1.2.3",
 			Instrument: configmap.WebhookInstrument{
 				{Metadata: services.MetadataGlobMap{services.AttrNamespace: strToGlob(ns)}},
 			},


### PR DESCRIPTION
I'm renaming the Beyla image volume path to be just the version. The full path will be recreated on the controller side from a configuration option. 