### PR TITLE
fix(examples/greeting-apps): fix tempo/mimir startup failures

### DIFF
--- a/examples/greeting-apps/configs/tempo-config.yaml
+++ b/examples/greeting-apps/configs/tempo-config.yaml
@@ -37,4 +37,6 @@ storage:
       path: /tmp/tempo/blocks
 
 overrides:
-  metrics_generator_processors: ["service-graphs", "span-metrics"]
+  defaults:
+    metrics_generator:
+      processors: ["service-graphs", "span-metrics"]

--- a/examples/greeting-apps/configs/tempo-config.yaml
+++ b/examples/greeting-apps/configs/tempo-config.yaml
@@ -11,7 +11,9 @@ distributor:
     otlp:
       protocols:
         http:
+          endpoint: 0.0.0.0:4318
         grpc:
+          endpoint: 0.0.0.0:4317
 
 metrics_generator:
   ring:

--- a/examples/greeting-apps/docker-compose.yaml
+++ b/examples/greeting-apps/docker-compose.yaml
@@ -166,6 +166,7 @@ services:
       - -server.grpc-listen-port=9096
     volumes:
       - ./configs/:/etc/mimir
+      - ./system/mimir-rules:/tmp/mimir/rules
     ports:
       - "9009:9009"
       - "9096:9096"


### PR DESCRIPTION
## Summary
- Tempo failed to start because `overrides` used the legacy flat format, which Tempo 3.0 disables by default.
- Tempo's OTLP receiver had no explicit endpoint, so it defaulted to `localhost` (per the vendored opentelemetry-collector `otlpreceiver`), making it unreachable from the `agent` container and causing trace export to fail with `connection refused`.
- Mimir's ruler crashed on startup because its local rule storage directory (`/tmp/mimir/rules`) didn't exist in the container and Mimir doesn't create it automatically.

Verified by running the full `docker compose up` stack and confirming:
- `demo-tempo` and `demo-mimir` reach a stable `Up` state instead of `Exited (1)`.
- Beyla-generated traces are received by Tempo's distributor (`tempo_distributor_traces_per_batch_count` increments, `/api/search` returns results).
- Metrics continue to flow into Mimir as before.

## Test plan
- [x] `docker compose up -d` in `examples/greeting-apps` — all services reach `Up`
- [x] Generate traffic via `loadgen.sh` and confirm Beyla-produced traces appear in Tempo (`/api/search`)
- [x] Confirm Mimir metrics (`http_server_request_duration_seconds_count`, etc.) are queryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)