### PR TITLE
fix(ci): helm-release requires signed commits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,20 @@
     },
     {
       customType: 'regex',
+      description: 'Track grafana/helm-charts update-helm-repo reusable workflow (referenced by bare commit SHA on main, which the standard github-actions manager cannot track)',
+      managerFilePatterns: [
+        '/^\\.github/workflows/helm-release\\.yml$/',
+      ],
+      matchStrings: [
+        'update-helm-repo\\.yaml@(?<currentDigest>[a-f0-9]{40})',
+      ],
+      depNameTemplate: 'grafana/helm-charts',
+      packageNameTemplate: 'https://github.com/grafana/helm-charts',
+      datasourceTemplate: 'git-refs',
+      currentValueTemplate: 'main',
+    },
+    {
+      customType: 'regex',
       description: 'Update opentelemetry-injector version',
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'open-telemetry/opentelemetry-injector',
@@ -130,6 +144,19 @@
         'digest',
         'minor',
         'major',
+      ],
+      schedule: [
+        'before 8am on Wednesday',
+      ],
+    },
+    {
+      description: 'Group the helm-charts reusable workflow bump with the other GitHub Actions updates',
+      groupName: 'Github Actions',
+      matchManagers: [
+        'custom.regex',
+      ],
+      matchFileNames: [
+        '.github/workflows/helm-release.yml',
       ],
       schedule: [
         'before 8am on Wednesday',

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   release-beyla-helm-chart:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@d7c4f4491dbe46d853833cd15a35159c28061f39
     permissions:
       contents: "write"
       id-token: "write"

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.151.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.151.0
 	go.opentelemetry.io/collector/pdata v1.57.0
-	go.opentelemetry.io/obi v0.9.0
+	go.opentelemetry.io/obi v0.10.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -805,7 +805,7 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/inte
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv
-# go.opentelemetry.io/obi v0.9.0 => ./.obi-src
+# go.opentelemetry.io/obi v0.10.0 => ./.obi-src
 ## explicit; go 1.25.11
 go.opentelemetry.io/obi/pkg/appolly
 go.opentelemetry.io/obi/pkg/appolly/app


### PR DESCRIPTION
The helm-release workflow [failed](https://github.com/grafana/beyla/actions/runs/28453120190/job/84320608127) with:

```
Pushing to branch "gh-pages"
remote: error: GH013: Repository rule violations found for refs/heads/gh-pages.        
remote: Review all repository rules at https://github.com/grafana/helm-charts/rules?ref=refs%2Fheads%2Fgh-pages        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation:        
remote: 
remote:   b669f00b8a6a7c3d9b5802dc24c41aa5e01e7f3c        
remote: 
To https://github.com/grafana/helm-charts
 ! [remote rejected]   HEAD -> gh-pages (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/grafana/helm-charts'
Error: exit status 1
```

This was fixed upstream in a newer version of the shared workflow.

As we're pinned to a `main` SHA of the shared workflow, I updated the Renovate config to be able to pick up future changes and roll them into our existing GitHub Actions weekly group.

Also found `go.mod` and `modules.txt` to be outdated.