### PR TITLE
ci: remove dev double-deploy

### DIFF
--- a/.github/workflows/publish_gar_release.yml
+++ b/.github/workflows/publish_gar_release.yml
@@ -139,12 +139,3 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "${META_JSON}") \
             "${IMAGE}@sha256:${AMD64_DIGEST}" \
             "${IMAGE}@sha256:${ARM64_DIGEST}"
-
-  deploy-dev:
-    needs: create-manifest
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/deploy-dev.yml
-    with:
-      version: ${{ github.ref_name }}


### PR DESCRIPTION
Looks like we're making 2 attempts to auto-deploy Beyla to dev:

1. `.github/workflows/publish_gar_release.yml` --> calls `deploy-dev.yml`
2. `.github/workflows/release-binaries.yml` --> calls `deploy-alloy-beyla-dev.yml`

For dev we only want `deploy-alloy-beyla-dev.yml`.