### PR TITLE
SDK Injector: refine endpoint definition

### DIFF
--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -68,23 +69,9 @@ func (pm *PodMutator) Protocol() string { return pm.proto }
 func NewPodMutator(cfg *beyla.Config, matcher *PodMatcher, metrics *SDKInjectionMetrics) (*PodMutator, error) {
 	var opts otelcfg.OTLPOptions
 
-	// Beyla may not be configured to produce traces at all. We first check if the injector has
-	// been supplied an endpoint and protocol and if not, then we pull out the endpoint and the
-	// protocol from Beyla's traces configuration.
-	protocol := cfg.Injector.Protocol
-	endpoint := cfg.Injector.Endpoint
-
-	if endpoint == "" {
-		protocol = cfg.Traces.GetProtocol()
-		var common bool
-		endpoint, common = cfg.Traces.OTLPTracesEndpoint()
-		if !common {
-			endpoint = strings.TrimSuffix(endpoint, "/v1/traces")
-		}
-	}
-
-	if protocol == "" {
-		protocol = otelcfg.ProtocolHTTPProtobuf
+	protocol, endpoint, err := protoEndpoint(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	logger := slog.Default().With("component", "webhook")
@@ -98,6 +85,50 @@ func NewPodMutator(cfg *beyla.Config, matcher *PodMatcher, metrics *SDKInjection
 		exportHeaders: opts.Headers,
 		proto:         string(protocol),
 	}, nil
+}
+
+// protoEnpoint returns the most likely endpoint from the Beyla configuration.
+// Known issue 1: there are some edge cases, like Beyla defining only a traces exporter
+// but configuring the injector to export only metrics. In this case, Beyla would
+// anyway silently assign the Traces OTLP endpoint to the SDK injector.
+// Known issue 2: Beyla might configure different endpoints for both metrics and traces,
+// but would pass only the traces endpoint to the injected SDK, to submit all the signals.
+func protoEndpoint(cfg *beyla.Config) (otelcfg.Protocol, string, error) {
+	// check if the injector has been supplied an endpoint and protocol and if not,
+	// then we pull out the endpoint and the protocol from Beyla's configuration.
+	protocol := cfg.Injector.Protocol
+	endpoint := cfg.Injector.Endpoint
+
+	// If the SDK injector is configured to export traces, try first to get the traces endpoint
+	if endpoint == "" && cfg.Injector.ExportedSignals.TracesEnabled() {
+		protocol = cfg.Traces.GetProtocol()
+		var common bool
+		endpoint, common = cfg.Traces.OTLPTracesEndpoint()
+		if !common {
+			endpoint = strings.TrimSuffix(endpoint, "/v1/traces")
+		}
+	}
+
+	// fallback to the metrics endpoint
+	if endpoint == "" {
+		protocol = cfg.OTELMetrics.GetProtocol()
+		var common bool
+		if endpoint, common = cfg.OTELMetrics.OTLPMetricsEndpoint(); !common {
+			endpoint = strings.TrimSuffix(endpoint, "/v1/metrics")
+		}
+	}
+
+	// edge case: Beyla is working in Prometheus-only mode and
+	// the user defines an inject section without an OTEL endpoint
+	if endpoint == "" {
+		return "", "", errors.New("working with OTEL SDK injection requires defining an OTLP endpoint")
+	}
+
+	if protocol == "" {
+		protocol = otelcfg.ProtocolHTTPProtobuf
+	}
+
+	return protocol, endpoint, nil
 }
 
 func errorResponse(admResponse *admissionv1.AdmissionResponse, message string) {

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 
 	"github.com/grafana/beyla/v3/pkg/beyla"
@@ -1035,4 +1036,55 @@ func TestProcessMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProtocolEndpoint(t *testing.T) {
+	type testCase struct {
+		name           string
+		cfg            beyla.Config
+		expectEndpoint string
+		expectProtocol string
+	}
+	// TODO: replace by new(false) after we upgrade to Go 1.26
+	falseVal := false
+	for _, tc := range []testCase{{
+		name:           "Override endpoint and proto",
+		cfg:            beyla.Config{Injector: beyla.SDKInject{Endpoint: "http://foo:4356", Protocol: "grpc"}},
+		expectEndpoint: "http://foo:4356",
+		expectProtocol: "grpc",
+	}, {
+		name:           "Default protocol",
+		cfg:            beyla.Config{Injector: beyla.SDKInject{Endpoint: "http://foo:4356"}},
+		expectEndpoint: "http://foo:4356",
+		expectProtocol: "http/protobuf",
+	}, {
+		name: "Defines both OTLP endpoints. Traces enabled",
+		cfg: beyla.Config{
+			Traces:      otelcfg.TracesConfig{Protocol: "http/json", TracesEndpoint: "http://traces:4356/v1/traces"},
+			OTELMetrics: otelcfg.MetricsConfig{MetricsEndpoint: "http://metrics:4356/v1/metrics"},
+		},
+		expectProtocol: "http/json",
+		expectEndpoint: "http://traces:4356",
+	}, {
+		name: "Defines both OTLP endpoints. Traces disabled",
+		cfg: beyla.Config{
+			Injector:    beyla.SDKInject{ExportedSignals: configmap.SDKExportedSignals{Traces: &falseVal}},
+			Traces:      otelcfg.TracesConfig{TracesEndpoint: "http://traces:4356/v1/traces"},
+			OTELMetrics: otelcfg.MetricsConfig{Protocol: "http/json", MetricsEndpoint: "http://metrics:4356/v1/metrics"},
+		},
+		expectProtocol: "http/json",
+		expectEndpoint: "http://metrics:4356",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			protocol, endpoint, err := protoEndpoint(&tc.cfg)
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.expectProtocol, protocol)
+			assert.Equal(t, tc.expectEndpoint, endpoint)
+		})
+	}
+}
+
+func TestProtocolEndpoit_Error(t *testing.T) {
+	_, _, err := protoEndpoint(&beyla.Config{Prometheus: prom.PrometheusConfig{Port: 9090}})
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Overall, the endpoint for the injected SDKs will be (from highest to lowest priority):

1. `sdk_inject > exporter_otlp_endpoint` if defined
2. `otel_traces_export > endpoint` if defined and the injector is configured to send traces
3. `otel_metrics_export > endpoint`
4. Return error if no OTLP endpoints are defined (e.g. Beyla operating in Prometheus mode)
