### PR TITLE
Uniform service definition for SDK injection and fixes to protocol handling

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -1149,47 +1149,6 @@
       },
       "type": "object"
     },
-    "K8sSelector": {
-      "properties": {
-        "namespaces": {
-          "items": {
-            "$ref": "#/$defs/GlobAttr"
-          },
-          "type": "array",
-          "description": "Namespaces lists namespace name globs. Empty means all namespaces. A pod matches if its namespace matches any entry (OR semantics)."
-        },
-        "ownerKinds": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "OwnerKinds restricts matching to specific owner kinds (e.g. Deployment, ReplicaSet, StatefulSet, DaemonSet). A link matches if its kind equals any entry (OR semantics). Empty means any kind. See OwnerNames for how kinds and names combine."
-        },
-        "ownerNames": {
-          "items": {
-            "$ref": "#/$defs/GlobAttr"
-          },
-          "type": "array",
-          "description": "OwnerNames lists globs matched against the names in the pod's resolved owner chain. For a pod owned by a ReplicaSet that is itself owned by a Deployment, every link in the chain is tried. Empty means any owner name. OwnerNames and OwnerKinds combine per link: a pod matches when a single owner-chain link satisfies both (kind ∈ OwnerKinds AND name matches some OwnerNames glob)."
-        },
-        "podAnnotations": {
-          "additionalProperties": {
-            "$ref": "#/$defs/GlobAttr"
-          },
-          "type": "object",
-          "description": "PodAnnotations maps annotation keys to value globs. Empty means all pods. All entries must match (AND semantics)."
-        },
-        "podLabels": {
-          "additionalProperties": {
-            "$ref": "#/$defs/GlobAttr"
-          },
-          "type": "object",
-          "description": "PodLabels maps label keys to value globs. Empty means all pods. All entries must match (AND semantics)."
-        }
-      },
-      "type": "object",
-      "description": "K8sSelector determines which pods a Rule applies to. All populated fields must match (AND). An empty field is a wildcard. Every field describes Kubernetes pod metadata, hence the k8s_ prefix on the YAML key."
-    },
     "KubernetesDecorator": {
       "properties": {
         "cluster_name": {
@@ -2108,10 +2067,6 @@
     },
     "SDKInject": {
       "properties": {
-        "disable_auto_restart": {
-          "type": "boolean",
-          "description": "Option to disable automatic bouncing of pods, it will be a responsibility of the end-user to bounce the pods to be instrumented TODO: move to controller?"
-        },
         "enabled_sdks": {
           "items": {
             "$ref": "#/$defs/InstrumentableType"
@@ -2120,15 +2075,29 @@
           "description": "List of enabled SDK auto-instrumentations. Can be used to disable specific language instrumentations."
         },
         "exclude_instrument": {
-          "$ref": "#/$defs/WebhookInstrument",
+          "$ref": "#/$defs/GlobDefinitionCriteria",
           "description": "ExcludeInstrument lists selectors whose matching pods are excluded from SDK instrumentation, even when they also match Instrument. Exclusion always wins, mirroring discovery.exclude_instrument."
+        },
+        "exporter_otlp_endpoint": {
+          "type": "string",
+          "description": "Override for the tracing endpoint, in case Beyla isn't configured to export traces"
+        },
+        "exporter_otlp_protocol": {
+          "type": "string",
+          "enum": [
+            "",
+            "debug",
+            "grpc",
+            "http/json",
+            "http/protobuf"
+          ]
         },
         "image_version": {
           "type": "string",
           "description": "OCI image version to inject"
         },
         "instrument": {
-          "$ref": "#/$defs/WebhookInstrument",
+          "$ref": "#/$defs/GlobDefinitionCriteria",
           "description": "OTel SDK instrumentation criteria"
         },
         "otel_exported_signals": {
@@ -2405,13 +2374,6 @@
       },
       "type": "object",
       "description": "WebhookConfig contains the configuration for the mutating webhook Functionality under active development TODO: most of the following options are not having effect. They must be moved to k8s-injection-controller"
-    },
-    "WebhookInstrument": {
-      "items": {
-        "$ref": "#/$defs/K8sSelector"
-      },
-      "type": "array",
-      "description": "WebhookInstrument is the list of selectors from the Beyla injector config that determine which pods to instrument. It carries selectors only — no per-rule config. When Beyla writes the state ConfigMap it promotes each K8sSelector into a full Rule by pairing it with the OTLP destination env vars derived from Beyla's own export configuration (see buildInjectConfig)."
     }
   },
   "properties": {

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -241,12 +241,11 @@ type SDKInject struct {
 	// instrumentation, even when they also match Instrument. Exclusion always wins,
 	// mirroring discovery.exclude_instrument.
 	ExcludeInstrument services.GlobDefinitionCriteria `yaml:"exclude_instrument"`
+	// Override for the tracing endpoint, in case Beyla isn't configured to export traces
+	Endpoint string           `yaml:"exporter_otlp_endpoint"`
+	Protocol otelcfg.Protocol `yaml:"exporter_otlp_protocol"`
 	// Webhook configuration for a mutating admission controller
 	Webhook WebhookConfig `yaml:"webhook"`
-	// Option to disable automatic bouncing of pods, it will be
-	// a responsibility of the end-user to bounce the pods to be instrumented
-	// TODO: move to controller?
-	NoAutoRestart bool `yaml:"disable_auto_restart"`
 	// OCI image version to inject
 	ImageVersion string `yaml:"image_version"`
 	// Default sampler configuration for SDK instrumentation
@@ -269,6 +268,11 @@ func (s *SDKInject) Validate() error {
 	if s.ImageVersion == "" {
 		return fmt.Errorf("image volume version is required")
 	}
+
+	if s.Endpoint == "" && s.Protocol != "" {
+		return fmt.Errorf("please specify the exporter_otlp_endpoint when choosing your OTLP protocol %s", string(s.Protocol))
+	}
+
 	return nil
 }
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -236,11 +236,11 @@ type HostIDConfig struct {
 // For SDK instrumentation on Kubernetes, use the OpenTelemetry Operator instead.
 type SDKInject struct {
 	// OTel SDK instrumentation criteria
-	Instrument configmap.WebhookInstrument `yaml:"instrument"`
+	Instrument services.GlobDefinitionCriteria `yaml:"instrument"`
 	// ExcludeInstrument lists selectors whose matching pods are excluded from SDK
 	// instrumentation, even when they also match Instrument. Exclusion always wins,
 	// mirroring discovery.exclude_instrument.
-	ExcludeInstrument configmap.WebhookInstrument `yaml:"exclude_instrument"`
+	ExcludeInstrument services.GlobDefinitionCriteria `yaml:"exclude_instrument"`
 	// Webhook configuration for a mutating admission controller
 	Webhook WebhookConfig `yaml:"webhook"`
 	// Option to disable automatic bouncing of pods, it will be

--- a/pkg/webhook/configmap/match.go
+++ b/pkg/webhook/configmap/match.go
@@ -25,6 +25,9 @@ type MatchInput struct {
 // Match reports whether the given input satisfies all populated selector fields.
 // An empty or unset field is a wildcard.
 func (s K8sSelector) Match(in MatchInput) bool {
+	if s.IsEmpty() {
+		return false
+	}
 	return s.matchNamespace(in.Namespace) &&
 		s.matchOwner(in.OwnerChain) &&
 		matchAllGlobs(s.PodLabels, in.Labels) &&

--- a/pkg/webhook/configmap/match_test.go
+++ b/pkg/webhook/configmap/match_test.go
@@ -16,10 +16,10 @@ func TestK8sSelector_Match(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "empty selector matches everything",
+			name:     "empty selector doesn't match everything",
 			selector: K8sSelector{},
 			input:    MatchInput{Namespace: "prod", Labels: map[string]string{"app": "foo"}},
-			want:     true,
+			want:     false,
 		},
 
 		// Namespace matching

--- a/pkg/webhook/matcher.go
+++ b/pkg/webhook/matcher.go
@@ -21,9 +21,109 @@ func NewPodMatcher(cfg *beyla.Config) *PodMatcher {
 		"selectors", cfg.Injector.Instrument, "exclude", cfg.Injector.ExcludeInstrument)
 	return &PodMatcher{
 		logger:     logger,
-		instrument: cfg.Injector.Instrument,
-		exclude:    cfg.Injector.ExcludeInstrument,
+		instrument: selectorsFromDefinitionCriteria(cfg.Injector.Instrument),
+		exclude:    selectorsFromDefinitionCriteria(cfg.Injector.ExcludeInstrument),
 	}
+}
+
+func selectorFromGlob(a *services.GlobAttributes) *configmap.K8sSelector {
+	var podLabels map[string]services.GlobAttr
+	if len(a.PodLabels) > 0 {
+		podLabels = make(map[string]services.GlobAttr, len(a.PodLabels))
+		for k, v := range a.PodLabels {
+			podLabels[k] = *v
+		}
+	}
+
+	var podAnnotations map[string]services.GlobAttr
+	if len(a.PodAnnotations) > 0 {
+		podAnnotations = make(map[string]services.GlobAttr, len(a.PodAnnotations))
+		for k, v := range a.PodAnnotations {
+			podAnnotations[k] = *v
+		}
+	}
+
+	metaGlob := func(name string) []services.GlobAttr {
+		if g := a.Metadata[name]; g != nil {
+			return []services.GlobAttr{*g}
+		}
+		return nil
+	}
+
+	// First check to see if the user used k8s_owner_name
+	ownerNames := metaGlob(services.AttrOwnerName)
+	var kinds []string
+	// If no owner name, then we check the specific types of definitions.
+	// In this case we set both the owner name and the kind to match the new
+	// service definition format.
+	if ownerNames == nil {
+		for _, owner := range []struct {
+			metadataKey string
+			kind        string
+		}{
+			{metadataKey: services.AttrDeploymentName, kind: "Deployment"},
+			{metadataKey: services.AttrDaemonSetName, kind: "DaemonSet"},
+			{metadataKey: services.AttrReplicaSetName, kind: "ReplicaSet"},
+			{metadataKey: services.AttrStatefulSetName, kind: "StatefulSet"},
+			{metadataKey: services.AttrJobName, kind: "Job"},
+			{metadataKey: services.AttrCronJobName, kind: "CronJob"},
+			{metadataKey: services.AttrPodName, kind: "Pod"},
+		} {
+			if names := metaGlob(owner.metadataKey); names != nil {
+				ownerNames = names
+				kinds = []string{owner.kind}
+				break
+			}
+		}
+	}
+
+	sel := configmap.K8sSelector{
+		Namespaces:     metaGlob(services.AttrNamespace),
+		OwnerNames:     ownerNames,
+		OwnerKinds:     kinds,
+		PodLabels:      podLabels,
+		PodAnnotations: podAnnotations,
+	}
+
+	if sel.IsEmpty() {
+		return nil
+	}
+
+	return &sel
+}
+
+// nsScope is the pre-computed namespace scope derived from the injector config.
+type nsScope struct {
+	clusterWide bool
+	globs       []*services.GlobAttr
+}
+
+// scopedNamespaces analyzes the injector configuration and returns an nsScope.
+func (m *PodMatcher) scopedNamespaces() nsScope {
+	for _, sel := range m.instrument {
+		if len(sel.Namespaces) == 0 {
+			return nsScope{clusterWide: true}
+		}
+	}
+	var globs []*services.GlobAttr
+	for _, sel := range m.instrument {
+		for i := range sel.Namespaces {
+			globs = append(globs, &sel.Namespaces[i])
+		}
+	}
+	return nsScope{globs: globs}
+}
+
+func selectorsFromDefinitionCriteria(criteria services.GlobDefinitionCriteria) configmap.WebhookInstrument {
+	instr := configmap.WebhookInstrument{}
+
+	for i := range criteria {
+		if sel := selectorFromGlob(&criteria[i]); sel != nil {
+			instr = append(instr, *sel)
+		}
+	}
+
+	return instr
 }
 
 func (m *PodMatcher) HasSelectionCriteria() bool {

--- a/pkg/webhook/matcher_test.go
+++ b/pkg/webhook/matcher_test.go
@@ -242,7 +242,7 @@ func TestNewPodMatcher(t *testing.T) {
 		prod := services.NewGlob("prod*")
 		cfg := &beyla.Config{
 			Injector: beyla.SDKInject{
-				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &prod}}},
+				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrNamespace: &prod}}},
 			},
 		}
 		matcher := NewPodMatcher(cfg)
@@ -256,8 +256,8 @@ func TestNewPodMatcher(t *testing.T) {
 
 		cfg := &beyla.Config{
 			Injector: beyla.SDKInject{
-				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &demo}}},
-				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &demo, "k8s_owner_name": &skipMe}}},
+				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrNamespace: &demo}}},
+				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrNamespace: &demo, services.AttrOwnerName: &skipMe}}},
 			},
 		}
 		matcher := NewPodMatcher(cfg)

