### PR TITLE
Emit grafana.host.id fallback when k8s and cloud are unavailable

### DIFF
--- a/pkg/components/beyla.go
+++ b/pkg/components/beyla.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 	"text/template"
 
@@ -15,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
 	"go.opentelemetry.io/obi/pkg/docker"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/connector"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	obiotel "go.opentelemetry.io/obi/pkg/export/otel"
@@ -33,6 +35,8 @@ import (
 	msg2 "github.com/grafana/beyla/v3/pkg/internal/helpers/msg"
 	"github.com/grafana/beyla/v3/pkg/webhook"
 )
+
+const grafanaHostIDAttr = "grafana.host.id"
 
 // RunBeyla in the foreground process. This is a blocking function and won't exit
 // until both the AppO11y and NetO11y components end
@@ -291,6 +295,8 @@ func buildCommonContextInfo(
 		config.Attributes.MetadataRetry,
 	)
 
+	applyHostIDFallback(&ctxInfo.NodeMeta, ctxInfo.K8sInformer.IsKubeEnabled())
+
 	ctxInfo.DockerMetadata = docker.NewStore()
 
 	attributeGroups(config, ctxInfo)
@@ -318,4 +324,34 @@ func attributeGroups(config *beyla.Config, ctxInfo *global.ContextInfo) {
 	if config.NetworkFlows.GeoIP.Enabled() {
 		ctxInfo.MetricAttributeGroups.Add(attributes.GroupNetGeoIP)
 	}
+}
+
+// applyHostIDFallback sets grafana.host.id as a resource attribute with the
+// machine hostname when neither Kubernetes nor a cloud provider is available.
+func applyHostIDFallback(nodeMeta *meta.NodeMeta, kubeEnabled bool) {
+	if kubeEnabled || hasCloudProvider(*nodeMeta) {
+		return
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		slog.Warn("failed to get hostname for fallback resource attribute", "attribute", grafanaHostIDAttr, "error", err)
+		return
+	}
+
+	nodeMeta.Metadata = append(nodeMeta.Metadata, meta.Entry{
+		Key:   attr.Name(grafanaHostIDAttr),
+		Value: hostname,
+	})
+}
+
+// hasCloudProvider reports whether any cloud provider metadata was detected
+// during node metadata discovery (e.g. AWS, GCP, Azure).
+func hasCloudProvider(nodeMeta meta.NodeMeta) bool {
+	for _, entry := range nodeMeta.Metadata {
+		if entry.Key == attr.Name(semconv.CloudProviderKey) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/components/beyla_test.go
+++ b/pkg/components/beyla_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
+	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/transform"
 
 	"github.com/grafana/beyla/v3/pkg/beyla"
@@ -41,6 +44,63 @@ func TestServiceNameTemplate(t *testing.T) {
 
 	assert.Nil(t, temp)
 	assert.Nil(t, err)
+}
+
+func TestHasCloudProvider(t *testing.T) {
+	t.Run("empty metadata returns false", func(t *testing.T) {
+		nm := meta.NodeMeta{}
+		assert.False(t, hasCloudProvider(nm))
+	})
+
+	t.Run("cloud.provider present returns true", func(t *testing.T) {
+		nm := meta.NodeMeta{
+			Metadata: []meta.Entry{
+				{Key: attr.Name(semconv.CloudProviderKey), Value: "aws"},
+			},
+		}
+		assert.True(t, hasCloudProvider(nm))
+	})
+
+	t.Run("other metadata without cloud.provider returns false", func(t *testing.T) {
+		nm := meta.NodeMeta{
+			Metadata: []meta.Entry{
+				{Key: attr.Name("cloud.region"), Value: "us-east-1"},
+				{Key: attr.Name("host.name"), Value: "web-01"},
+			},
+		}
+		assert.False(t, hasCloudProvider(nm))
+	})
+}
+
+func TestApplyHostIDFallback(t *testing.T) {
+	t.Run("adds grafana.host.id when no k8s and no cloud", func(t *testing.T) {
+		nm := meta.NodeMeta{}
+		applyHostIDFallback(&nm, false)
+
+		require.Len(t, nm.Metadata, 1)
+		assert.Equal(t, attr.Name(grafanaHostIDAttr), nm.Metadata[0].Key)
+		assert.NotEmpty(t, nm.Metadata[0].Value)
+	})
+
+	t.Run("skips when kubernetes is enabled", func(t *testing.T) {
+		nm := meta.NodeMeta{}
+		applyHostIDFallback(&nm, true)
+
+		assert.Empty(t, nm.Metadata)
+	})
+
+	t.Run("skips when cloud provider is present", func(t *testing.T) {
+		nm := meta.NodeMeta{
+			Metadata: []meta.Entry{
+				{Key: attr.Name(semconv.CloudProviderKey), Value: "gcp"},
+			},
+		}
+		applyHostIDFallback(&nm, false)
+
+		require.Len(t, nm.Metadata, 1)
+		assert.Equal(t, attr.Name(semconv.CloudProviderKey), nm.Metadata[0].Key)
+		assert.Equal(t, "gcp", nm.Metadata[0].Value)
+	})
 }
 
 // See: https://github.com/grafana/beyla/issues/2410


### PR DESCRIPTION
## Summary

- When neither Kubernetes (`k8s.node.name`) nor a cloud provider (`cloud.provider`) is detected, Beyla now sets `grafana.host.id` as a resource attribute with the machine hostname
- Injects the attribute into `NodeMeta.Metadata` at startup, so it flows through all existing export paths without changes to OBI