### PR TITLE
Add custom yaml marshaler / unmarshaler for []corev1.EnvVar to respect JSON tags

### DIFF
--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -10,6 +10,7 @@ package configmap
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -118,7 +119,7 @@ type RuleConfig struct {
 	Mode Mode `yaml:"mode,omitempty"`
 	// Env is the list of environment variables to set on instrumented containers.
 	// Supports all corev1.EnvVar sources (valueFrom.secretKeyRef, etc.).
-	Env []corev1.EnvVar `yaml:"env,omitempty"`
+	Env EnvVars `yaml:"env,omitempty"`
 	// TODO: add declarativeConfig support — when set, mount the inline OTel
 	// declarative config (file_format: "1.0") as a ConfigMap and set
 	// OTEL_CONFIG_FILE on matched containers. Requires volume mount + env var
@@ -130,6 +131,52 @@ type RuleConfig struct {
 // explicit ModeSkip excludes.
 func (c RuleConfig) Skips() bool {
 	return c.Mode == ModeSkip
+}
+
+// EnvVars is a list of environment variables that (un)marshals through
+// Kubernetes' JSON field conventions rather than yaml.v3's defaults.
+// corev1.EnvVar carries only `json:` tags; yaml.v3 ignores them, so it emits
+// lowercased field names and `valuefrom: null` for the unset pointer. Routing
+// each entry through encoding/json honors the json tags — camelCase names and
+// omitempty — so unset optional fields (valueFrom, and the nested source
+// pointers) are dropped. JSON is a subset of YAML, so the round-trip is lossless.
+type EnvVars []corev1.EnvVar
+
+func (e EnvVars) MarshalYAML() (any, error) {
+	out := make([]any, 0, len(e))
+	for i := range e {
+		j, err := json.Marshal(e[i])
+		if err != nil {
+			return nil, fmt.Errorf("marshal env var %q: %w", e[i].Name, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(j, &m); err != nil {
+			return nil, fmt.Errorf("unmarshal env var %q: %w", e[i].Name, err)
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+func (e *EnvVars) UnmarshalYAML(value *yaml.Node) error {
+	var raw []any
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	out := make(EnvVars, 0, len(raw))
+	for _, item := range raw {
+		j, err := json.Marshal(item)
+		if err != nil {
+			return fmt.Errorf("marshal env var node: %w", err)
+		}
+		var ev corev1.EnvVar
+		if err := json.Unmarshal(j, &ev); err != nil {
+			return fmt.Errorf("unmarshal env var: %w", err)
+		}
+		out = append(out, ev)
+	}
+	*e = out
+	return nil
 }
 
 // EligibleDeployment names one workload whose pre-existing pods are

--- a/pkg/webhook/configmap/types_test.go
+++ b/pkg/webhook/configmap/types_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestRuleConfigSkips(t *testing.T) {
@@ -51,4 +52,44 @@ func TestRuleConfigModeRoundTrip(t *testing.T) {
 	require.Len(t, got.Rules, 2)
 	assert.True(t, got.Rules[0].Config.Skips())
 	assert.False(t, got.Rules[1].Config.Skips())
+}
+
+// corev1.EnvVar carries only json tags, which yaml.v3 ignores; the EnvVars
+// wrapper bridges through encoding/json so unset optional fields (notably the
+// valueFrom pointer) are omitted instead of serialized as `valuefrom: null`,
+// and field names follow k8s camelCase conventions. Both a plain value var and
+// a valueFrom.secretKeyRef var must survive the round trip intact.
+func TestEnvVarsRoundTrip(t *testing.T) {
+	in := InjectConfig{
+		Rules: []Rule{{
+			Config: RuleConfig{
+				Env: EnvVars{
+					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "API_KEY", ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+							Key:                  "api-key",
+						},
+					}},
+				},
+			},
+		}},
+	}
+
+	out, err := yaml.Marshal(in)
+	require.NoError(t, err)
+	s := string(out)
+
+	// The unset pointer is dropped, not emitted as null, and the source nests
+	// using k8s camelCase keys.
+	assert.NotContains(t, s, "valuefrom")
+	assert.NotContains(t, s, "valueFrom: null")
+	assert.Contains(t, s, "value: none")
+	assert.Contains(t, s, "valueFrom:")
+	assert.Contains(t, s, "secretKeyRef:")
+
+	var got InjectConfig
+	require.NoError(t, yaml.Unmarshal(out, &got))
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, in.Rules[0].Config.Env, got.Rules[0].Config.Env)
 }

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -231,7 +231,7 @@ func trimContainerIDScheme(containerID string) string {
 // Each selector becomes one Rule whose Config.Env carries all SDK configuration as
 // env vars, derived from Beyla as the single source of truth.
 func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.InjectConfig {
-	var env []corev1.EnvVar
+	var env configmap.EnvVars
 
 	// OTLP destination
 	env = append(env, corev1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: endpoint})


### PR DESCRIPTION
Currently when beyla serializes data for the k8s-injector-controller ConfigMap, it produces strings which ignore the `json` tag present on `corev1.EnvVar`. This occurs because beyla serializes using `gopkg.in/yaml.v3`, which uses `yaml` tags and ignores `json` tags. To fix, we add a custom yaml marshaler / unmarshaler for []corev1.EnvVar which uses `encoding/json`, such that the `json` tags are respected.