### PR TITLE
feat: enable helm chart signing

### DIFF
--- a/.github/configs/cr.yml
+++ b/.github/configs/cr.yml
@@ -1,3 +1,5 @@
 owner: grafana
 git-repo: helm-charts
 skip-existing: true
+release-name-template: "{{ .Name }}-{{ .Version }}"
+sign: true

--- a/.github/configs/cr.yml
+++ b/.github/configs/cr.yml
@@ -1,5 +1,4 @@
 owner: grafana
 git-repo: helm-charts
 skip-existing: true
-release-name-template: "{{ .Name }}-{{ .Version }}"
 sign: true

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   release-beyla-helm-chart:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@hackathon-17-verify-all-the-charts
     permissions:
       contents: "write"
       id-token: "write"


### PR DESCRIPTION
As part of Hackathon 17 we're adding signing support to our helm charts via the `update-helm-repo` action. You can see this in action [here](https://github.com/grafana/k8s-manifest-tail/releases/tag/k8s-manifest-tail-0.1.5).

I noticed this chart doesn't have a local release in this repo like k8s-manifest-tail or k8s-monitoring. If you want we can add that, but it doesn't have anything to do with signing.

Draft until we get the proper secrets setup.