### PR TITLE
Add Hash() method to injector's RuleConfig type

### DIFF
--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -144,8 +144,11 @@ func (c *RuleConfig) Hash() uint64 {
 		hasher.Write([]byte(c.Env[i].Value))
 		hasher.Write(delimiter)
 		if c.Env[i].ValueFrom != nil {
+			// Known limitation: if the referenced value changes (e.g. a referenced secret is rotated),
+			// we won't notice any change in the calculated hash
 			valueFrom, _ := c.Env[i].ValueFrom.Marshal()
 			hasher.Write(valueFrom)
+			hasher.Write(delimiter)
 		}
 	}
 	return hasher.Sum64()

--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -12,7 +12,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -124,6 +127,28 @@ type RuleConfig struct {
 	// declarative config (file_format: "1.0") as a ConfigMap and set
 	// OTEL_CONFIG_FILE on matched containers. Requires volume mount + env var
 	// injection in the mutator before this field can be added to the schema.
+}
+
+var delimiter = []byte{255}
+
+func (c *RuleConfig) Hash() uint64 {
+	hasher := fnv.New64()
+	hasher.Write([]byte(c.Mode))
+	slices.SortStableFunc(c.Env, func(a, b corev1.EnvVar) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	for i := range c.Env {
+		hasher.Write(delimiter)
+		hasher.Write([]byte(c.Env[i].Name))
+		hasher.Write(delimiter)
+		hasher.Write([]byte(c.Env[i].Value))
+		hasher.Write(delimiter)
+		if c.Env[i].ValueFrom != nil {
+			valueFrom, _ := c.Env[i].ValueFrom.Marshal()
+			hasher.Write(valueFrom)
+		}
+	}
+	return hasher.Sum64()
 }
 
 // Skips reports whether this config excludes matched pods from instrumentation.

--- a/pkg/webhook/configmap/types_test.go
+++ b/pkg/webhook/configmap/types_test.go
@@ -93,3 +93,63 @@ func TestEnvVarsRoundTrip(t *testing.T) {
 	require.Len(t, got.Rules, 1)
 	assert.Equal(t, in.Rules[0].Config.Env, got.Rules[0].Config.Env)
 }
+
+func TestRuleConfigHash(t *testing.T) {
+	pastValues := map[uint64]struct{}{}
+	rc := RuleConfig{
+		Mode: ModeInstall,
+		Env:  EnvVars{{Name: "OTEL_LOGS_EXPORTER", Value: "none"}, {Name: "API_KEY", Value: "api-key"}},
+	}
+	testHashChanged := func(t *testing.T) {
+		h := rc.Hash()
+		assert.NotContains(t, pastValues, h)
+		pastValues[h] = struct{}{}
+	}
+
+	h := rc.Hash()
+	assert.NotZero(t, h)
+	pastValues[h] = struct{}{}
+	// multiple calls returns always the same value
+	assert.Equal(t, h, rc.Hash())
+	assert.Equal(t, h, rc.Hash())
+	assert.Equal(t, h, rc.Hash())
+
+	// Changing the order of the env vars does not affect the hash result
+	rc.Env = EnvVars{{Name: "API_KEY", Value: "api-key"}, {Name: "OTEL_LOGS_EXPORTER", Value: "none"}}
+	assert.Equal(t, h, rc.Hash())
+
+	// Changing the mode affects the hash result
+	rc.Mode = ModeSkip
+	testHashChanged(t)
+
+	// Adding an env var changes the hash result
+	rc.Env = append(rc.Env, corev1.EnvVar{Name: "OTEL_ENDPOINT", ValueFrom: &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"},
+	}})
+
+	testHashChanged(t)
+
+	// removing an env var changes the hash result
+	rc.Env = rc.Env[1:]
+	testHashChanged(t)
+
+	// Changing a variable name changes the hash result
+	rc.Env[0].Name = "OTEL_SAMPLER"
+	testHashChanged(t)
+
+	// Changing a variable value changes the hash result
+	rc.Env[0].Value = "always_on"
+	testHashChanged(t)
+
+	// Changing ValueFrom changes the hash result
+	rc.Env[1].ValueFrom = &corev1.EnvVarSource{
+		ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+		},
+	}
+	testHashChanged(t)
+
+	// Ditto
+	rc.Env[1].ValueFrom = &corev1.EnvVarSource{}
+	testHashChanged(t)
+}


### PR DESCRIPTION
This will allow detecting when a instrumented pod configuration has changed and needs to be restarted.