### PR TITLE
Update helm to mount tracefs for tracepoints

### DIFF
--- a/charts/beyla/templates/daemon-set.yaml
+++ b/charts/beyla/templates/daemon-set.yaml
@@ -126,6 +126,8 @@ spec:
           {{- if .Values.contextPropagation.enabled }}
             - mountPath: /sys/fs/cgroup
               name: cgroup
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
           {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -158,6 +160,9 @@ spec:
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
       {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/docs/sources/configure/controlling-instrumentation.md
+++ b/docs/sources/configure/controlling-instrumentation.md
@@ -49,6 +49,8 @@ To use this option in containerized environments (Kubernetes and Docker), you mu
 
 - Deploy Beyla as a `DaemonSet` with host network access `hostNetwork: true`
 - Volume mount the `/sys/fs/cgroup` path from the host as local `/sys/fs/cgroup` path
+- The `/sys/kernel/tracing` path from the host must be volume mounted as local `/sys/kernel/tracing` path, because of the
+  mitigation code added to handle the [FIONREAD kernel bug](https://lore.kernel.org/bpf/CAOvpEWN6xgFx4GWFnnWLGCB+_1auDcAZPYPSv1PDu3UfXkcriw@mail.gmail.com/t/#r36b3618483204331fed2978fbaa67be0cb6ad975).
 - Grant the `CAP_NET_ADMIN` capability to the Beyla container
 
 gRPC and HTTP2 are not supported.

--- a/docs/sources/distributed-traces.md
+++ b/docs/sources/distributed-traces.md
@@ -65,6 +65,8 @@ The recommended way to deploy Beyla on Kubernetes with distributed tracing suppo
 The following `Kubernetes` configuration must be used:
 - Beyla must be deployed as a `DaemonSet` with host network access (`hostNetwork: true`).
 - The `/sys/fs/cgroup` path from the host must be volume mounted as local `/sys/fs/cgroup` path.
+- The `/sys/kernel/tracing` path from the host must be volume mounted as local `/sys/kernel/tracing` path, because of the
+  mitigation code added to handle the [FIONREAD kernel bug](https://lore.kernel.org/bpf/CAOvpEWN6xgFx4GWFnnWLGCB+_1auDcAZPYPSv1PDu3UfXkcriw@mail.gmail.com/t/#r36b3618483204331fed2978fbaa67be0cb6ad975).
 - The `CAP_NET_ADMIN` capability must be granted to the Beyla container.
 
 The following YAML snippet shows an example Beyla deployment configuration:
@@ -105,6 +107,8 @@ The following YAML snippet shows an example Beyla deployment configuration:
         volumeMounts:
           - name: cgroup
             mountPath: /sys/fs/cgroup # <-- Important. Allows Beyla to monitor all newly sockets to track outgoing requests.
+          - name: tracefs # <-- Important. Allows Beyla to mitigate the FIONREAD kernel bug for the broken kernel versions.
+            mountPath: /sys/kernel/tracing  
           - mountPath: /config
             name: beyla-config
       tolerations:
@@ -119,6 +123,9 @@ The following YAML snippet shows an example Beyla deployment configuration:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
+      - name: tracefs
+        hostPath:
+          path: /sys/kernel/tracing
 ```
 
 If `/sys/fs/cgroup` is not mounted as a local volume path for the Beyla `DaemonSet` some requests may not
@@ -155,6 +162,7 @@ services:
     volumes:
       - /sys/kernel/security:/sys/kernel/security
       - /sys/fs/cgroup:/sys/fs/cgroup
+      - /sys/kernel/tracing:/sys/kernel/tracing
 ```
 
 If the `/sys/kernel/security/` volume is not mounted, Beyla assumes that the Linux Kernel is not running in integrity mode.

--- a/docs/sources/setup/kubernetes.md
+++ b/docs/sources/setup/kubernetes.md
@@ -298,7 +298,7 @@ spec:
               - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
               - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
               #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
-              #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+              - SYS_ADMIN           # <-- Required for user space probes, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
             drop:
               - ALL
         volumeMounts:
@@ -306,6 +306,8 @@ spec:
           mountPath: /var/run/beyla
         - name: cgroup
           mountPath: /sys/fs/cgroup
+        - name: tracefs # <-- Important. Allows Beyla to mitigate the FIONREAD kernel bug for the broken kernel versions.
+          mountPath: /sys/kernel/tracing  
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -317,6 +319,9 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
+      - name: tracefs
+        hostPath:
+          path: /sys/kernel/tracing
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/k8s/unprivileged.yaml
+++ b/examples/k8s/unprivileged.yaml
@@ -118,7 +118,7 @@ spec:
               - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
               - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
               #- SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
-              #- SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+              - SYS_ADMIN           # <-- Required for user space probes, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
             drop:
               - ALL
         volumeMounts:
@@ -126,6 +126,8 @@ spec:
           mountPath: /var/run/beyla
         - name: cgroup
           mountPath: /sys/fs/cgroup
+        - name: tracefs # <-- Important. Allows Beyla to mitigate the FIONREAD kernel bug for the broken kernel versions.
+          mountPath: /sys/kernel/tracing  
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -137,6 +139,9 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
+      - name: tracefs
+        hostPath:
+          path: /sys/kernel/tracing
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The OBI fix https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2580 added mitigation code to handle broken linux kernels with the bug exposed by our use of sock_maps. However, the fix was added with normal tracepoints (not raw tracepoints), which require that tracefs is mounted.

This PR adds the tracefs mount and updates the docs. I also fixed the docs for SYS_ADMIN, which is required on all new kernels for uprobes to work.