--- a/pkg/webhook/matcher_test.go
+++ b/pkg/webhook/matcher_test.go
@@ -26,6 +26,12 @@ func TestPodMatcher_MatchProcessInfo(t *testing.T) {
 		wantSel    *configmap.K8sSelector // non-nil: assert the exact selector returned
 	}{
 		{
+			name:       "no instrument — no match",
+			instrument: configmap.WebhookInstrument{{}},
+			process:    &ProcessInfo{metadata: map[string]string{"k8s_namespace": "prod"}},
+			want:       false,
+		},
+		{
 			name:       "nil process — no match",
 			instrument: configmap.WebhookInstrument{{}},
 			process:    nil,
@@ -148,6 +154,12 @@ func TestPodMatcher_MatchProcessInfo_Exclusion(t *testing.T) {
 		OwnerNames: []services.GlobAttr{services.NewGlob("skip-me")},
 	}}
 
+	excludeReplicaSet := configmap.WebhookInstrument{{
+		Namespaces: []services.GlobAttr{services.NewGlob("demo")},
+		OwnerNames: []services.GlobAttr{services.NewGlob("skip-me")},
+		OwnerKinds: []string{"ReplicaSet"},
+	}}
+
 	tests := []struct {
 		name       string
 		instrument configmap.WebhookInstrument
@@ -155,6 +167,16 @@ func TestPodMatcher_MatchProcessInfo_Exclusion(t *testing.T) {
 		process    *ProcessInfo
 		want       bool
 	}{
+		{
+			name:       "exclusion is filtered out because skip-me is a Deployment and not a ReplicaSet",
+			instrument: instrument,
+			exclude:    excludeReplicaSet,
+			process: &ProcessInfo{
+				metadata:   map[string]string{"k8s_namespace": "demo"},
+				ownerChain: []configmap.Owner{{Name: "skip-me", Kind: "Deployment"}},
+			},
+			want: true,
+		},
 		{
 			name:       "exclusion wins over a matching instrument selector",
 			instrument: instrument,
@@ -217,11 +239,10 @@ func TestNewPodMatcher(t *testing.T) {
 	})
 
 	t.Run("with instrument criteria", func(t *testing.T) {
+		prod := services.NewGlob("prod*")
 		cfg := &beyla.Config{
 			Injector: beyla.SDKInject{
-				Instrument: configmap.WebhookInstrument{{
-					Namespaces: []services.GlobAttr{services.NewGlob("prod*")},
-				}},
+				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &prod}}},
 			},
 		}
 		matcher := NewPodMatcher(cfg)
@@ -230,15 +251,13 @@ func TestNewPodMatcher(t *testing.T) {
 	})
 
 	t.Run("wires exclude_instrument and exclusion wins", func(t *testing.T) {
+		demo := services.NewGlob("demo")
+		skipMe := services.NewGlob("skip-me")
+
 		cfg := &beyla.Config{
 			Injector: beyla.SDKInject{
-				Instrument: configmap.WebhookInstrument{{
-					Namespaces: []services.GlobAttr{services.NewGlob("demo")},
-				}},
-				ExcludeInstrument: configmap.WebhookInstrument{{
-					Namespaces: []services.GlobAttr{services.NewGlob("demo")},
-					OwnerNames: []services.GlobAttr{services.NewGlob("skip-me")},
-				}},
+				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &demo}}},
+				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &demo, "k8s_owner_name": &skipMe}}},
 			},
 		}
 		matcher := NewPodMatcher(cfg)

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -68,37 +67,36 @@ func (pm *PodMutator) Protocol() string { return pm.proto }
 // TODO: we don't need most of the code, as this is already mutated in the external webhook. Cleanup
 func NewPodMutator(cfg *beyla.Config, matcher *PodMatcher, metrics *SDKInjectionMetrics) (*PodMutator, error) {
 	var opts otelcfg.OTLPOptions
-	var err error
 
-	switch proto := cfg.Traces.GetProtocol(); proto {
-	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "":
-		opts, err = otelcfg.HTTPTracesEndpointOptions(&cfg.Traces)
-		if err != nil {
-			return nil, err
+	// Beyla may not be configured to produce traces at all. We first check if the injector has
+	// been supplied an endpoint and protocol and if not, then we pull out the endpoint and the
+	// protocol from Beyla's traces configuration.
+	protocol := cfg.Injector.Protocol
+	endpoint := cfg.Injector.Endpoint
+
+	if endpoint == "" {
+		protocol = cfg.Traces.GetProtocol()
+		var common bool
+		endpoint, common = cfg.Traces.OTLPTracesEndpoint()
+		if !common {
+			endpoint = strings.TrimSuffix(endpoint, "/v1/traces")
 		}
-	case otelcfg.ProtocolGRPC:
-		opts, err = otelcfg.GRPCTracesEndpointOptions(&cfg.Traces)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unsupported SDK export protocol %s", proto)
+	}
+
+	if protocol == "" {
+		protocol = otelcfg.ProtocolHTTPProtobuf
 	}
 
 	logger := slog.Default().With("component", "webhook")
-	proto := string(cfg.Traces.Protocol)
-	if proto == "" {
-		proto = string(otelcfg.ProtocolHTTPProtobuf)
-	}
 
 	return &PodMutator{
 		logger:        logger,
 		matcher:       matcher,
 		cfg:           cfg,
 		metrics:       metrics,
-		endpoint:      opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
+		endpoint:      endpoint,
 		exportHeaders: opts.Headers,
-		proto:         proto,
+		proto:         string(protocol),
 	}, nil
 }
 

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -5,18 +5,120 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 
 	"github.com/grafana/beyla/v3/pkg/beyla"
 	svcextra "github.com/grafana/beyla/v3/pkg/services"
 	"github.com/grafana/beyla/v3/pkg/webhook/configmap"
 )
+
+func TestNewPodMutator(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              *beyla.Config
+		expectedEndpoint string
+		expectedProtocol string
+	}{
+		{
+			// When the injector is given an explicit endpoint, it is used
+			// verbatim and the Beyla traces configuration is ignored.
+			name: "injector endpoint overrides traces config (grpc)",
+			cfg: &beyla.Config{
+				Injector: beyla.SDKInject{
+					Endpoint: "collector.example.com:4317",
+					Protocol: otelcfg.ProtocolGRPC,
+				},
+				// Deliberately different to prove it is NOT consulted.
+				Traces: otelcfg.TracesConfig{
+					CommonEndpoint: "http://should-not-be-used:4318",
+					Protocol:       otelcfg.ProtocolHTTPProtobuf,
+				},
+			},
+			expectedEndpoint: "collector.example.com:4317",
+			expectedProtocol: "grpc",
+		},
+		{
+			name: "injector endpoint overrides traces config (http)",
+			cfg: &beyla.Config{
+				Injector: beyla.SDKInject{
+					Endpoint: "https://otel.example.com/custom",
+					Protocol: otelcfg.ProtocolHTTPProtobuf,
+				},
+			},
+			expectedEndpoint: "https://otel.example.com/custom",
+			expectedProtocol: "http/protobuf",
+		},
+		{
+			// No injector endpoint: fall back to deriving the destination from
+			// Beyla's own traces export configuration.
+			name: "falls back to traces http endpoint",
+			cfg: &beyla.Config{
+				Traces: otelcfg.TracesConfig{
+					CommonEndpoint: "http://otel-collector:4318",
+					Protocol:       otelcfg.ProtocolHTTPProtobuf,
+				},
+			},
+			expectedEndpoint: "http://otel-collector:4318",
+			expectedProtocol: "http/protobuf",
+		},
+		{
+			name: "falls back to traces grpc endpoint",
+			cfg: &beyla.Config{
+				Traces: otelcfg.TracesConfig{
+					CommonEndpoint: "http://otel-collector:4317",
+					Protocol:       otelcfg.ProtocolGRPC,
+				},
+			},
+			expectedEndpoint: "http://otel-collector:4317",
+			expectedProtocol: "grpc",
+		},
+		{
+			// An explicit (non-common) traces endpoint keeps its path, but the
+			// /v1/traces signal suffix is trimmed off.
+			name: "trims /v1/traces from explicit traces endpoint",
+			cfg: &beyla.Config{
+				Traces: otelcfg.TracesConfig{
+					TracesEndpoint: "http://otel-collector:4318/v1/traces",
+					Protocol:       otelcfg.ProtocolHTTPProtobuf,
+				},
+			},
+			expectedEndpoint: "http://otel-collector:4318",
+			expectedProtocol: "http/protobuf",
+		},
+		{
+			// Injector endpoint set but no protocol: protocol defaults to
+			// http/protobuf rather than being left empty.
+			name: "defaults protocol when injector protocol unset",
+			cfg: &beyla.Config{
+				Injector: beyla.SDKInject{
+					Endpoint: "collector.example.com:4317",
+				},
+			},
+			expectedEndpoint: "collector.example.com:4317",
+			expectedProtocol: "http/protobuf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewPodMatcher(tt.cfg)
+
+			mutator, err := NewPodMutator(tt.cfg, matcher, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedEndpoint, mutator.Endpoint())
+			assert.Equal(t, tt.expectedProtocol, mutator.Protocol())
+		})
+	}
+}
 
 func TestErrorResponse(t *testing.T) {
 	tests := []struct {

--- a/pkg/webhook/state_collector.go
+++ b/pkg/webhook/state_collector.go
@@ -124,28 +124,6 @@ func alreadyInstrumentedByOther(spec *corev1.PodSpec, meta *metav1.ObjectMeta) b
 	return false
 }
 
-// nsScope is the pre-computed namespace scope derived from the injector config.
-type nsScope struct {
-	clusterWide bool
-	globs       []*services.GlobAttr
-}
-
-// scopedNamespaces analyzes the injector configuration and returns an nsScope.
-func scopedNamespaces(cfg *beyla.Config) nsScope {
-	for _, sel := range cfg.Injector.Instrument {
-		if len(sel.Namespaces) == 0 {
-			return nsScope{clusterWide: true}
-		}
-	}
-	var globs []*services.GlobAttr
-	for _, sel := range cfg.Injector.Instrument {
-		for i := range sel.Namespaces {
-			globs = append(globs, &sel.Namespaces[i])
-		}
-	}
-	return nsScope{globs: globs}
-}
-
 func inScope(namespace string, scope nsScope) bool {
 	if systemNamespaces[namespace] {
 		return false
@@ -261,7 +239,7 @@ func (c *PodStateCache) On(event *informer.Event) error {
 		if c.ownNode == "" || pod.Pod.NodeName != c.ownNode {
 			return nil
 		}
-		pc := classifyFromInformer(pod, c.matcher, scopedNamespaces(c.cfg), c.cfg.Injector.PackageVersion())
+		pc := classifyFromInformer(pod, c.matcher, c.matcher.scopedNamespaces(), c.cfg.Injector.PackageVersion())
 		c.mu.Lock()
 		if pc == nil {
 			delete(c.pods, uid)

--- a/pkg/webhook/state_collector_test.go
+++ b/pkg/webhook/state_collector_test.go
@@ -28,6 +28,17 @@ func nsMatcher(ns string) *PodMatcher {
 	}
 }
 
+func nsMatchers(namespaces []string) *PodMatcher {
+	i := configmap.WebhookInstrument{}
+	for _, ns := range namespaces {
+		i = append(i, configmap.K8sSelector{Namespaces: []services.GlobAttr{services.NewGlob(ns)}})
+	}
+	return &PodMatcher{
+		logger:     slog.Default(),
+		instrument: i,
+	}
+}
+
 // nsLabelMatcher builds a PodMatcher that matches pods in the given namespace
 // AND carrying the given pod label key=value.
 func nsLabelMatcher(ns, labelKey, labelValue string) *PodMatcher {
@@ -37,29 +48,6 @@ func nsLabelMatcher(ns, labelKey, labelValue string) *PodMatcher {
 			{
 				Namespaces: []services.GlobAttr{services.NewGlob(ns)},
 				PodLabels:  map[string]services.GlobAttr{labelKey: services.NewGlob(labelValue)},
-			},
-		},
-	}
-}
-
-// nsCfg builds a beyla.Config whose Injector.Instrument restricts to ns.
-func nsCfg(ns string) *beyla.Config {
-	return &beyla.Config{
-		Injector: beyla.SDKInject{
-			Instrument: configmap.WebhookInstrument{
-				{Namespaces: []services.GlobAttr{services.NewGlob(ns)}},
-			},
-		},
-	}
-}
-
-// wildcardCfg returns a config with a selector that has no namespace constraint.
-func wildcardCfg() *beyla.Config {
-	return &beyla.Config{
-		Injector: beyla.SDKInject{
-			// An empty Selector is a wildcard — matches any pod.
-			Instrument: configmap.WebhookInstrument{
-				{},
 			},
 		},
 	}
@@ -118,7 +106,6 @@ func TestClassify(t *testing.T) {
 		name       string
 		pod        *corev1.Pod
 		matcher    *PodMatcher
-		cfg        *beyla.Config
 		wantNil    bool
 		wantStatus Status
 		wantSkip   string
@@ -128,21 +115,18 @@ func TestClassify(t *testing.T) {
 			name:       "instrumented_basic",
 			pod:        pod(prodNS, "my-pod", withEnv(envVarLdPreloadName, envVarLdPreloadValue)),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusInstrumented,
 		},
 		{
 			name:       "pending_restart_basic",
 			pod:        pod(prodNS, "my-pod"),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusPendingRestart,
 		},
 		{
 			name:       "skipped_conflict",
 			pod:        pod(prodNS, "my-pod", withEnv(envVarLdPreloadName, "/some/other/lib.so")),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusSkipped,
 			wantSkip:   SkipReasonConflict,
 		},
@@ -150,7 +134,6 @@ func TestClassify(t *testing.T) {
 			name:       "skipped_already_instrumented_label",
 			pod:        pod(prodNS, "my-pod", withLabel(instrumentedLabel, "v1.2.3")),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusSkipped,
 			wantSkip:   SkipReasonAlreadyInstrumented,
 		},
@@ -158,7 +141,6 @@ func TestClassify(t *testing.T) {
 			name:       "skipped_already_instrumented_env",
 			pod:        pod(prodNS, "my-pod", withEnv(envOtelInjectorConfigFileName, envOtelInjectorConfigFileValue)),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusSkipped,
 			wantSkip:   SkipReasonAlreadyInstrumented,
 		},
@@ -166,35 +148,30 @@ func TestClassify(t *testing.T) {
 			name:       "unmatched_in_scope",
 			pod:        pod(prodNS, "other-app"),
 			matcher:    nsLabelMatcher(prodNS, "app", "specific-app"),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusUnmatched,
 		},
 		{
 			name:    "out_of_scope_different_namespace",
 			pod:     pod("staging", "my-pod"),
 			matcher: nsMatcher(prodNS),
-			cfg:     nsCfg(prodNS),
 			wantNil: true,
 		},
 		{
 			name:    "out_of_scope_system_namespace",
 			pod:     pod("kube-system", "my-pod"),
 			matcher: &PodMatcher{logger: slog.Default(), instrument: configmap.WebhookInstrument{{}}},
-			cfg:     wildcardCfg(),
 			wantNil: true,
 		},
 		{
 			name:    "out_of_scope_no_selectors",
 			pod:     pod(prodNS, "my-pod"),
 			matcher: &PodMatcher{logger: slog.Default()},
-			cfg:     &beyla.Config{},
 			wantNil: true,
 		},
 		{
 			name:       "node_name_propagated",
 			pod:        pod(prodNS, "my-pod", withEnv(envVarLdPreloadName, envVarLdPreloadValue), withNodeName("node-1")),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusInstrumented,
 			wantNode:   "node-1",
 		},
@@ -205,7 +182,6 @@ func TestClassify(t *testing.T) {
 			name:       "skipped_already_instrumented_label_beats_conflict",
 			pod:        pod(prodNS, "my-pod", withLabel(instrumentedLabel, "v1.2.3"), withEnv(envVarLdPreloadName, "/foreign/lib.so")),
 			matcher:    nsMatcher(prodNS),
-			cfg:        nsCfg(prodNS),
 			wantStatus: StatusSkipped,
 			wantSkip:   SkipReasonAlreadyInstrumented,
 		},
@@ -213,7 +189,7 @@ func TestClassify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classify(tt.pod, tt.matcher, scopedNamespaces(tt.cfg))
+			got := classify(tt.pod, tt.matcher, tt.matcher.scopedNamespaces())
 			if tt.wantNil {
 				assert.Nil(t, got)
 				return
@@ -279,12 +255,11 @@ func TestClassifyWorkloadResolution(t *testing.T) {
 		},
 	}
 
-	cfg := nsCfg(ns)
 	matcher := nsMatcher(ns)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classify(tt.pod, matcher, scopedNamespaces(cfg))
+			got := classify(tt.pod, matcher, matcher.scopedNamespaces())
 			require.NotNil(t, got)
 			assert.Equal(t, tt.wantKind, got.WorkloadKind, "workload_kind")
 			assert.Equal(t, tt.wantWorkName, got.WorkloadName, "workload_name")
@@ -297,75 +272,70 @@ func TestIsInScope(t *testing.T) {
 	tests := []struct {
 		name      string
 		namespace string
-		cfg       *beyla.Config
+		matchNs   []string
 		want      bool
 	}{
 		{
 			name:      "in_scope_explicit_namespace",
 			namespace: "prod",
-			cfg:       nsCfg("prod"),
+			matchNs:   []string{"prod"},
 			want:      true,
 		},
 		{
 			name:      "in_scope_glob_namespace",
 			namespace: "production",
-			cfg:       nsCfg("prod*"),
+			matchNs:   []string{"prod*"},
 			want:      true,
 		},
 		{
 			name:      "out_of_scope_different_namespace",
 			namespace: "staging",
-			cfg:       nsCfg("prod"),
+			matchNs:   []string{"prod"},
 			want:      false,
 		},
 		{
 			name:      "in_scope_wildcard_selector",
 			namespace: "any-namespace",
-			cfg:       wildcardCfg(),
+			matchNs:   []string{"*"},
 			want:      true,
 		},
 		{
 			name:      "out_of_scope_system_namespace",
 			namespace: "kube-system",
-			cfg:       wildcardCfg(),
+			matchNs:   []string{"*"},
 			want:      false,
 		},
 		{
 			name:      "out_of_scope_kube_node_lease",
 			namespace: "kube-node-lease",
-			cfg:       wildcardCfg(),
+			matchNs:   []string{"*"},
 			want:      false,
 		},
 		{
 			name:      "out_of_scope_kube_public",
 			namespace: "kube-public",
-			cfg:       wildcardCfg(),
+			matchNs:   []string{"*"},
 			want:      false,
 		},
 		{
 			name:      "out_of_scope_no_selectors",
 			namespace: "prod",
-			cfg:       &beyla.Config{},
+			matchNs:   []string{},
 			want:      false,
 		},
 		{
 			name:      "in_scope_multi_selector_second_matches",
 			namespace: "staging",
-			cfg: &beyla.Config{
-				Injector: beyla.SDKInject{
-					Instrument: configmap.WebhookInstrument{
-						{Namespaces: []services.GlobAttr{services.NewGlob("prod")}},
-						{Namespaces: []services.GlobAttr{services.NewGlob("staging")}},
-					},
-				},
-			},
-			want: true,
+			matchNs:   []string{"prod", "staging"},
+			want:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := inScope(tt.namespace, scopedNamespaces(tt.cfg))
+			matcher := nsMatchers(tt.matchNs)
+
+			got := inScope(tt.namespace, matcher.scopedNamespaces())
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -510,9 +480,7 @@ func TestClassifyFromInformer(t *testing.T) {
 		version = "v1.2.3"
 	)
 
-	cfg := nsCfg(ns)
 	matcher := nsMatcher(ns)
-	scope := scopedNamespaces(cfg)
 
 	tests := []struct {
 		name       string
@@ -572,7 +540,7 @@ func TestClassifyFromInformer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyFromInformer(tt.pod, matcher, scope, version)
+			got := classifyFromInformer(tt.pod, matcher, matcher.scopedNamespaces(), version)
 			if tt.wantNil {
 				assert.Nil(t, got)
 				return
@@ -589,7 +557,7 @@ func TestClassifyFromInformer(t *testing.T) {
 
 	t.Run("unmatched_in_scope", func(t *testing.T) {
 		m := nsLabelMatcher(ns, "app", "specific-app")
-		got := classifyFromInformer(informerPod(ns, "other-app", "uid-u", node), m, scope, version)
+		got := classifyFromInformer(informerPod(ns, "other-app", "uid-u", node), m, m.scopedNamespaces(), version)
 		require.NotNil(t, got)
 		assert.Equal(t, StatusUnmatched, got.Status)
 	})
@@ -601,12 +569,12 @@ func TestPodStateCache_On(t *testing.T) {
 		node = "node-1"
 	)
 
+	prod := services.NewGlob(ns)
+
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
 			ImageVersion: "v1.2.3",
-			Instrument: configmap.WebhookInstrument{
-				{Namespaces: []services.GlobAttr{services.NewGlob(ns)}},
-			},
+			Instrument:   services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &prod}}},
 		},
 	}
 	version := cfg.Injector.PackageVersion()
@@ -683,12 +651,12 @@ func TestPodStateCache_Collect(t *testing.T) {
 		node = "node-1"
 	)
 
+	prod := services.NewGlob(ns)
+
 	cfg := &beyla.Config{
 		Injector: beyla.SDKInject{
 			ImageVersion: "v1.2.3",
-			Instrument: configmap.WebhookInstrument{
-				{Namespaces: []services.GlobAttr{services.NewGlob(ns)}},
-			},
+			Instrument:   services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8_namespace": &prod}}},
 		},
 	}
 	version := cfg.Injector.PackageVersion()

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -310,8 +310,9 @@ func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.I
 	// (first match wins), so a skip rule ahead of the install rules carves the
 	// excluded workloads out — e.g. "instrument all except serviceA". Skip rules
 	// carry no env; the injector only needs to know not to instrument.
-	for _, glob := range cfg.Injector.ExcludeInstrument {
-		sel := selectorFromGlob(&glob)
+	for i := range cfg.Injector.ExcludeInstrument {
+		glob := &cfg.Injector.ExcludeInstrument[i]
+		sel := selectorFromGlob(glob)
 		if sel == nil {
 			continue
 		}
@@ -320,8 +321,9 @@ func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.I
 			Config:   configmap.RuleConfig{Mode: configmap.ModeSkip},
 		})
 	}
-	for _, glob := range cfg.Injector.Instrument {
-		sel := selectorFromGlob(&glob)
+	for i := range cfg.Injector.Instrument {
+		glob := &cfg.Injector.Instrument[i]
+		sel := selectorFromGlob(glob)
 		if sel == nil {
 			continue
 		}

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -344,7 +344,7 @@ func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.I
 func ruleFromDefinition(a *services.GlobAttributes, mode configmap.Mode) *configmap.Rule {
 	sel := selectorFromGlob(a)
 
-	if sel.IsEmpty() {
+	if sel == nil || sel.IsEmpty() {
 		return nil
 	}
 

--- a/pkg/webhook/state_configmap.go
+++ b/pkg/webhook/state_configmap.go
@@ -310,15 +310,23 @@ func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.I
 	// (first match wins), so a skip rule ahead of the install rules carves the
 	// excluded workloads out — e.g. "instrument all except serviceA". Skip rules
 	// carry no env; the injector only needs to know not to instrument.
-	for _, sel := range cfg.Injector.ExcludeInstrument {
+	for _, glob := range cfg.Injector.ExcludeInstrument {
+		sel := selectorFromGlob(&glob)
+		if sel == nil {
+			continue
+		}
 		rules = append(rules, configmap.Rule{
-			Selector: sel,
+			Selector: *sel,
 			Config:   configmap.RuleConfig{Mode: configmap.ModeSkip},
 		})
 	}
-	for _, sel := range cfg.Injector.Instrument {
+	for _, glob := range cfg.Injector.Instrument {
+		sel := selectorFromGlob(&glob)
+		if sel == nil {
+			continue
+		}
 		rules = append(rules, configmap.Rule{
-			Selector: sel,
+			Selector: *sel,
 			Config:   configmap.RuleConfig{Env: env},
 		})
 	}
@@ -334,70 +342,14 @@ func buildInjectConfig(cfg *beyla.Config, endpoint, protocol string) configmap.I
 }
 
 func ruleFromDefinition(a *services.GlobAttributes, mode configmap.Mode) *configmap.Rule {
-	var podLabels map[string]services.GlobAttr
-	if len(a.PodLabels) > 0 {
-		podLabels = make(map[string]services.GlobAttr, len(a.PodLabels))
-		for k, v := range a.PodLabels {
-			podLabels[k] = *v
-		}
-	}
-
-	var podAnnotations map[string]services.GlobAttr
-	if len(a.PodAnnotations) > 0 {
-		podAnnotations = make(map[string]services.GlobAttr, len(a.PodAnnotations))
-		for k, v := range a.PodAnnotations {
-			podAnnotations[k] = *v
-		}
-	}
-
-	metaGlob := func(name string) []services.GlobAttr {
-		if g := a.Metadata[name]; g != nil {
-			return []services.GlobAttr{*g}
-		}
-		return nil
-	}
-
-	// First check to see if the user used k8s_owner_name
-	ownerNames := metaGlob(services.AttrOwnerName)
-	var kinds []string
-	// If no owner name, then we check the specific types of definitions.
-	// In this case we set both the owner name and the kind to match the new
-	// service definition format.
-	if ownerNames == nil {
-		for _, owner := range []struct {
-			metadataKey string
-			kind        string
-		}{
-			{metadataKey: services.AttrDeploymentName, kind: "Deployment"},
-			{metadataKey: services.AttrDaemonSetName, kind: "DaemonSet"},
-			{metadataKey: services.AttrReplicaSetName, kind: "ReplicaSet"},
-			{metadataKey: services.AttrStatefulSetName, kind: "StatefulSet"},
-			{metadataKey: services.AttrJobName, kind: "Job"},
-			{metadataKey: services.AttrCronJobName, kind: "CronJob"},
-			{metadataKey: services.AttrPodName, kind: "Pod"},
-		} {
-			if names := metaGlob(owner.metadataKey); names != nil {
-				ownerNames = names
-				kinds = []string{owner.kind}
-				break
-			}
-		}
-	}
-
-	sel := configmap.K8sSelector{
-		Namespaces:     metaGlob(services.AttrNamespace),
-		OwnerNames:     ownerNames,
-		OwnerKinds:     kinds,
-		PodLabels:      podLabels,
-		PodAnnotations: podAnnotations,
-	}
+	sel := selectorFromGlob(a)
 
 	if sel.IsEmpty() {
 		return nil
 	}
 
 	return &configmap.Rule{
-		Selector: sel,
+		Selector: *sel,
 		Config:   configmap.RuleConfig{Mode: mode},
 	}
 }

--- a/pkg/webhook/state_configmap_test.go
+++ b/pkg/webhook/state_configmap_test.go
@@ -523,6 +523,10 @@ func TestBuildInjectConfig(t *testing.T) {
 		}
 	}
 
+	deployment := services.NewGlob("Deployment")
+	statefulSet := services.NewGlob("StatefulSet")
+	daemonSet := services.NewGlob("DaemonSet")
+
 	tests := []struct {
 		name     string
 		cfg      beyla.Config
@@ -540,7 +544,7 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "single selector becomes one rule with all default env vars",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument: configmap.WebhookInstrument{{OwnerKinds: []string{"Deployment"}}},
+				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",
@@ -552,9 +556,9 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "multiple selectors each get the same env",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument: configmap.WebhookInstrument{
-					{OwnerKinds: []string{"Deployment"}},
-					{OwnerKinds: []string{"StatefulSet"}},
+				Instrument: services.GlobDefinitionCriteria{
+					{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}},
+					{Metadata: services.MetadataGlobMap{"k8s_kind": &statefulSet}},
 				},
 			}},
 			endpoint: "http://otel:4318",
@@ -568,7 +572,7 @@ func TestBuildInjectConfig(t *testing.T) {
 			name: "ImageVersion is set at the top level",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
 				ImageVersion: "ghcr.io/grafana/beyla/inject-sdk-image:v1.2.3",
-				Instrument:   configmap.WebhookInstrument{{OwnerKinds: []string{"Deployment"}}},
+				Instrument:   services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",
@@ -583,7 +587,7 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "propagators written as OTEL_PROPAGATORS",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument:  configmap.WebhookInstrument{{OwnerKinds: []string{"Deployment"}}},
+				Instrument:  services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
 				Propagators: []string{"tracecontext", "baggage"},
 			}},
 			endpoint: "http://otel:4318",
@@ -599,8 +603,8 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "exclude_instrument becomes a leading skip rule",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument:        configmap.WebhookInstrument{{OwnerKinds: []string{"Deployment"}}},
-				ExcludeInstrument: configmap.WebhookInstrument{{OwnerKinds: []string{"DaemonSet"}}},
+				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
+				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &daemonSet}}},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",

--- a/pkg/webhook/state_configmap_test.go
+++ b/pkg/webhook/state_configmap_test.go
@@ -523,9 +523,7 @@ func TestBuildInjectConfig(t *testing.T) {
 		}
 	}
 
-	deployment := services.NewGlob("Deployment")
-	statefulSet := services.NewGlob("StatefulSet")
-	daemonSet := services.NewGlob("DaemonSet")
+	test := services.NewGlob("test")
 
 	tests := []struct {
 		name     string
@@ -534,6 +532,25 @@ func TestBuildInjectConfig(t *testing.T) {
 		protocol string
 		want     configmap.InjectConfig
 	}{
+		{
+			name: "exclude_instrument becomes a leading skip rule",
+			cfg: beyla.Config{Injector: beyla.SDKInject{
+				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrDeploymentName: &test}}},
+				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrDaemonSetName: &test}}},
+			}},
+			endpoint: "http://otel:4318",
+			protocol: "http/protobuf",
+			want: configmap.InjectConfig{Rules: []configmap.Rule{
+				{
+					Selector: configmap.K8sSelector{OwnerKinds: []string{"DaemonSet"}, OwnerNames: []services.GlobAttr{test}},
+					Config:   configmap.RuleConfig{Mode: configmap.ModeSkip},
+				},
+				{
+					Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}, OwnerNames: []services.GlobAttr{test}},
+					Config:   configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "http/protobuf")},
+				},
+			}},
+		},
 		{
 			name:     "empty instrument yields empty config",
 			cfg:      beyla.Config{Injector: beyla.SDKInject{}},
@@ -544,12 +561,12 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "single selector becomes one rule with all default env vars",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
+				Instrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrDeploymentName: &test}}},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",
 			want: configmap.InjectConfig{Rules: []configmap.Rule{{
-				Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}},
+				Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}, OwnerNames: []services.GlobAttr{test}},
 				Config:   configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "http/protobuf")},
 			}}},
 		},
