### PR TITLE
Replace FNV1 by FNV1a in ruleconfig hashing

### DIFF
--- a/pkg/webhook/configmap/types.go
+++ b/pkg/webhook/configmap/types.go
@@ -132,7 +132,7 @@ type RuleConfig struct {
 var delimiter = []byte{255}
 
 func (c *RuleConfig) Hash() uint64 {
-	hasher := fnv.New64()
+	hasher := fnv.New64a()
 	hasher.Write([]byte(c.Mode))
 	slices.SortStableFunc(c.Env, func(a, b corev1.EnvVar) int {
 		return strings.Compare(a.Name, b.Name)


### PR DESCRIPTION
Both have the same computational cost. But theoretically, FNV-1a has better distribution and lower collision rate: http://isthe.com/chongo/tech/comp/fnv/