### PR TITLE
Docs: undocument go install as installation method

### DIFF
--- a/docs/sources/quickstart/golang.md
+++ b/docs/sources/quickstart/golang.md
@@ -26,13 +26,6 @@ go run quickstart.go
 Download the latest Beyla executable from the [Beyla releases page](https://github.com/grafana/beyla/releases).
 Uncompress and copy the Beyla executable to any location in your `$PATH`.
 
-As an alternative (if your host has the Go toolset installed), you can directly download the
-Beyla executable with the `go install` command:
-
-```sh
-go install github.com/grafana/beyla/cmd/beyla@latest
-```
-
 ## 3. (Optional) get Grafana Cloud credentials
 
 Beyla can export metrics and traces to any OpenTelemetry endpoint, as well as exposing metrics as a Prometheus endpoint. However, we recommend using the OpenTelemetry endpoint in Grafana Cloud. You can get a [Free Grafana Cloud Account at Grafana's website](/pricing/).

--- a/docs/sources/setup/standalone.md
+++ b/docs/sources/setup/standalone.md
@@ -21,12 +21,6 @@ Beyla can run as a standalone Linux OS process with elevated privileges that can
 
 You can download the Beyla executable from the [Beyla releases page](https://github.com/grafana/beyla/releases).
 
-Alternatively, download the Beyla executable with the `go install` command:
-
-```sh
-go install github.com/grafana/beyla/cmd/beyla@latest
-```
-
 ## Installing as a service
 
 After you have Beyla installed on your system, you can use the


### PR DESCRIPTION
Despite we clearly specify a download location and describe `go install` as an alternative methods, some users complain about having to use `go install` to install Beyla. Probably there was something something in the doc "visuals" that take user's attention directly to the `go install` part.

`go install` might be useful for development purposes, but I don't think it's possible to use it in many production environments, so removing.