@@ -557,29 +574,29 @@ func TestBuildInjectConfig(t *testing.T) {
 			name: "multiple selectors each get the same env",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
 				Instrument: services.GlobDefinitionCriteria{
-					{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}},
-					{Metadata: services.MetadataGlobMap{"k8s_kind": &statefulSet}},
+					{Metadata: services.MetadataGlobMap{services.AttrDeploymentName: &test}},
+					{Metadata: services.MetadataGlobMap{services.AttrStatefulSetName: &test}},
 				},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "grpc",
 			want: configmap.InjectConfig{Rules: []configmap.Rule{
-				{Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}}, Config: configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "grpc")}},
-				{Selector: configmap.K8sSelector{OwnerKinds: []string{"StatefulSet"}}, Config: configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "grpc")}},
+				{Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}, OwnerNames: []services.GlobAttr{test}}, Config: configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "grpc")}},
+				{Selector: configmap.K8sSelector{OwnerKinds: []string{"StatefulSet"}, OwnerNames: []services.GlobAttr{test}}, Config: configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "grpc")}},
 			}},
 		},
 		{
 			name: "ImageVersion is set at the top level",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
 				ImageVersion: "ghcr.io/grafana/beyla/inject-sdk-image:v1.2.3",
-				Instrument:   services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
+				Instrument:   services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrDeploymentName: &test}}},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",
 			want: configmap.InjectConfig{
 				ImageVersion: "ghcr.io/grafana/beyla/inject-sdk-image:v1.2.3",
 				Rules: []configmap.Rule{{
-					Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}},
+					Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}, OwnerNames: []services.GlobAttr{test}},
 					Config:   configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "http/protobuf")},
 				}},
 			},
