### PR TITLE
docs: document sensitive query parameter redaction

### DIFF
--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -262,6 +262,31 @@ And the following table describes the metrics and their associated groups.
 | `k8s_app_meta` | `gpu.kernel.block.size` | `gpu_kernel_block_size_total` |
 | `k8s_app_meta` | `gpu.memory.allocations` | `gpu_memory_allocations_bytes_total` |
 
+## Redact sensitive query parameters
+
+YAML section: `attributes`
+
+Beyla replaces the values of known-sensitive query parameters with `REDACTED` in the `url.full` and `url.query` trace attributes. The built-in list covers the parameters recommended by the OpenTelemetry HTTP semantic conventions (`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`, `AWSAccessKeyId`, `Signature`, `SecurityToken`, `X-Goog-Signature`, `sig`) along with common credential, session and payment parameter names such as `token`, `access_token`, `api_key`, `client_secret`, `password`, `otp`, `SAMLResponse`, `cvv` and `ssn`.
+
+| YAML<p>environment variable</p>             | Description                                                                                               | Type    | Default |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------- | ------- |
+| `sensitive_query_params.add`<p>`BEYLA_SENSITIVE_QUERY_PARAMS_ADD`</p> | Parameter names to redact in addition to the built-in list. | list of strings | (empty) |
+| `sensitive_query_params.remove`<p>`BEYLA_SENSITIVE_QUERY_PARAMS_REMOVE`</p> | Parameter names to drop from the built-in list. | list of strings | (empty) |
+
+The effective list is the built-in list, minus the names in `remove`, plus the names in `add`. When both options are empty, the built-in list is used unchanged. In the environment variables, the names are comma separated.
+
+```yaml
+attributes:
+  sensitive_query_params:
+    add:
+      - internal_token
+      - X-Tenant-Key
+    remove:
+      - sig
+```
+
+Names are matched exactly and are case sensitive, so `token` does not cover `Token`. Percent-encoded parameter names are decoded before matching, which means `?X-Amz-Signatur%65=v` is redacted like `?X-Amz-Signature=v`; the parameter name is exported as it appeared in the request, only the value is replaced.
+
 ## Configure cardinality limits
 
 YAML section: `attributes`

--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -266,7 +266,13 @@ And the following table describes the metrics and their associated groups.
 
 YAML section: `attributes`
 
-Beyla replaces the values of known-sensitive query parameters with `REDACTED` in the `url.full` and `url.query` trace attributes. The built-in list covers the parameters recommended by the OpenTelemetry HTTP semantic conventions (`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`, `AWSAccessKeyId`, `Signature`, `SecurityToken`, `X-Goog-Signature`, `sig`) along with common credential, session and payment parameter names such as `token`, `access_token`, `api_key`, `client_secret`, `password`, `otp`, `SAMLResponse`, `cvv` and `ssn`.
+Beyla replaces the values of known-sensitive query parameters with `REDACTED` in the `url.full` and `url.query` trace attributes.
+
+The built-in list is:
+
+`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`, `AWSAccessKeyId`, `Signature`, `SecurityToken`, `X-Goog-Signature`, `sig`, `token`, `access_token`, `refresh_token`, `id_token`, `jwt`, `session`, `sid`, `signature`, `api_key`, `apikey`, `client_secret`, `secret`, `password`, `pass`, `pwd`, `reset_token`, `invite_token`, `verify_token`, `otp`, `totp`, `mfa_code`, `verification_code`, `SAMLResponse`, `assertion`, `card`, `cc`, `pan`, `cvv`, `ssn`, `tax_id`.
+
+The first eight come from the [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/); the rest are common credential, session and payment parameter names. The list is defined in [`attr_selector.go`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/pkg/export/attributes/attr_selector.go) in OpenTelemetry eBPF Instrumentation.
 
 | YAML<p>environment variable</p>             | Description                                                                                               | Type    | Default |
 | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------- | ------- |


### PR DESCRIPTION
Closes #2987.

Documents `attributes.sensitive_query_params.add` / `remove` in the metrics and traces attributes page: what the built-in list covers, how the effective list is composed, and a YAML example.

Two details worth calling out, both taken from `queryscrub.go` in the vendored OBI:

- matching is exact and case sensitive (`buildRedactSet` builds a plain map and `scrubQuery` looks the key up as is), so `token` does not cover `Token`
- the key is percent-decoded before the lookup, so `?X-Amz-Signatur%65=v` is redacted, while the exported attribute keeps the original spelling and only the value becomes `REDACTED`

The environment variables are documented under the `BEYLA_` names as in the issue; they reach the OBI config through the `BEYLA_` to `OTEL_EBPF_` duplication in `config_obi.go`.
