### PR TITLE
ci: fix unit test workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,19 +21,11 @@ jobs:
     timeout-minutes: 45
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-    # Grant specific permissions needed for DockerHub login via Vault OIDC
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           submodules: true
-
-      - name: Login to DockerHub
-        if: github.repository == 'grafana/beyla' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
-        uses: grafana/shared-workflows/actions/dockerhub-login@e5b7989c92b55fe3ac6dd006d6de49082ba8c507
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -272,6 +272,7 @@ network:
 				instrumentations.InstrumentationMongo,
 				instrumentations.InstrumentationCouchbase,
 				instrumentations.InstrumentationMemcached,
+				instrumentations.InstrumentationSunRPC,
 				// no traces for DNS and GPU by default
 			},
 		},
@@ -382,8 +383,9 @@ network:
 					Metadata: map[string]*services.GlobAttr{"k8s_container_name": &servicesextra.K8sDefaultExcludeContainerNamesGlob},
 				},
 			},
-			DefaultOtlpGRPCPort:   4317,
-			RouteHarvesterTimeout: 10 * time.Second,
+			DefaultOtlpGRPCPort:     4317,
+			RouteHarvesterTimeout:   10 * time.Second,
+			DisabledRouteHarvesters: []services.RouteHarvesterLanguage{services.RouteHarvesterLanguageJava},
 			RouteHarvestConfig: servicesextra.RouteHarvestingConfig{
 				JavaHarvestDelay: 60 * time.Second,
 			},


### PR DESCRIPTION
Pull requests checks action is failing silently:

- https://github.com/grafana/beyla/actions/runs/27753575892?pr=2905

Apparently this may be due to GitHub's secret masking behaviour, where the docker hub username overlaps with the matrix output, causing the matrix to be emptied and no shards being created.

The only image that is pulled in the generate job is obi-generator, which comes from GHCR anyway - so we can remove the docker hub login and associated permissions.

The action can be seen working again here:

- https://github.com/grafana/beyla/actions/runs/27754346846?pr=2906

The tests are now running again on this PR, I got the agent to finish the partial OBI update which was missed due to the broken workflow.