@@ -587,37 +604,18 @@ func TestBuildInjectConfig(t *testing.T) {
 		{
 			name: "propagators written as OTEL_PROPAGATORS",
 			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument:  services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
+				Instrument:  services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{services.AttrDeploymentName: &test}}},
 				Propagators: []string{"tracecontext", "baggage"},
 			}},
 			endpoint: "http://otel:4318",
 			protocol: "http/protobuf",
 			want: configmap.InjectConfig{Rules: []configmap.Rule{{
-				Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}},
+				Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}, OwnerNames: []services.GlobAttr{test}},
 				Config: configmap.RuleConfig{Env: append(
 					defaultEnv("http://otel:4318", "http/protobuf"),
 					corev1.EnvVar{Name: "OTEL_PROPAGATORS", Value: "tracecontext,baggage"},
 				)},
 			}}},
-		},
-		{
-			name: "exclude_instrument becomes a leading skip rule",
-			cfg: beyla.Config{Injector: beyla.SDKInject{
-				Instrument:        services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &deployment}}},
-				ExcludeInstrument: services.GlobDefinitionCriteria{{Metadata: services.MetadataGlobMap{"k8s_kind": &daemonSet}}},
-			}},
-			endpoint: "http://otel:4318",
-			protocol: "http/protobuf",
-			want: configmap.InjectConfig{Rules: []configmap.Rule{
-				{
-					Selector: configmap.K8sSelector{OwnerKinds: []string{"DaemonSet"}},
-					Config:   configmap.RuleConfig{Mode: configmap.ModeSkip},
-				},
-				{
-					Selector: configmap.K8sSelector{OwnerKinds: []string{"Deployment"}},
-					Config:   configmap.RuleConfig{Env: defaultEnv("http://otel:4318", "http/protobuf")},
-				},
-			}},
 		},
 	}
 


### PR DESCRIPTION
We had a discussion with @mariomac on the new SDK injection format, which is dictated by the controller. The configuration looked strange if we kept this format, since the eBPF service definitions are completely different to the injector. While we expect this configuration to be used by Alloy only, where these definitions incompatibility was hidden via Alloy config translation, it's also messy and maybe we'll find uses for the beyla direct config.

Secondly, we were pulling the endpoint and the protocol from the traces config of Beyla. We cannot assume that Beyla eBPF is configured to export traces, it's actually likely it's only configured to export metrics. If we forced the OTLP endpoint to be set, to trigger the traces export, we'd inadvertently start exporting Beyla traces, which is undesirable. To fix this:

1. I introduced back the SDK Injector endpoint and protocol config options.
2. I removed the parsing complexity of the endpoint. The parsing wouldn't actually work for gRPC since OBI doesn't export  the gRPC scheme back and it might fail altogether on unix sockets. 