### PR TITLE
helm-chart-bump: sign the bump commit

### DIFF
--- a/.github/workflows/helm-chart-bump.yml
+++ b/.github/workflows/helm-chart-bump.yml
@@ -154,6 +154,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
+          sign-commits: true # repo ruleset requires verified signatures; sign via the GitHub App token
           commit-message: "Bump Helm chart for Beyla ${{ inputs.version_tag }}"
           title: "Bump Helm chart for Beyla ${{ inputs.version_tag }}"
           body: |


### PR DESCRIPTION
The Bump Helm chart workflow's "Create or update PR" step pushed an unsigned commit, which is now rejected by the repository ruleset:

  GH013: Repository rule violations found
  - Commits must have verified signatures.

peter-evans/create-pull-request signs commits via the GitHub API when `sign-commits: true` and a GitHub App token is supplied (as here), so the resulting commit is verified and passes the ruleset.