### PR TITLE
Decouple beyla and alloy beyla tags

### DIFF
--- a/.github/workflows/deploy-alloy-beyla-dev.yml
+++ b/.github/workflows/deploy-alloy-beyla-dev.yml
@@ -54,8 +54,9 @@ jobs:
           fi
           SHORT_SHA="$(git rev-parse --short HEAD)"
           echo "image_tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "alloy-beyla dev image tag: ${IMAGE_TAG}, beyla short SHA: ${SHORT_SHA}"
+          echo "alloy-beyla dev image tag: ${IMAGE_TAG}, beyla image tag: ${VERSION}, beyla short SHA: ${SHORT_SHA}"
 
       - name: Log in to Google Artifact Registry
         uses: grafana/shared-workflows/actions/login-to-gar@00646b30431b955ec3c00982b23b1eeb7b66445b # v1.0.0
@@ -70,6 +71,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
           SHORT_SHA: ${{ steps.tag.outputs.short_sha }}
         # zizmor: ignore[template-injection] CONFIG_JSON is locally generated and passed as plain string
         run: |
@@ -92,7 +94,7 @@ jobs:
               {
                 "file_path": "ksonnet/environments/beyla/versions.libsonnet",
                 "jsonnet_key_path": "dev.container_image_tag",
-                "jsonnet_value": "${IMAGE_TAG}"
+                "jsonnet_value": "${VERSION}"
               },
               {
                 "file_path": "ksonnet/environments/beyla/versions.libsonnet",


### PR DESCRIPTION
The deploy alloy beyla to dev wave workflow (and the build alloy beyla workflow) accept a build suffix parameter to the version, so you can end up with a version tag such as `v3.28.0-1`. This is _not_ the case with the regular non alloy beyla version, which always has `v3.28.0`.

This PR decouples the version to allow us to keep bumping alloy beyla images without bumping the cache version (which will not exist).