### PR TITLE
Restore service.name and namespace as metric attributes

### DIFF
--- a/docs/sources/configure/metrics-traces-attributes.md
+++ b/docs/sources/configure/metrics-traces-attributes.md
@@ -267,7 +267,10 @@ Beyla allows you to enhance your metrics with custom attributes using the `extra
 
 To use this feature, specify the group name and the list of attributes you want to include in that group.
 
-Currently, only the `k8s_app_meta` group is supported. This group contains Kubernetes-specific metadata such as Pod name, namespace, container name, Pod UID, and more.
+The following groups are supported:
+
+- `k8s_app_meta`: Kubernetes-specific metadata such as Pod name, namespace, container name, Pod UID, and more.
+- `app`: application-level attributes shared by most application metrics, such as `service.name` and `service.namespace`.
 
 Example configuration:
 
@@ -283,6 +286,8 @@ In this example:
 
 - Adding `k8s.app.version` to the `extra_group_attributes > k8s_app_meta` block causes the `k8s.app.version` label to appear in the metrics.
 - You can also define annotations with the prefix `resource.opentelemetry.io/` and suffix `k8s.app.version` in your Kubernetes manifests, these annotations are automatically included in the metrics.
+
+By default, Beyla sets `extra_group_attributes > app` to `["service.name", "service.namespace"]`, so these two attributes are reported both as OTEL resource attributes and as metric-level attributes. If you set `extra_group_attributes > app` yourself, your list replaces this default entirely.
 
 The following table describes the default group attributes.
 

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -567,6 +567,7 @@ func normalizeConfig(c *Config) {
 		c.Discovery.OverrideDefaultExcludeForSurvey()
 	}
 	c.Attributes.Select.Normalize()
+	defaultServiceNameMetricAttributes(c)
 	// backwards compatibility assumptions for the deprecated Metric feature sections in OTEL and Prom metrics config.
 	// Old, deprecated properties would take precedence over metrics > features, to avoid breaking changes.
 	if c.OTELMetrics.EndpointEnabled() && c.OTELMetrics.DeprFeatures != 0 {
@@ -586,6 +587,22 @@ func normalizeConfig(c *Config) {
 
 	// GenAI APIs are HTTP at the moment, so we only enable HTTP instrumentation for Sigil
 	c.SigilExport.Instrumentations = []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}
+}
+
+// defaultServiceNameMetricAttributes sets service.name and service.namespace as
+// default metric-level attributes (also being reported as Resource attributes),
+// which matches some Grafana Cloud metric queries.
+//
+// If the user has already configured the "app" extra_group_attributes group themselves,
+// their configuration is respected and this default is not applied.
+func defaultServiceNameMetricAttributes(c *Config) {
+	if _, userConfigured := c.Attributes.ExtraGroupAttributes["app"]; userConfigured {
+		return
+	}
+	if c.Attributes.ExtraGroupAttributes == nil {
+		c.Attributes.ExtraGroupAttributes = map[string][]attr.Name{}
+	}
+	c.Attributes.ExtraGroupAttributes["app"] = []attr.Name{attr.ServiceName, attr.ServiceNamespace}
 }
 
 func appendDefaultResourceLabels(dst []string) []string {

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -351,6 +351,7 @@ network:
 			},
 			ExtraGroupAttributes: map[string][]attr.Name{
 				"k8s_app_meta": {"k8s.app.version"},
+				"app":          {attr.ServiceName, attr.ServiceNamespace},
 			},
 			RenameUnresolvedHosts:          "unresolved",
 			RenameUnresolvedHostsOutgoing:  "outgoing",
@@ -435,6 +436,22 @@ func TestConfig_ServiceName(t *testing.T) {
 	cfg, err := LoadConfig(bytes.NewReader(nil))
 	require.NoError(t, err)
 	assert.Equal(t, "some-svc-name", cfg.ServiceName)
+}
+
+func TestConfig_DefaultServiceNameMetricAttributes(t *testing.T) {
+	cfg, err := LoadConfig(bytes.NewReader(nil))
+	require.NoError(t, err)
+	assert.Equal(t, []attr.Name{attr.ServiceName, attr.ServiceNamespace}, cfg.Attributes.ExtraGroupAttributes["app"])
+}
+
+func TestConfig_DefaultServiceNameMetricAttributes_UserOverride(t *testing.T) {
+	cfg, err := LoadConfig(bytes.NewBufferString(`
+attributes:
+  extra_group_attributes:
+    app: ["k8s.pod.uid"]
+`))
+	require.NoError(t, err)
+	assert.Equal(t, []attr.Name{"k8s.pod.uid"}, cfg.Attributes.ExtraGroupAttributes["app"])
 }
 
 func TestConfig_ShutdownTimeout(t *testing.T) {

--- a/pkg/export/extraattributes/attr_defaults_test.go
+++ b/pkg/export/extraattributes/attr_defaults_test.go
@@ -1,0 +1,36 @@
+package extraattributes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+)
+
+// service.name and service.namespace are always reported as OTEL resource
+// attributes (and joinable via target_info in Prometheus). Some Grafana Cloud
+// apps however, read service identity directly off the metric series,
+// so Beyla additionally wants these two attributes reported at the metric-attribute
+// level by default, unless overridden by the users.
+func TestServiceNameAndNamespace_DefaultOnAppMetrics(t *testing.T) {
+	for _, section := range []attributes.Name{
+		attributes.HTTPServerDuration,
+		attributes.HTTPClientDuration,
+		attributes.RPCServerDuration,
+		attributes.RPCClientDuration,
+	} {
+		t.Run(string(section.Section), func(t *testing.T) {
+			p, err := attributes.NewAttrSelector(0, &attributes.SelectorConfig{})
+			require.NoError(t, err)
+
+			got := p.For(section)
+			assert.Contains(t, got, attr.ServiceName,
+				"service.name should be reported by default on metric attributes, in addition to resource attributes")
+			assert.Contains(t, got, attr.ServiceNamespace,
+				"service.namespace should be reported by default on metric attributes, in addition to resource attributes")
+		})
+	}
+}

--- a/pkg/export/extraattributes/attr_defaults_test.go
+++ b/pkg/export/extraattributes/attr_defaults_test.go
@@ -10,27 +10,48 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
+var appMetricSections = []attributes.Name{
+	attributes.HTTPServerDuration,
+	attributes.HTTPClientDuration,
+	attributes.RPCServerDuration,
+	attributes.RPCClientDuration,
+}
+
 // service.name and service.namespace are always reported as OTEL resource
 // attributes (and joinable via target_info in Prometheus). Some Grafana Cloud
 // apps however, read service identity directly off the metric series,
 // so Beyla additionally wants these two attributes reported at the metric-attribute
 // level by default, unless overridden by the users.
+// This test configuration mimics the default Beyla behavior (defaulting ExtraGroupAttributesCfg to app)
+func TestServiceNameAndNamespace_DefaultOnAppMetrics_BeylaOverride(t *testing.T) {
+	for _, section := range appMetricSections {
+		t.Run(string(section.Section), func(t *testing.T) {
+			p, err := attributes.NewAttrSelector(0, &attributes.SelectorConfig{
+				ExtraGroupAttributesCfg: map[string][]attr.Name{
+					"app": {attr.ServiceName, attr.ServiceNamespace},
+				},
+			})
+			require.NoError(t, err)
+
+			got := p.For(section)
+			assert.Contains(t, got, attr.ServiceName)
+			assert.Contains(t, got, attr.ServiceNamespace)
+		})
+	}
+}
+
+// similar test scenario to TestServiceNameAndNamespace_DefaultOnAppMetrics_BeylaOverride
+// but not providing any app extra attribute (default OBI configuration) so we
+// expect that service name and namespace are not reported
 func TestServiceNameAndNamespace_DefaultOnAppMetrics(t *testing.T) {
-	for _, section := range []attributes.Name{
-		attributes.HTTPServerDuration,
-		attributes.HTTPClientDuration,
-		attributes.RPCServerDuration,
-		attributes.RPCClientDuration,
-	} {
+	for _, section := range appMetricSections {
 		t.Run(string(section.Section), func(t *testing.T) {
 			p, err := attributes.NewAttrSelector(0, &attributes.SelectorConfig{})
 			require.NoError(t, err)
 
 			got := p.For(section)
-			assert.Contains(t, got, attr.ServiceName,
-				"service.name should be reported by default on metric attributes, in addition to resource attributes")
-			assert.Contains(t, got, attr.ServiceNamespace,
-				"service.namespace should be reported by default on metric attributes, in addition to resource attributes")
+			assert.NotContains(t, got, attr.ServiceName)
+			assert.NotContains(t, got, attr.ServiceNamespace)
 		})
 	}
 }


### PR DESCRIPTION
Recently OBI removed `service.name` and `service.namespace` as metric attributes. This PR restores them by default and let users override the behavior by means of the `extra_group_attributes` section.