### PR TITLE
docs: document database client server port attribute

### DIFF
--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -39,6 +39,28 @@ attributes:
       exclude: ["k8s.pod.*"]
 ```
 
+### Select database client metric attributes
+
+The `db.client.operation.duration` (`db_client_operation_duration_seconds` in
+Prometheus) metric includes `server.port` by default when Beyla detects a valid
+database port. The `include` and `exclude` lists accept both `server.port` and
+its Prometheus-style name, `server_port`.
+
+For example, you can remove the port from the default attribute set by using
+the Prometheus-style names:
+
+```yaml
+attributes:
+  select:
+    db_client_operation_duration:
+      exclude: ["server_port"]
+```
+
+You can use `server.port` instead of `server_port` in the example; the two forms
+are equivalent. Including a server port can increase metric cardinality when an
+application connects to many database ports, so exclude it when that
+distinction isn't useful.
+
 Additionally, you can use wildcards as metric names to add and exclude attributes for groups of metrics with the same name. For example:
 
 ```yaml

--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -112,6 +112,7 @@ For more information about the OpenTelemetry semantic conventions for each metri
 | `db.client.operation.duration` | `db.system.name`             | shown                                             |
 | `db.client.operation.duration` | `db.query.text`              | hidden                                            |
 | `db.client.operation.duration` | `server.address`             | shown                                             |
+| `db.client.operation.duration` | `server.port`                | shown when a valid database port is available     |
 | `db.client.operation.duration` | `error.type`                 | shown                                             |
 | `messaging.publish.duration`   | `messaging.system`           | shown                                             |
 | `messaging.publish.duration`   | `messaging.destination.name` | shown                                             |


### PR DESCRIPTION
Closes #3079.

## What changed

- document the default `server.port` attribute for database client duration metrics
- clarify that `server.port` and `server_port` are equivalent in attribute selection
- add an exclusion example and call out the cardinality tradeoff
- add `server.port` to the default metric attribute table

The documentation is intentionally being submitted ahead of the scheduled OBI submodule bump, as agreed in the issue discussion.

## Validation

- Vale on the added documentation: 0 errors, 0 warnings, 0 suggestions
- `git diff --check`
